### PR TITLE
Added option to suppress parse errors

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -34,12 +34,13 @@ module.exports = function(engine) {
    * The basic parser api
    */
   var api = {
-    // le lexer
+    // the lexer
     lexer: engine.lexer,
     token: null,
     prev: null,
     debug: false,
     locations: false,
+    suppressErrors: false,
     startAt: [],
     entries: {
       'SCALAR': [
@@ -166,10 +167,12 @@ module.exports = function(engine) {
           msgExpect += getTokenName(expect);
         }
       }
-      throw new Error(
-        'Parse Error : unexpected ' + token + msgExpect,
-        '\nat line ' + this.lexer.yylloc.first_line
-      );
+      var errorMessage = 'Parse Error : unexpected ' + token + msgExpect + ' at line ' + this.lexer.yylloc.first_line;
+      if (suppressErrors) {
+        console.error(errorMessage)
+      } else {
+        throw new Error(errorMessage);
+      }
     }
     /**
      * Creates a new AST node


### PR DESCRIPTION
I've added a flag to allow you to suppress errors when parsing a PHP file. This means that if a parse error is enountered, the AST generated up to that point will be returned instead of throwing an exception.

Default behaviour is to not suppress errors (how it used to be).

Usage:

```
var phpParser = require("php-parser");
phpParser.parser.suppressErrors = true;
```

This also fixes a bug where the line number is not being returned in the exception thrown.