### PR TITLE
Use short form for type casts

### DIFF
--- a/src/parser/expr.js
+++ b/src/parser/expr.js
@@ -272,7 +272,7 @@ module.exports = {
         return this.node('cast')('int', this.next().read_expr());
 
       case this.tok.T_DOUBLE_CAST:
-        return this.node('cast')('double', this.next().read_expr());
+        return this.node('cast')('float', this.next().read_expr());
 
       case this.tok.T_STRING_CAST:
         return this.node('cast')('string', this.next().read_expr());
@@ -284,7 +284,7 @@ module.exports = {
         return this.node('cast')('object', this.next().read_expr());
 
       case this.tok.T_BOOL_CAST:
-        return this.node('cast')('boolean', this.next().read_expr());
+        return this.node('cast')('bool', this.next().read_expr());
 
       case this.tok.T_UNSET_CAST:
         return this.node('unset')(

--- a/test/exprTests.js
+++ b/test/exprTests.js
@@ -142,28 +142,35 @@ describe('Test expressions', function() {
   });
 
   it('test cast', function() {
+    var typesWithAlias = {
+      int: ['int', 'integer'],
+      bool: ['bool', 'boolean'],
+      float: ['float', 'double', 'real']
+    }
+    Object.keys(typesWithAlias).forEach(function(shortName) {
+      var aliases = typesWithAlias[shortName];
+      var ast = parser.parseEval(aliases.map(function(alias) {
+        return '(' + alias + ')$var;';
+      }).join('\n'));
+
+      aliases.forEach(function(alias, index) {
+        ast.children[index].kind.should.be.exactly('cast');
+        ast.children[index].type.should.be.exactly(shortName);
+      });
+    });
     var ast = parser.parseEval([
-      '(int)$var;',
-      '(double)$var;',
       '(string)$var;',
       '(array)$var;',
       '(object)$var;',
-      '(boolean)$var;',
       '(unset)$var;'
     ].join('\n'));
     ast.children[0].kind.should.be.exactly('cast');
-    ast.children[0].type.should.be.exactly('int');
+    ast.children[0].type.should.be.exactly('string');
     ast.children[1].kind.should.be.exactly('cast');
-    ast.children[1].type.should.be.exactly('double');
+    ast.children[1].type.should.be.exactly('array');
     ast.children[2].kind.should.be.exactly('cast');
-    ast.children[2].type.should.be.exactly('string');
-    ast.children[3].kind.should.be.exactly('cast');
-    ast.children[3].type.should.be.exactly('array');
-    ast.children[4].kind.should.be.exactly('cast');
-    ast.children[4].type.should.be.exactly('object');
-    ast.children[5].kind.should.be.exactly('cast');
-    ast.children[5].type.should.be.exactly('boolean');
-    ast.children[6].kind.should.be.exactly('unset');
+    ast.children[2].type.should.be.exactly('object');
+    ast.children[3].kind.should.be.exactly('unset');
   });
 
   it('test exit', function() {


### PR DESCRIPTION
The `type` of types casts has been inconsistent: Sometimes, an alias/long form was used (e.g. `boolean`), other times the short form (e.g. `int`). This PR changes this by always using the short form.
Please also see https://github.com/prettier/prettier-php/pull/5#discussion_r158664155 for some more context. 
Thanks for your feedback in advance!