### PR TITLE
Bug fixes + unit tests for suppressErrors flag

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -170,6 +170,7 @@ module.exports = function(engine) {
       var errorMessage = 'Parse Error : unexpected ' + token + msgExpect + ' at line ' + this.lexer.yylloc.first_line;
       if (this.suppressErrors) {
         // Prevent further parsing of the file
+        // TODO -- Gracefully handle errors -> continue parsing file
         this.token = EOF;
         // TODO -- Send errors back with the AST?
         console.error(errorMessage)

--- a/src/parser.js
+++ b/src/parser.js
@@ -169,6 +169,8 @@ module.exports = function(engine) {
       }
       var errorMessage = 'Parse Error : unexpected ' + token + msgExpect + ' at line ' + this.lexer.yylloc.first_line;
       if (this.suppressErrors) {
+        // Prevent further parsing of the file
+        this.token = EOF;
         // TODO -- Send errors back with the AST?
         console.error(errorMessage)
       } else {

--- a/src/parser.js
+++ b/src/parser.js
@@ -168,7 +168,8 @@ module.exports = function(engine) {
         }
       }
       var errorMessage = 'Parse Error : unexpected ' + token + msgExpect + ' at line ' + this.lexer.yylloc.first_line;
-      if (suppressErrors) {
+      if (this.suppressErrors) {
+        // TODO -- Send errors back with the AST?
         console.error(errorMessage)
       } else {
         throw new Error(errorMessage);

--- a/test/functional/suppressErrorsTests.js
+++ b/test/functional/suppressErrorsTests.js
@@ -1,0 +1,30 @@
+var should = require("should");
+var assert = should;
+var parser = require('../../main');
+
+describe('Suppress errors option', function() {
+
+  describe('when enabled', function () {
+    it('should not throw exception', function () {
+      parser.parser.suppressErrors = true;
+      var ast = parser.parseEval('$test = ""; $va =');
+      ast[1].length.should.be.exactly(2);
+    });
+
+    it('should not parse file past the error point', function () {
+      parser.parser.suppressErrors = true;
+      var ast = parser.parseEval('$test = ""; $va =; $myVar = "";');
+      console.log(ast);
+      ast[1].length.should.be.exactly(2);
+    });
+  });
+
+    // TODO -- Figure out how to assert exceptions in should.js/mocha
+//   describe('when disabled', function () {
+//     it('should throw exception', function () {
+//       parser.parser.suppressErrors = false;
+//       parser.parseEval('$va =; $test = "";').should.throw();
+//     });
+//   });
+
+});


### PR DESCRIPTION
- Fixed the `.this` bug
- Set token to `EOF` to prevent further parsing
- Added unit tests