### PR TITLE
fix: use unary instead negative number

### DIFF
--- a/src/parser/expr.js
+++ b/src/parser/expr.js
@@ -106,25 +106,12 @@ module.exports = {
     if (this.token === "@") return this.node("silent")(this.next().read_expr());
     if (this.token === "+")
       return this.node("unary")("+", this.next().read_expr());
+    if (this.token === "-")
+      return this.node("unary")("-", this.next().read_expr());
     if (this.token === "!")
       return this.node("unary")("!", this.next().read_expr());
     if (this.token === "~")
       return this.node("unary")("~", this.next().read_expr());
-
-    if (this.token === "-") {
-      result = this.node();
-      this.next();
-      if (
-        this.token === this.tok.T_LNUMBER ||
-        this.token === this.tok.T_DNUMBER
-      ) {
-        // negative number
-        result = result("number", "-" + this.text(), null);
-        this.next();
-        return result;
-      }
-      return result("unary", "-", this.read_expr());
-    }
 
     if (this.token === "(") {
       expr = this.next().read_expr();

--- a/test/snapshot/__snapshots__/acid.test.js.snap
+++ b/test/snapshot/__snapshots__/acid.test.js.snap
@@ -2735,22 +2735,39 @@ Program {
                     },
                   },
                   "operator": "=",
-                  "right": Number {
-                    "kind": "number",
+                  "right": Unary {
+                    "kind": "unary",
                     "loc": Location {
                       "end": Position {
-                        "column": 14,
+                        "column": 15,
                         "line": 82,
-                        "offset": 1657,
+                        "offset": 1658,
                       },
-                      "source": "-",
+                      "source": "-1",
                       "start": Position {
                         "column": 13,
                         "line": 82,
                         "offset": 1656,
                       },
                     },
-                    "value": "-1",
+                    "type": "-",
+                    "what": Number {
+                      "kind": "number",
+                      "loc": Location {
+                        "end": Position {
+                          "column": 15,
+                          "line": 82,
+                          "offset": 1658,
+                        },
+                        "source": "1",
+                        "start": Position {
+                          "column": 14,
+                          "line": 82,
+                          "offset": 1657,
+                        },
+                      },
+                      "value": "1",
+                    },
                   },
                 },
                 "kind": "expressionstatement",

--- a/test/snapshot/__snapshots__/ast.test.js.snap
+++ b/test/snapshot/__snapshots__/ast.test.js.snap
@@ -232,9 +232,13 @@ Program {
     ExpressionStatement {
       "expression": Exit {
         "kind": "exit",
-        "status": Number {
-          "kind": "number",
-          "value": "-1",
+        "status": Unary {
+          "kind": "unary",
+          "type": "-",
+          "what": Number {
+            "kind": "number",
+            "value": "1",
+          },
         },
         "useDie": false,
       },

--- a/test/snapshot/__snapshots__/location.test.js.snap
+++ b/test/snapshot/__snapshots__/location.test.js.snap
@@ -6171,8 +6171,8 @@ exports[`Test locations negative number 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
-      "expression": Number {
-        "kind": "number",
+      "expression": Unary {
+        "kind": "unary",
         "loc": Location {
           "end": Position {
             "column": 6,
@@ -6186,7 +6186,24 @@ Program {
             "offset": 0,
           },
         },
-        "value": "-2112",
+        "type": "-",
+        "what": Number {
+          "kind": "number",
+          "loc": Location {
+            "end": Position {
+              "column": 5,
+              "line": 1,
+              "offset": 5,
+            },
+            "source": "2112",
+            "start": Position {
+              "column": 1,
+              "line": 1,
+              "offset": 1,
+            },
+          },
+          "value": "2112",
+        },
       },
       "kind": "expressionstatement",
       "loc": Location {

--- a/test/snapshot/__snapshots__/number.test.js.snap
+++ b/test/snapshot/__snapshots__/number.test.js.snap
@@ -13,9 +13,13 @@ Program {
           "name": "a",
         },
         "operator": "=",
-        "right": Number {
-          "kind": "number",
-          "value": "-1.5",
+        "right": Unary {
+          "kind": "unary",
+          "type": "-",
+          "what": Number {
+            "kind": "number",
+            "value": "1.5",
+          },
         },
       },
       "kind": "expressionstatement",

--- a/test/snapshot/__snapshots__/scalar.test.js.snap
+++ b/test/snapshot/__snapshots__/scalar.test.js.snap
@@ -15,9 +15,13 @@ Program {
         "operator": "=",
         "right": OffsetLookup {
           "kind": "offsetlookup",
-          "offset": Number {
-            "kind": "number",
-            "value": "-5",
+          "offset": Unary {
+            "kind": "unary",
+            "type": "-",
+            "what": Number {
+              "kind": "number",
+              "value": "5",
+            },
           },
           "what": StaticLookup {
             "kind": "staticlookup",

--- a/test/snapshot/__snapshots__/unary.test.js.snap
+++ b/test/snapshot/__snapshots__/unary.test.js.snap
@@ -1,0 +1,608 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test unary boolean 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "type": "!",
+        "what": Boolean {
+          "kind": "boolean",
+          "raw": "true",
+          "value": true,
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary multiple (2) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Pre {
+        "kind": "pre",
+        "type": "-",
+        "what": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary multiple (3) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "type": "+",
+        "what": Unary {
+          "kind": "unary",
+          "parenthesizedExpression": true,
+          "type": "+",
+          "what": Variable {
+            "byref": false,
+            "curly": false,
+            "kind": "variable",
+            "name": "var",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary multiple (4) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "type": "-",
+        "what": Unary {
+          "kind": "unary",
+          "parenthesizedExpression": true,
+          "type": "-",
+          "what": Variable {
+            "byref": false,
+            "curly": false,
+            "kind": "variable",
+            "name": "var",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary multiple (5) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "type": "!",
+        "what": Unary {
+          "kind": "unary",
+          "type": "!",
+          "what": Unary {
+            "kind": "unary",
+            "type": "!",
+            "what": Unary {
+              "kind": "unary",
+              "type": "!",
+              "what": Unary {
+                "kind": "unary",
+                "type": "!",
+                "what": Variable {
+                  "byref": false,
+                  "curly": false,
+                  "kind": "variable",
+                  "name": "var",
+                },
+              },
+            },
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary multiple 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "type": "!",
+        "what": Unary {
+          "kind": "unary",
+          "type": "!",
+          "what": Variable {
+            "byref": false,
+            "curly": false,
+            "kind": "variable",
+            "name": "var",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary multiple 2`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "type": "~",
+        "what": Unary {
+          "kind": "unary",
+          "type": "~",
+          "what": Variable {
+            "byref": false,
+            "curly": false,
+            "kind": "variable",
+            "name": "var",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary number (2) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "type": "+",
+        "what": Number {
+          "kind": "number",
+          "value": "100",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary number (3) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "type": "~",
+        "what": Number {
+          "kind": "number",
+          "value": "100",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary number (4) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "type": "!",
+        "what": Number {
+          "kind": "number",
+          "value": "100",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary number 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "type": "-",
+        "what": Number {
+          "kind": "number",
+          "value": "100",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary parens (2) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "type": "!",
+        "what": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+          "parenthesizedExpression": true,
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary parens (3) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "parenthesizedExpression": true,
+        "type": "-",
+        "what": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary parens (4) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "type": "-",
+        "what": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+          "parenthesizedExpression": true,
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary parens (5) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "parenthesizedExpression": true,
+        "type": "+",
+        "what": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary parens (6) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "type": "+",
+        "what": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+          "parenthesizedExpression": true,
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary parens (7) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "type": "~",
+        "what": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+          "parenthesizedExpression": true,
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary parens (8) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "parenthesizedExpression": true,
+        "type": "~",
+        "what": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary parens (9) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "parenthesizedExpression": true,
+        "type": "-",
+        "what": Number {
+          "kind": "number",
+          "value": "100",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary parens (10) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "type": "-",
+        "what": Number {
+          "kind": "number",
+          "parenthesizedExpression": true,
+          "value": "100",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary parens 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "parenthesizedExpression": true,
+        "type": "!",
+        "what": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary simple 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "type": "!",
+        "what": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary string (2) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "type": "-",
+        "what": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"string\\"",
+          "unicode": false,
+          "value": "string",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary string (3) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "type": "~",
+        "what": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"string\\"",
+          "unicode": false,
+          "value": "string",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary string (4) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "type": "!",
+        "what": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"string\\"",
+          "unicode": false,
+          "value": "string",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary string 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Unary {
+        "kind": "unary",
+        "type": "+",
+        "what": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"string\\"",
+          "unicode": false,
+          "value": "string",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;

--- a/test/snapshot/unary.test.js
+++ b/test/snapshot/unary.test.js
@@ -1,0 +1,82 @@
+const parser = require('../main');
+
+describe("Test unary", function() {
+  it("simple", function() {
+    expect(parser.parseEval('!$var;')).toMatchSnapshot();
+  });
+  it("number", function() {
+    expect(parser.parseEval('-100;')).toMatchSnapshot();
+  });
+  it("number (2)", function() {
+    expect(parser.parseEval('+100;')).toMatchSnapshot();
+  });
+  it("number (3)", function() {
+    expect(parser.parseEval('~100;')).toMatchSnapshot();
+  });
+  it("number (4)", function() {
+    expect(parser.parseEval('!100;')).toMatchSnapshot();
+  });
+  it("string", function() {
+    expect(parser.parseEval('+"string";')).toMatchSnapshot();
+  });
+  it("string (2)", function() {
+    expect(parser.parseEval('-"string";')).toMatchSnapshot();
+  });
+  it("string (3)", function() {
+    expect(parser.parseEval('~"string";')).toMatchSnapshot();
+  });
+  it("string (4)", function() {
+    expect(parser.parseEval('!"string";')).toMatchSnapshot();
+  });
+  it("boolean", function() {
+    expect(parser.parseEval('!true;')).toMatchSnapshot();
+  });
+  it("multiple", function() {
+    expect(parser.parseEval('!!$var;')).toMatchSnapshot();
+  });
+  it("multiple", function() {
+    expect(parser.parseEval('~~$var;')).toMatchSnapshot();
+  });
+  it("multiple (2)", function() {
+    expect(parser.parseEval('--$var;')).toMatchSnapshot();
+  });
+  it("multiple (3)", function() {
+    expect(parser.parseEval('+(+$var);')).toMatchSnapshot();
+  });
+  it("multiple (4)", function() {
+    expect(parser.parseEval('-(-$var);')).toMatchSnapshot();
+  });
+  it("multiple (5)", function() {
+    expect(parser.parseEval('!!!!!$var;')).toMatchSnapshot();
+  });
+  it("parens", function() {
+    expect(parser.parseEval('(!$var);')).toMatchSnapshot();
+  });
+  it("parens (2)", function() {
+    expect(parser.parseEval('!($var);')).toMatchSnapshot();
+  });
+  it("parens (3)", function() {
+    expect(parser.parseEval('(-$var);')).toMatchSnapshot();
+  });
+  it("parens (4)", function() {
+    expect(parser.parseEval('-($var);')).toMatchSnapshot();
+  });
+  it("parens (5)", function() {
+    expect(parser.parseEval('(+$var);')).toMatchSnapshot();
+  });
+  it("parens (6)", function() {
+    expect(parser.parseEval('+($var);')).toMatchSnapshot();
+  });
+  it("parens (7)", function() {
+    expect(parser.parseEval('~($var);')).toMatchSnapshot();
+  });
+  it("parens (8)", function() {
+    expect(parser.parseEval('(~$var);')).toMatchSnapshot();
+  });
+  it("parens (9)", function() {
+    expect(parser.parseEval('(-100);')).toMatchSnapshot();
+  });
+  it("parens (10)", function() {
+    expect(parser.parseEval('-(100);')).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
fixes #214

After investigate `babylon` and `PHP` parser (https://github.com/nikic/PHP-Parser) - they do not have negative number, they interpreted `-` as `unary` always, i think we should use same logic.

More tests included