### PR TITLE
fix: reference node

### DIFF
--- a/src/ast/parentreference.js
+++ b/src/ast/parentreference.js
@@ -14,9 +14,11 @@ const KIND = "parentreference";
  * @extends {Reference}
  */
 const ParentReference = Reference.extends(KIND, function ParentReference(
+  raw,
   docs,
   location
 ) {
   Reference.apply(this, [KIND, docs, location]);
+  this.raw = raw;
 });
 module.exports = ParentReference;

--- a/src/ast/selfreference.js
+++ b/src/ast/selfreference.js
@@ -14,9 +14,11 @@ const KIND = "selfreference";
  * @extends {Reference}
  */
 const SelfReference = Reference.extends(KIND, function SelfReference(
+  raw,
   docs,
   location
 ) {
   Reference.apply(this, [KIND, docs, location]);
+  this.raw = raw;
 });
 module.exports = SelfReference;

--- a/src/ast/staticreference.js
+++ b/src/ast/staticreference.js
@@ -14,9 +14,11 @@ const KIND = "staticreference";
  * @extends {Reference}
  */
 const StaticReference = Reference.extends(KIND, function StaticReference(
+  raw,
   docs,
   location
 ) {
   Reference.apply(this, [KIND, docs, location]);
+  this.raw = raw;
 });
 module.exports = StaticReference;

--- a/src/ast/typereference.js
+++ b/src/ast/typereference.js
@@ -16,13 +16,24 @@ const KIND = "typereference";
  */
 const TypeReference = Reference.extends(KIND, function TypeReference(
   name,
+  raw,
   docs,
   location
 ) {
   Reference.apply(this, [KIND, docs, location]);
   this.name = name;
+  this.raw = raw;
 });
 
-TypeReference.types = ["int", "float", "string", "bool", "object", "array"];
+TypeReference.types = [
+  "int",
+  "float",
+  "string",
+  "bool",
+  "object",
+  "array",
+  "callable",
+  "iterable"
+];
 
 module.exports = TypeReference;

--- a/src/parser/function.js
+++ b/src/parser/function.js
@@ -240,12 +240,11 @@ module.exports = {
    * ```
    */
   read_type: function() {
-    const result = this.node("typereference");
-    let type = null;
+    const result = this.node();
     if (this.token === this.tok.T_ARRAY || this.token === this.tok.T_CALLABLE) {
       let type = this.text();
       this.next();
-      return result(type);
+      return result("typereference", type.toLowerCase(), type);
     } else if (this.token === this.tok.T_STRING) {
       let type = this.text();
       const backup = [this.token, this.lexer.getState()];
@@ -254,7 +253,7 @@ module.exports = {
         this.token !== this.tok.T_NS_SEPARATOR &&
         this.ast.typereference.types.indexOf(type.toLowerCase()) > -1
       ) {
-        return result(type);
+        return result("typereference", type.toLowerCase(), type);
       } else {
         // rollback a classic namespace
         this.lexer.tokens.push(backup);

--- a/src/parser/namespace.js
+++ b/src/parser/namespace.js
@@ -74,10 +74,10 @@ module.exports = {
       true
     );
     if (!relative && names.length === 1) {
-      if (names[0] === "parent") {
-        return result("parentreference");
-      } else if (names[0] === "self") {
-        return result("selfreference");
+      if (names[0].toLowerCase() === "parent") {
+        return result("parentreference", names[0]);
+      } else if (names[0].toLowerCase() === "self") {
+        return result("selfreference", names[0]);
       }
     }
     return result("classreference", names, relative);

--- a/src/parser/variable.js
+++ b/src/parser/variable.js
@@ -60,8 +60,9 @@ module.exports = {
       }
     } else if (this.token === this.tok.T_STATIC) {
       result = this.node("staticreference");
+      const raw = this.text();
       this.next();
-      result = result();
+      result = result(raw);
     } else {
       this.expect("VARIABLE");
     }

--- a/test/snapshot/__snapshots__/acid.test.js.snap
+++ b/test/snapshot/__snapshots__/acid.test.js.snap
@@ -1448,6 +1448,7 @@ Program {
                   },
                 },
                 "name": "bool",
+                "raw": "bool",
               },
               "visibility": "public",
             },
@@ -1506,6 +1507,7 @@ Program {
                   },
                 },
                 "name": "bool",
+                "raw": "bool",
               },
               "visibility": "protected",
             },
@@ -1564,6 +1566,7 @@ Program {
                   },
                 },
                 "name": "bool",
+                "raw": "bool",
               },
               "visibility": "protected",
             },
@@ -1860,6 +1863,7 @@ Program {
                       },
                     },
                     "name": "bool",
+                    "raw": "bool",
                   },
                   "value": Boolean {
                     "kind": "boolean",
@@ -2504,6 +2508,7 @@ Program {
                   },
                 },
                 "name": "string",
+                "raw": "string",
               },
               "visibility": "public",
             },
@@ -3637,6 +3642,7 @@ next:
               },
             },
             "name": "int",
+            "raw": "int",
           },
         },
         ExpressionStatement {
@@ -3747,6 +3753,7 @@ next:
                       },
                     },
                     "name": "int",
+                    "raw": "int",
                   },
                   "value": Number {
                     "kind": "number",
@@ -6318,6 +6325,7 @@ next:
                   },
                 },
                 "name": "bool",
+                "raw": "bool",
               },
               "uses": Array [
                 Variable {

--- a/test/snapshot/__snapshots__/call.test.js.snap
+++ b/test/snapshot/__snapshots__/call.test.js.snap
@@ -711,6 +711,7 @@ Program {
                   },
                   "what": ParentReference {
                     "kind": "parentreference",
+                    "raw": "parent",
                   },
                 },
               },
@@ -830,6 +831,7 @@ Program {
                   },
                   "what": SelfReference {
                     "kind": "selfreference",
+                    "raw": "self",
                   },
                 },
               },
@@ -928,6 +930,7 @@ Program {
                     },
                     "what": StaticReference {
                       "kind": "staticreference",
+                      "raw": "static",
                     },
                   },
                 },

--- a/test/snapshot/__snapshots__/class.test.js.snap
+++ b/test/snapshot/__snapshots__/class.test.js.snap
@@ -284,6 +284,7 @@ Program {
                   },
                   "what": ParentReference {
                     "kind": "parentreference",
+                    "raw": "parent",
                   },
                 },
               },
@@ -298,6 +299,7 @@ Program {
                   },
                   "what": SelfReference {
                     "kind": "selfreference",
+                    "raw": "self",
                   },
                 },
               },
@@ -313,6 +315,7 @@ Program {
                     },
                     "what": StaticReference {
                       "kind": "staticreference",
+                      "raw": "static",
                     },
                   },
                 },
@@ -462,6 +465,7 @@ Program {
                   },
                   "what": SelfReference {
                     "kind": "selfreference",
+                    "raw": "self",
                   },
                 },
                 "operator": "=",
@@ -650,6 +654,7 @@ Program {
               "type": TypeReference {
                 "kind": "typereference",
                 "name": "array",
+                "raw": "array",
               },
               "value": Identifier {
                 "kind": "identifier",
@@ -737,6 +742,7 @@ Program {
                 },
                 "what": SelfReference {
                   "kind": "selfreference",
+                  "raw": "self",
                 },
               },
               "variadic": false,

--- a/test/snapshot/__snapshots__/classreference.test.js.snap
+++ b/test/snapshot/__snapshots__/classreference.test.js.snap
@@ -1,0 +1,146 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`classreference argument type (2) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": ClassReference {
+            "kind": "classreference",
+            "name": "Foo\\\\Foo",
+            "resolution": "qn",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`classreference argument type 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": ClassReference {
+            "kind": "classreference",
+            "name": "Foo",
+            "resolution": "uqn",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`classreference call 1`] = `
+Program {
+  "children": Array [
+    Call {
+      "arguments": Array [],
+      "kind": "call",
+      "what": StaticLookup {
+        "kind": "staticlookup",
+        "offset": Identifier {
+          "kind": "identifier",
+          "name": "call",
+        },
+        "what": ClassReference {
+          "kind": "classreference",
+          "name": "Foo",
+          "resolution": "uqn",
+        },
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`classreference constant 1`] = `
+Program {
+  "children": Array [
+    StaticLookup {
+      "kind": "staticlookup",
+      "offset": Identifier {
+        "kind": "identifier",
+        "name": "CONSTANT",
+      },
+      "what": ClassReference {
+        "kind": "classreference",
+        "name": "Foo",
+        "resolution": "uqn",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`classreference variable 1`] = `
+Program {
+  "children": Array [
+    StaticLookup {
+      "kind": "staticlookup",
+      "offset": Variable {
+        "byref": false,
+        "curly": false,
+        "kind": "variable",
+        "name": "var",
+      },
+      "what": ClassReference {
+        "kind": "classreference",
+        "name": "Foo",
+        "resolution": "uqn",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;

--- a/test/snapshot/__snapshots__/function.test.js.snap
+++ b/test/snapshot/__snapshots__/function.test.js.snap
@@ -13,6 +13,7 @@ Program {
           "type": TypeReference {
             "kind": "typereference",
             "name": "int",
+            "raw": "int",
           },
           "value": Number {
             "kind": "number",
@@ -28,6 +29,7 @@ Program {
           "type": TypeReference {
             "kind": "typereference",
             "name": "float",
+            "raw": "float",
           },
           "value": Number {
             "kind": "number",
@@ -43,6 +45,7 @@ Program {
           "type": TypeReference {
             "kind": "typereference",
             "name": "bool",
+            "raw": "bool",
           },
           "value": Number {
             "kind": "number",
@@ -58,6 +61,7 @@ Program {
           "type": TypeReference {
             "kind": "typereference",
             "name": "string",
+            "raw": "string",
           },
           "value": null,
           "variadic": false,
@@ -70,6 +74,7 @@ Program {
           "type": TypeReference {
             "kind": "typereference",
             "name": "callable",
+            "raw": "callable",
           },
           "value": null,
           "variadic": false,
@@ -95,6 +100,7 @@ Program {
           "type": TypeReference {
             "kind": "typereference",
             "name": "array",
+            "raw": "array",
           },
           "value": null,
           "variadic": true,
@@ -114,6 +120,7 @@ Program {
       "type": TypeReference {
         "kind": "typereference",
         "name": "object",
+        "raw": "object",
       },
     },
   ],
@@ -193,6 +200,7 @@ Program {
           "type": TypeReference {
             "kind": "typereference",
             "name": "callable",
+            "raw": "callable",
           },
           "value": null,
           "variadic": false,
@@ -205,6 +213,7 @@ Program {
           "type": TypeReference {
             "kind": "typereference",
             "name": "array",
+            "raw": "array",
           },
           "value": null,
           "variadic": true,
@@ -269,6 +278,7 @@ Program {
           "type": TypeReference {
             "kind": "typereference",
             "name": "array",
+            "raw": "array",
           },
           "uses": Array [
             Variable {

--- a/test/snapshot/__snapshots__/location.test.js.snap
+++ b/test/snapshot/__snapshots__/location.test.js.snap
@@ -6690,6 +6690,7 @@ Program {
               },
             },
             "name": "int",
+            "raw": "int",
           },
           "value": Number {
             "kind": "number",

--- a/test/snapshot/__snapshots__/parentreference.test.js.snap
+++ b/test/snapshot/__snapshots__/parentreference.test.js.snap
@@ -1,0 +1,165 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parentreference call 1`] = `
+Program {
+  "children": Array [
+    Call {
+      "arguments": Array [],
+      "kind": "call",
+      "what": StaticLookup {
+        "kind": "staticlookup",
+        "offset": Identifier {
+          "kind": "identifier",
+          "name": "call",
+        },
+        "what": ParentReference {
+          "kind": "parentreference",
+          "raw": "parent",
+        },
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`parentreference constant 1`] = `
+Program {
+  "children": Array [
+    StaticLookup {
+      "kind": "staticlookup",
+      "offset": Identifier {
+        "kind": "identifier",
+        "name": "CONSTANT",
+      },
+      "what": ParentReference {
+        "kind": "parentreference",
+        "raw": "parent",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`parentreference parent (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": ParentReference {
+            "kind": "parentreference",
+            "raw": "PARENT",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`parentreference parent 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": ParentReference {
+            "kind": "parentreference",
+            "raw": "parent",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`parentreference uppercase 1`] = `
+Program {
+  "children": Array [
+    Call {
+      "arguments": Array [],
+      "kind": "call",
+      "what": StaticLookup {
+        "kind": "staticlookup",
+        "offset": Identifier {
+          "kind": "identifier",
+          "name": "call",
+        },
+        "what": ParentReference {
+          "kind": "parentreference",
+          "raw": "PARENT",
+        },
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`parentreference variable 1`] = `
+Program {
+  "children": Array [
+    StaticLookup {
+      "kind": "staticlookup",
+      "offset": Variable {
+        "byref": false,
+        "curly": false,
+        "kind": "variable",
+        "name": "var",
+      },
+      "what": ParentReference {
+        "kind": "parentreference",
+        "raw": "parent",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;

--- a/test/snapshot/__snapshots__/selfreference.test.js.snap
+++ b/test/snapshot/__snapshots__/selfreference.test.js.snap
@@ -1,0 +1,165 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`selfreference call 1`] = `
+Program {
+  "children": Array [
+    Call {
+      "arguments": Array [],
+      "kind": "call",
+      "what": StaticLookup {
+        "kind": "staticlookup",
+        "offset": Identifier {
+          "kind": "identifier",
+          "name": "call",
+        },
+        "what": SelfReference {
+          "kind": "selfreference",
+          "raw": "self",
+        },
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`selfreference constant 1`] = `
+Program {
+  "children": Array [
+    StaticLookup {
+      "kind": "staticlookup",
+      "offset": Identifier {
+        "kind": "identifier",
+        "name": "CONSTANT",
+      },
+      "what": SelfReference {
+        "kind": "selfreference",
+        "raw": "self",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`selfreference parent (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": SelfReference {
+            "kind": "selfreference",
+            "raw": "SELF",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`selfreference parent 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": SelfReference {
+            "kind": "selfreference",
+            "raw": "self",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`selfreference uppercase 1`] = `
+Program {
+  "children": Array [
+    Call {
+      "arguments": Array [],
+      "kind": "call",
+      "what": StaticLookup {
+        "kind": "staticlookup",
+        "offset": Identifier {
+          "kind": "identifier",
+          "name": "call",
+        },
+        "what": SelfReference {
+          "kind": "selfreference",
+          "raw": "SELF",
+        },
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`selfreference variable 1`] = `
+Program {
+  "children": Array [
+    StaticLookup {
+      "kind": "staticlookup",
+      "offset": Variable {
+        "byref": false,
+        "curly": false,
+        "kind": "variable",
+        "name": "var",
+      },
+      "what": SelfReference {
+        "kind": "selfreference",
+        "raw": "self",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;

--- a/test/snapshot/__snapshots__/staticreference.test.js.snap
+++ b/test/snapshot/__snapshots__/staticreference.test.js.snap
@@ -1,0 +1,103 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`staticreference call 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Call {
+        "arguments": Array [],
+        "kind": "call",
+        "what": StaticLookup {
+          "kind": "staticlookup",
+          "offset": Identifier {
+            "kind": "identifier",
+            "name": "call",
+          },
+          "what": StaticReference {
+            "kind": "staticreference",
+            "raw": "static",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`staticreference constant 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": StaticLookup {
+        "kind": "staticlookup",
+        "offset": Identifier {
+          "kind": "identifier",
+          "name": "CONSTANT",
+        },
+        "what": StaticReference {
+          "kind": "staticreference",
+          "raw": "static",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`staticreference uppercase 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Call {
+        "arguments": Array [],
+        "kind": "call",
+        "what": StaticLookup {
+          "kind": "staticlookup",
+          "offset": Identifier {
+            "kind": "identifier",
+            "name": "call",
+          },
+          "what": StaticReference {
+            "kind": "staticreference",
+            "raw": "STATIC",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`staticreference variable 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": StaticLookup {
+        "kind": "staticlookup",
+        "offset": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "what": StaticReference {
+          "kind": "staticreference",
+          "raw": "static",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;

--- a/test/snapshot/__snapshots__/typereference.test.js.snap
+++ b/test/snapshot/__snapshots__/typereference.test.js.snap
@@ -1,0 +1,685 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`typereference array (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "array",
+            "raw": "ARRAY",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference array 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "array",
+            "raw": "array",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference bool (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "bool",
+            "raw": "BOOL",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference bool 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "bool",
+            "raw": "bool",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference callable (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "callable",
+            "raw": "CALLABLE",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference callable 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "callable",
+            "raw": "callable",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference class (2) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": ClassReference {
+            "kind": "classreference",
+            "name": "Foo\\\\Foo",
+            "resolution": "qn",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference class 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": ClassReference {
+            "kind": "classreference",
+            "name": "Foo",
+            "resolution": "uqn",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference float (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "float",
+            "raw": "FLOAT",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference float 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "float",
+            "raw": "float",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference int (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "int",
+            "raw": "INT",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference int 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "int",
+            "raw": "int",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference iterable (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "iterable",
+            "raw": "ITERABLE",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference iterable 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "iterable",
+            "raw": "iterable",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference object (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "object",
+            "raw": "OBJECT",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference object 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "object",
+            "raw": "object",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference string (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "string",
+            "raw": "STRING",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference string 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "string",
+            "raw": "string",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;

--- a/test/snapshot/__snapshots__/variable.test.js.snap
+++ b/test/snapshot/__snapshots__/variable.test.js.snap
@@ -292,6 +292,7 @@ Program {
           },
           "what": StaticReference {
             "kind": "staticreference",
+            "raw": "static",
           },
         },
       },
@@ -308,6 +309,7 @@ Program {
         },
         "what": SelfReference {
           "kind": "selfreference",
+          "raw": "self",
         },
       },
     },
@@ -322,6 +324,7 @@ Program {
         },
         "what": ParentReference {
           "kind": "parentreference",
+          "raw": "parent",
         },
       },
     },

--- a/test/snapshot/classreference.test.js
+++ b/test/snapshot/classreference.test.js
@@ -1,0 +1,19 @@
+const parser = require('../main');
+
+describe("classreference", function() {
+  it("variable", function() {
+    expect(parser.parseEval('Foo::$var;')).toMatchSnapshot();
+  });
+  it("constant", function() {
+    expect(parser.parseEval('Foo::CONSTANT;')).toMatchSnapshot();
+  });
+  it("call", function() {
+    expect(parser.parseEval('Foo::call();')).toMatchSnapshot();
+  });
+  it("argument type", function() {
+    expect(parser.parseEval('function fn(Foo $arg) {}')).toMatchSnapshot();
+  });
+  it("argument type (2)", function() {
+    expect(parser.parseEval('function fn(Foo\\Foo $arg) {}')).toMatchSnapshot();
+  });
+});

--- a/test/snapshot/parentreference.test.js
+++ b/test/snapshot/parentreference.test.js
@@ -1,0 +1,22 @@
+const parser = require('../main');
+
+describe("parentreference", function() {
+  it("variable", function() {
+    expect(parser.parseEval('parent::$var;')).toMatchSnapshot();
+  });
+  it("constant", function() {
+    expect(parser.parseEval('parent::CONSTANT;')).toMatchSnapshot();
+  });
+  it("call", function() {
+    expect(parser.parseEval('parent::call();')).toMatchSnapshot();
+  });
+  it("uppercase", function() {
+    expect(parser.parseEval('PARENT::call();')).toMatchSnapshot();
+  });
+  it("parent", function() {
+    expect(parser.parseEval('function fn(parent $arg) {}')).toMatchSnapshot();
+  });
+  it("parent (uppercase)", function() {
+    expect(parser.parseEval('function fn(PARENT $arg) {}')).toMatchSnapshot();
+  });
+});

--- a/test/snapshot/selfreference.test.js
+++ b/test/snapshot/selfreference.test.js
@@ -1,0 +1,22 @@
+const parser = require('../main');
+
+describe("selfreference", function() {
+  it("variable", function() {
+    expect(parser.parseEval('self::$var;')).toMatchSnapshot();
+  });
+  it("constant", function() {
+    expect(parser.parseEval('self::CONSTANT;')).toMatchSnapshot();
+  });
+  it("call", function() {
+    expect(parser.parseEval('self::call();')).toMatchSnapshot();
+  });
+  it("uppercase", function() {
+    expect(parser.parseEval('SELF::call();')).toMatchSnapshot();
+  });
+  it("parent", function() {
+    expect(parser.parseEval('function fn(self $arg) {}')).toMatchSnapshot();
+  });
+  it("parent (uppercase)", function() {
+    expect(parser.parseEval('function fn(SELF $arg) {}')).toMatchSnapshot();
+  });
+});

--- a/test/snapshot/staticreference.test.js
+++ b/test/snapshot/staticreference.test.js
@@ -1,0 +1,16 @@
+const parser = require('../main');
+
+describe("staticreference", function() {
+  it("variable", function() {
+    expect(parser.parseEval('static::$var;')).toMatchSnapshot();
+  });
+  it("constant", function() {
+    expect(parser.parseEval('static::CONSTANT;')).toMatchSnapshot();
+  });
+  it("call", function() {
+    expect(parser.parseEval('static::call();')).toMatchSnapshot();
+  });
+  it("uppercase", function() {
+    expect(parser.parseEval('STATIC::call();')).toMatchSnapshot();
+  });
+});

--- a/test/snapshot/typereference.test.js
+++ b/test/snapshot/typereference.test.js
@@ -1,0 +1,58 @@
+const parser = require('../main');
+
+describe("typereference", function() {
+  it("int", function() {
+    expect(parser.parseEval('function fn(int $arg) {}')).toMatchSnapshot();
+  });
+  it("int (uppercase)", function() {
+    expect(parser.parseEval('function fn(INT $arg) {}')).toMatchSnapshot();
+  });
+  it("float", function() {
+    expect(parser.parseEval('function fn(float $arg) {}')).toMatchSnapshot();
+  });
+  it("float (uppercase)", function() {
+    expect(parser.parseEval('function fn(FLOAT $arg) {}')).toMatchSnapshot();
+  });
+  it("bool", function() {
+    expect(parser.parseEval('function fn(bool $arg) {}')).toMatchSnapshot();
+  });
+  it("bool (uppercase)", function() {
+    expect(parser.parseEval('function fn(BOOL $arg) {}')).toMatchSnapshot();
+  });
+  it("string", function() {
+    expect(parser.parseEval('function fn(string $arg) {}')).toMatchSnapshot();
+  });
+  it("string (uppercase)", function() {
+    expect(parser.parseEval('function fn(STRING $arg) {}')).toMatchSnapshot();
+  });
+  it("array", function() {
+    expect(parser.parseEval('function fn(array $arg) {}')).toMatchSnapshot();
+  });
+  it("array (uppercase)", function() {
+    expect(parser.parseEval('function fn(ARRAY $arg) {}')).toMatchSnapshot();
+  });
+  it("callable", function() {
+    expect(parser.parseEval('function fn(callable $arg) {}')).toMatchSnapshot();
+  });
+  it("callable (uppercase)", function() {
+    expect(parser.parseEval('function fn(CALLABLE $arg) {}')).toMatchSnapshot();
+  });
+  it("object", function() {
+    expect(parser.parseEval('function fn(object $arg) {}')).toMatchSnapshot();
+  });
+  it("object (uppercase)", function() {
+    expect(parser.parseEval('function fn(OBJECT $arg) {}')).toMatchSnapshot();
+  });
+  it("iterable", function() {
+    expect(parser.parseEval('function fn(iterable $arg) {}')).toMatchSnapshot();
+  });
+  it("iterable (uppercase)", function() {
+    expect(parser.parseEval('function fn(ITERABLE $arg) {}')).toMatchSnapshot();
+  });
+  it("class", function() {
+    expect(parser.parseEval('function fn(Foo $arg) {}')).toMatchSnapshot();
+  });
+  it("class (2)", function() {
+    expect(parser.parseEval('function fn(Foo\\Foo $arg) {}')).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Includes:
- Add `raw` property (`self`, `parent`, `static` references can be in uppercase, mixedcase - `pArEnt`)
- `callable` and `iterable` to `typereference`
- fix detection `self` and `parent` ( as i write above `self` and `parent` can be in any case)
- Tests