### PR TITLE
Filter out falsy nodes in blocks

### DIFF
--- a/src/ast/block.js
+++ b/src/ast/block.js
@@ -15,7 +15,7 @@ var KIND = 'block';
  */
 var Block = Statement.extends(function Block(kind, children, location) {
   Statement.apply(this, [kind || KIND, location]);
-  this.children = children;
+  this.children = children.filter(Boolean);
 });
 
 module.exports = Block;

--- a/test/ifTests.js
+++ b/test/ifTests.js
@@ -102,4 +102,19 @@ describe('Test IF statements', function() {
       ast.children[1].alternate.kind.should.be.exactly('block');
     });
   });
+  describe('Issue #84', function () {
+    var ast = parser.parseCode([
+      '<?php if (true): ?>',
+      '<?php else: ?>',
+      '<?php endif; ?>'
+    ].join('\n'), {
+      parser: { debug: false }
+    });
+    it('if block should have zero children', function() {
+      ast.children[0].body.children.length.should.be.exactly(0);
+    });
+    it('else block should have zero children', function() {
+      ast.children[0].alternate.children.length.should.be.exactly(0);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #84 and adds a regression test. This is perhaps a crude fix, as I chose not to hunt down the specific `null`-producing cases in e.g. [`parser/if.js`](https://github.com/glayzzle/php-parser/blob/a99ae872cd33259d534c2631020482911b943368/src/parser/if.js), but rather to remove them after the fact in the `Block` constructor.