### PR TITLE
fix: broken code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     sourceType: "module"
   },
   plugins: ["prettier"],
-  extends: ["eslint:recommended", "prettier"],
+  extends: ["eslint:recommended"],
   env: {
     browser: true,
     node: true,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dist"
   ],
   "scripts": {
-    "lint": "prettier --write src/*.js src/**/*.js",
+    "lint": "eslint 'src/**/*.js'",
     "pretest": "npm run lint",
     "test": "jest",
     "prebuild": "npm run test",
@@ -58,7 +58,8 @@
     "babel-loader": "^7",
     "babel-preset-es2015": "^6",
     "coveralls": "^3",
-    "eslint-plugin-prettier": "^2.6.2",
+    "eslint": "^5.8.0",
+    "eslint-plugin-prettier": "^3.0.0",
     "jest": "^22.4",
     "jsdoc": "^3.5.5",
     "jsdoc-template": "github:braintree/jsdoc-template",

--- a/src/parser.js
+++ b/src/parser.js
@@ -355,7 +355,9 @@ parser.prototype.node = function(name) {
       docs = this._docs.slice(this._docIndex);
       this._docIndex = this._docs.length;
       if (this.debug) {
+        // eslint-disable-next-line no-console
         console.log(new Error("Append docs on " + name));
+        // eslint-disable-next-line no-console
         console.log(docs);
       }
     }

--- a/src/parser/expr.js
+++ b/src/parser/expr.js
@@ -417,9 +417,9 @@ module.exports = {
       expr = this.read_scalar();
       if (expr.kind === "array" && expr.shortForm && this.token === "=") {
         // list assign
-        let list = this.node("list")(expr.items, true);
+        const list = this.node("list")(expr.items, true);
         if (expr.loc) list.loc = expr.loc;
-        let right = this.next().read_expr();
+        const right = this.next().read_expr();
         return result("assign", list, right, "=");
       } else {
         // see #189 - swap docs on nodes

--- a/src/parser/function.js
+++ b/src/parser/function.js
@@ -80,7 +80,7 @@ module.exports = {
       returnType = null,
       nullable = false;
     if (type !== 1) {
-      let nameNode = this.node("identifier");
+      const nameNode = this.node("identifier");
       if (type === 2) {
         if (
           this.token === this.tok.T_STRING ||
@@ -241,13 +241,12 @@ module.exports = {
    */
   read_type: function() {
     const result = this.node("typereference");
-    let type = null;
     if (this.token === this.tok.T_ARRAY || this.token === this.tok.T_CALLABLE) {
-      let type = this.text();
+      const type = this.text();
       this.next();
       return result(type);
     } else if (this.token === this.tok.T_STRING) {
-      let type = this.text();
+      const type = this.text();
       const backup = [this.token, this.lexer.getState()];
       this.next();
       if (

--- a/src/parser/variable.js
+++ b/src/parser/variable.js
@@ -175,7 +175,7 @@ module.exports = {
     encapsed,
     dereferencable
   ) {
-    let name, node, offset;
+    let node, offset;
     recursive_scan_loop: while (this.token != this.EOF) {
       switch (this.token) {
         case "(":

--- a/test/snapshot/__snapshots__/encapsed.test.js.snap
+++ b/test/snapshot/__snapshots__/encapsed.test.js.snap
@@ -296,7 +296,7 @@ exports[`encapsed variable curly (simple syntax) 1`] = `
 Program {
   "children": Array [
     Echo {
-      "arguments": Array [
+      "expressions": Array [
         Encapsed {
           "kind": "encapsed",
           "raw": "\\"string \${var} string\\"",


### PR DESCRIPTION
Now we have broken code in `master` if parent script use `"use_strict";` - https://github.com/glayzzle/php-parser/blob/master/src/parser/statement.js#L253 (here `result` is not null, it is https://github.com/glayzzle/php-parser/blob/master/src/parser/statement.js#L339) to avoid these problem in future i will setup `eslint` and refactor some places