### PR TITLE
fix: ast for constants

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -14,6 +14,7 @@ const Position = require("./ast/position");
  * - [Location](#location)
  * - [Position](#position)
  * - [Node](#node)
+ *   - [Constant](#constant)
  *   - [Identifier](#identifier)
  *   - [Reference](#reference)
  *     - [TypeReference](#classreference)
@@ -67,6 +68,8 @@ const Position = require("./ast/position");
  *       - [Nowdoc](#nowdoc)
  *       - [Encapsed](#encapsed)
  *   - [Statement](#statement)
+ *     - [ConstantStatement](#constantstatement)
+ *       - [ClassConstant](#classconstant)
  *     - [Return](#return)
  *     - [Label](#label)
  *     - [Continue](#continue)
@@ -98,8 +101,6 @@ const Position = require("./ast/position");
  *       - [Class](#class)
  *       - [Interface](#interface)
  *       - [Trait](#trait)
- *       - [Constant](#constant)
- *         - [ClassConstant](#classconstant)
  *       - [Function](#function)
  *         - [Method](#method)
  *       - [Parameter](#parameter)
@@ -359,6 +360,7 @@ AST.prototype.prepare = function(kind, docs, parser) {
   require("./ast/commentblock"),
   require("./ast/commentline"),
   require("./ast/constant"),
+  require("./ast/constantstatement"),
   require("./ast/continue"),
   require("./ast/declaration"),
   require("./ast/declare"),

--- a/src/ast/classconstant.js
+++ b/src/ast/classconstant.js
@@ -5,24 +5,48 @@
  */
 "use strict";
 
-const Constant = require("./constant");
+const ConstantStatement = require("./constantstatement");
 const KIND = "classconstant";
+
+const IS_UNDEFINED = "";
+const IS_PUBLIC = "public";
+const IS_PROTECTED = "protected";
+const IS_PRIVATE = "private";
 
 /**
  * Defines a class/interface/trait constant
  * @constructor ClassConstant
- * @extends {Constant}
- * @property {boolean} isStatic
+ * @extends {ConstantStatement}
  * @property {string} visibility
  */
-module.exports = Constant.extends(KIND, function ClassConstant(
-  name,
-  value,
+const ClassConstant = ConstantStatement.extends(KIND, function ClassConstant(
+  kind,
+  items,
   flags,
   docs,
   location
 ) {
-  Constant.apply(this, [name, value, docs, location]);
-  this.kind = KIND;
+  ConstantStatement.apply(this, [kind || KIND, items, docs, location]);
   this.parseFlags(flags);
 });
+
+/**
+ * Generic flags parser
+ * @param {Integer[]} flags
+ * @return {void}
+ */
+ClassConstant.prototype.parseFlags = function(flags) {
+  if (flags[0] === -1) {
+    this.visibility = IS_UNDEFINED;
+  } else if (flags[0] === null) {
+    this.visibility = null;
+  } else if (flags[0] === 0) {
+    this.visibility = IS_PUBLIC;
+  } else if (flags[0] === 1) {
+    this.visibility = IS_PROTECTED;
+  } else if (flags[0] === 2) {
+    this.visibility = IS_PRIVATE;
+  }
+};
+
+module.exports = ClassConstant;

--- a/src/ast/constant.js
+++ b/src/ast/constant.js
@@ -5,21 +5,23 @@
  */
 "use strict";
 
-const Declaration = require("./declaration");
+const Node = require("./node");
 const KIND = "constant";
 
 /**
- * Defines a namespace constant
+ * Defines a constant
  * @constructor Constant
- * @extends {Declaration}
- * @property {Node|null} value
+ * @extends {Node}
+ * @property {string} name
+ * @property {Node|string|number|boolean|null} value
  */
-module.exports = Declaration.extends(KIND, function Constant(
+module.exports = Node.extends(KIND, function Constant(
   name,
   value,
   docs,
   location
 ) {
-  Declaration.apply(this, [KIND, name, docs, location]);
+  Node.apply(this, [KIND, docs, location]);
+  this.name = name;
   this.value = value;
 });

--- a/src/ast/constantstatement.js
+++ b/src/ast/constantstatement.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2018 Glayzzle (BSD3 License)
+ * @authors https://github.com/glayzzle/php-parser/graphs/contributors
+ * @url http://glayzzle.com
+ */
+"use strict";
+
+const Statement = require("./statement");
+const KIND = "constantstatement";
+
+/**
+ * Declares a constants into the current scope
+ * @constructor ConstantStatement
+ * @extends {Statement}
+ * @property {Constant[]} items
+ */
+module.exports = Statement.extends(KIND, function ConstantStatement(
+  kind,
+  items,
+  docs,
+  location
+) {
+  Statement.apply(this, [kind || KIND, docs, location]);
+  this.items = items;
+});

--- a/src/parser/class.js
+++ b/src/parser/class.js
@@ -165,7 +165,8 @@ module.exports = {
     if (this.expect(this.tok.T_CONST)) {
       this.next();
     }
-    return this.read_list(
+    const result = this.node("classconstant");
+    const items = this.read_list(
       /**
        * Reads a constant declaration
        *
@@ -175,7 +176,7 @@ module.exports = {
        * @return {Constant} [:link:](AST.md#constant)
        */
       function read_constant_declaration() {
-        const result = this.node("classconstant");
+        const result = this.node("constant");
         let name = null;
         let value = null;
         if (
@@ -190,10 +191,12 @@ module.exports = {
         if (this.expect("=")) {
           value = this.next().read_expr();
         }
-        return result(name, value, flags);
+        return result(name, value);
       },
       ","
     );
+
+    return result(null, items, flags);
   },
   /**
    * Read member flags

--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -51,8 +51,12 @@ module.exports = {
         return this.read_trait();
       case this.tok.T_USE:
         return this.read_use_statement();
-      case this.tok.T_CONST:
-        return this.next().read_const_list();
+      case this.tok.T_CONST: {
+        const result = this.node("constantstatement");
+        const items = this.next().read_const_list();
+        this.expectEndOfStatement();
+        return result(null, items);
+      }
       case this.tok.T_NAMESPACE:
         return this.read_namespace();
       case this.tok.T_HALT_COMPILER: {
@@ -109,7 +113,6 @@ module.exports = {
       ",",
       false
     );
-    this.expectEndOfStatement();
     return result;
   },
   /**

--- a/test/snapshot/__snapshots__/acid.test.js.snap
+++ b/test/snapshot/__snapshots__/acid.test.js.snap
@@ -373,8 +373,47 @@ Program {
           "name": null,
           "type": null,
         },
-        Constant {
-          "kind": "constant",
+        ConstantStatement {
+          "items": Array [
+            Constant {
+              "kind": "constant",
+              "loc": Location {
+                "end": Position {
+                  "column": 28,
+                  "line": 20,
+                  "offset": 360,
+                },
+                "source": "FOOBAR = 'foo & bar'",
+                "start": Position {
+                  "column": 8,
+                  "line": 20,
+                  "offset": 340,
+                },
+              },
+              "name": "FOOBAR",
+              "value": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "loc": Location {
+                  "end": Position {
+                    "column": 28,
+                    "line": 20,
+                    "offset": 360,
+                  },
+                  "source": "'foo & bar'",
+                  "start": Position {
+                    "column": 17,
+                    "line": 20,
+                    "offset": 349,
+                  },
+                },
+                "raw": "'foo & bar'",
+                "unicode": false,
+                "value": "foo & bar",
+              },
+            },
+          ],
+          "kind": "constantstatement",
           "leadingComments": Array [
             CommentLine {
               "kind": "commentline",
@@ -398,38 +437,40 @@ Program {
           ],
           "loc": Location {
             "end": Position {
-              "column": 28,
+              "column": 29,
               "line": 20,
-              "offset": 360,
+              "offset": 361,
             },
-            "source": "FOOBAR = 'foo & bar'",
+            "source": "const FOOBAR = 'foo & bar';",
             "start": Position {
-              "column": 8,
+              "column": 2,
               "line": 20,
-              "offset": 340,
+              "offset": 334,
             },
           },
-          "name": "FOOBAR",
-          "value": String {
-            "isDoubleQuote": false,
-            "kind": "string",
-            "loc": Location {
-              "end": Position {
-                "column": 28,
-                "line": 20,
-                "offset": 360,
+          "trailingComments": Array [
+            CommentBlock {
+              "kind": "commentblock",
+              "loc": Location {
+                "end": Position {
+                  "column": 5,
+                  "line": 24,
+                  "offset": 387,
+                },
+                "source": "/**
+   * a class
+   */",
+                "start": Position {
+                  "column": 2,
+                  "line": 22,
+                  "offset": 365,
+                },
               },
-              "source": "'foo & bar'",
-              "start": Position {
-                "column": 17,
-                "line": 20,
-                "offset": 349,
-              },
+              "value": "/**
+   * a class
+   */",
             },
-            "raw": "'foo & bar'",
-            "unicode": false,
-            "value": "foo & bar",
-          },
+          ],
         },
         Class {
           "body": Array [
@@ -622,9 +663,45 @@ Program {
               ],
             },
             ClassConstant {
-              "isAbstract": false,
-              "isFinal": false,
-              "isStatic": false,
+              "items": Array [
+                Constant {
+                  "kind": "constant",
+                  "loc": Location {
+                    "end": Position {
+                      "column": 27,
+                      "line": 31,
+                      "offset": 561,
+                    },
+                    "source": "FOOBAR = 'BARFOO'",
+                    "start": Position {
+                      "column": 10,
+                      "line": 31,
+                      "offset": 544,
+                    },
+                  },
+                  "name": "FOOBAR",
+                  "value": String {
+                    "isDoubleQuote": false,
+                    "kind": "string",
+                    "loc": Location {
+                      "end": Position {
+                        "column": 27,
+                        "line": 31,
+                        "offset": 561,
+                      },
+                      "source": "'BARFOO'",
+                      "start": Position {
+                        "column": 19,
+                        "line": 31,
+                        "offset": 553,
+                      },
+                    },
+                    "raw": "'BARFOO'",
+                    "unicode": false,
+                    "value": "BARFOO",
+                  },
+                },
+              ],
               "kind": "classconstant",
               "loc": Location {
                 "end": Position {
@@ -638,27 +715,6 @@ Program {
                   "line": 31,
                   "offset": 544,
                 },
-              },
-              "name": "FOOBAR",
-              "value": String {
-                "isDoubleQuote": false,
-                "kind": "string",
-                "loc": Location {
-                  "end": Position {
-                    "column": 27,
-                    "line": 31,
-                    "offset": 561,
-                  },
-                  "source": "'BARFOO'",
-                  "start": Position {
-                    "column": 19,
-                    "line": 31,
-                    "offset": 553,
-                  },
-                },
-                "raw": "'BARFOO'",
-                "unicode": false,
-                "value": "BARFOO",
               },
               "visibility": "",
             },
@@ -1331,29 +1387,6 @@ Program {
           "isAnonymous": false,
           "isFinal": false,
           "kind": "class",
-          "leadingComments": Array [
-            CommentBlock {
-              "kind": "commentblock",
-              "loc": Location {
-                "end": Position {
-                  "column": 5,
-                  "line": 24,
-                  "offset": 387,
-                },
-                "source": "/**
-   * a class
-   */",
-                "start": Position {
-                  "column": 2,
-                  "line": 22,
-                  "offset": 365,
-                },
-              },
-              "value": "/**
-   * a class
-   */",
-            },
-          ],
           "loc": Location {
             "end": Position {
               "column": 3,

--- a/test/snapshot/__snapshots__/ast.test.js.snap
+++ b/test/snapshot/__snapshots__/ast.test.js.snap
@@ -198,13 +198,18 @@ Program {
 exports[`Test AST structure test constants 1`] = `
 Program {
   "children": Array [
-    Constant {
-      "kind": "constant",
-      "name": "FOO",
-      "value": Number {
-        "kind": "number",
-        "value": "3.14",
-      },
+    ConstantStatement {
+      "items": Array [
+        Constant {
+          "kind": "constant",
+          "name": "FOO",
+          "value": Number {
+            "kind": "number",
+            "value": "3.14",
+          },
+        },
+      ],
+      "kind": "constantstatement",
     },
   ],
   "errors": Array [],

--- a/test/snapshot/__snapshots__/bin.test.js.snap
+++ b/test/snapshot/__snapshots__/bin.test.js.snap
@@ -782,6 +782,7 @@ Program {
         },
         "right": ParentReference {
           "kind": "parentreference",
+          "raw": "parent",
         },
         "type": "instanceof",
       },
@@ -807,6 +808,7 @@ Program {
         },
         "right": SelfReference {
           "kind": "selfreference",
+          "raw": "self",
         },
         "type": "instanceof",
       },
@@ -832,6 +834,7 @@ Program {
         },
         "right": StaticReference {
           "kind": "staticreference",
+          "raw": "static",
         },
         "type": "instanceof",
       },
@@ -935,6 +938,7 @@ Program {
           },
           "right": StaticReference {
             "kind": "staticreference",
+            "raw": "static",
           },
           "type": "instanceof",
         },
@@ -948,6 +952,7 @@ Program {
           },
           "right": SelfReference {
             "kind": "selfreference",
+            "raw": "self",
           },
           "type": "instanceof",
         },

--- a/test/snapshot/__snapshots__/class.test.js.snap
+++ b/test/snapshot/__snapshots__/class.test.js.snap
@@ -122,9 +122,16 @@ Program {
     Interface {
       "body": Array [
         ClassConstant {
-          "isAbstract": false,
-          "isFinal": false,
-          "isStatic": false,
+          "items": Array [
+            Constant {
+              "kind": "constant",
+              "name": "A",
+              "value": Number {
+                "kind": "number",
+                "value": "1.5",
+              },
+            },
+          ],
           "kind": "classconstant",
           "leadingComments": Array [
             CommentLine {
@@ -133,11 +140,6 @@ Program {
 ",
             },
           ],
-          "name": "A",
-          "value": Number {
-            "kind": "number",
-            "value": "1.5",
-          },
           "visibility": "",
         },
         Method {
@@ -176,9 +178,16 @@ Program {
     Trait {
       "body": Array [
         ClassConstant {
-          "isAbstract": false,
-          "isFinal": false,
-          "isStatic": false,
+          "items": Array [
+            Constant {
+              "kind": "constant",
+              "name": "A",
+              "value": Number {
+                "kind": "number",
+                "value": "1.5",
+              },
+            },
+          ],
           "kind": "classconstant",
           "leadingComments": Array [
             CommentLine {
@@ -187,11 +196,6 @@ Program {
 ",
             },
           ],
-          "name": "A",
-          "value": Number {
-            "kind": "number",
-            "value": "1.5",
-          },
           "visibility": "",
         },
         Method {
@@ -621,18 +625,20 @@ Program {
     Class {
       "body": Array [
         ClassConstant {
-          "isAbstract": false,
-          "isFinal": false,
-          "isStatic": false,
+          "items": Array [
+            Constant {
+              "kind": "constant",
+              "name": "FOO",
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": "\\"azerty\\"",
+                "unicode": false,
+                "value": "azerty",
+              },
+            },
+          ],
           "kind": "classconstant",
-          "name": "FOO",
-          "value": String {
-            "isDoubleQuote": true,
-            "kind": "string",
-            "raw": "\\"azerty\\"",
-            "unicode": false,
-            "value": "azerty",
-          },
           "visibility": "",
         },
         Property {
@@ -712,18 +718,20 @@ Program {
           "visibility": "public",
         },
         ClassConstant {
-          "isAbstract": false,
-          "isFinal": false,
-          "isStatic": false,
+          "items": Array [
+            Constant {
+              "kind": "constant",
+              "name": "list",
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": "\\"bar\\"",
+                "unicode": false,
+                "value": "bar",
+              },
+            },
+          ],
           "kind": "classconstant",
-          "name": "list",
-          "value": String {
-            "isDoubleQuote": true,
-            "kind": "string",
-            "raw": "\\"bar\\"",
-            "unicode": false,
-            "value": "bar",
-          },
           "visibility": "",
         },
         Method {

--- a/test/snapshot/__snapshots__/classconstant.test.js.snap
+++ b/test/snapshot/__snapshots__/classconstant.test.js.snap
@@ -1,0 +1,197 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`classconstant multiple 1`] = `
+Program {
+  "children": Array [
+    Class {
+      "body": Array [
+        ClassConstant {
+          "items": Array [
+            Constant {
+              "kind": "constant",
+              "name": "CONSTANT",
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": "\\"Hello world!\\"",
+                "unicode": false,
+                "value": "Hello world!",
+              },
+            },
+            Constant {
+              "kind": "constant",
+              "name": "OTHER_CONSTANT",
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": "\\"Other hello world!\\"",
+                "unicode": false,
+                "value": "Other hello world!",
+              },
+            },
+          ],
+          "kind": "classconstant",
+          "visibility": "",
+        },
+      ],
+      "extends": null,
+      "implements": null,
+      "isAbstract": false,
+      "isAnonymous": false,
+      "isFinal": false,
+      "kind": "class",
+      "name": "Foo",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`classconstant private 1`] = `
+Program {
+  "children": Array [
+    Class {
+      "body": Array [
+        ClassConstant {
+          "items": Array [
+            Constant {
+              "kind": "constant",
+              "name": "CONSTANT",
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": "\\"Hello world!\\"",
+                "unicode": false,
+                "value": "Hello world!",
+              },
+            },
+          ],
+          "kind": "classconstant",
+          "visibility": "private",
+        },
+      ],
+      "extends": null,
+      "implements": null,
+      "isAbstract": false,
+      "isAnonymous": false,
+      "isFinal": false,
+      "kind": "class",
+      "name": "Foo",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`classconstant protected 1`] = `
+Program {
+  "children": Array [
+    Class {
+      "body": Array [
+        ClassConstant {
+          "items": Array [
+            Constant {
+              "kind": "constant",
+              "name": "CONSTANT",
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": "\\"Hello world!\\"",
+                "unicode": false,
+                "value": "Hello world!",
+              },
+            },
+          ],
+          "kind": "classconstant",
+          "visibility": "protected",
+        },
+      ],
+      "extends": null,
+      "implements": null,
+      "isAbstract": false,
+      "isAnonymous": false,
+      "isFinal": false,
+      "kind": "class",
+      "name": "Foo",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`classconstant public 1`] = `
+Program {
+  "children": Array [
+    Class {
+      "body": Array [
+        ClassConstant {
+          "items": Array [
+            Constant {
+              "kind": "constant",
+              "name": "CONSTANT",
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": "\\"Hello world!\\"",
+                "unicode": false,
+                "value": "Hello world!",
+              },
+            },
+          ],
+          "kind": "classconstant",
+          "visibility": "public",
+        },
+      ],
+      "extends": null,
+      "implements": null,
+      "isAbstract": false,
+      "isAnonymous": false,
+      "isFinal": false,
+      "kind": "class",
+      "name": "Foo",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`classconstant simple 1`] = `
+Program {
+  "children": Array [
+    Class {
+      "body": Array [
+        ClassConstant {
+          "items": Array [
+            Constant {
+              "kind": "constant",
+              "name": "CONSTANT",
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": "\\"Hello world!\\"",
+                "unicode": false,
+                "value": "Hello world!",
+              },
+            },
+          ],
+          "kind": "classconstant",
+          "visibility": "",
+        },
+      ],
+      "extends": null,
+      "implements": null,
+      "isAbstract": false,
+      "isAnonymous": false,
+      "isFinal": false,
+      "kind": "class",
+      "name": "Foo",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;

--- a/test/snapshot/__snapshots__/constantstatement.test.js.snap
+++ b/test/snapshot/__snapshots__/constantstatement.test.js.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`constantstatement multiple 1`] = `
+Program {
+  "children": Array [
+    ConstantStatement {
+      "items": Array [
+        Constant {
+          "kind": "constant",
+          "name": "CONSTANT",
+          "value": String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "raw": "\\"Hello world!\\"",
+            "unicode": false,
+            "value": "Hello world!",
+          },
+        },
+        Constant {
+          "kind": "constant",
+          "name": "OTHER_CONSTANT",
+          "value": String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "raw": "\\"Other hello world!\\"",
+            "unicode": false,
+            "value": "Other hello world!",
+          },
+        },
+      ],
+      "kind": "constantstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`constantstatement simple 1`] = `
+Program {
+  "children": Array [
+    ConstantStatement {
+      "items": Array [
+        Constant {
+          "kind": "constant",
+          "name": "CONSTANT",
+          "value": String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "raw": "\\"Hello world!\\"",
+            "unicode": false,
+            "value": "Hello world!",
+          },
+        },
+      ],
+      "kind": "constantstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;

--- a/test/snapshot/__snapshots__/graceful.test.js.snap
+++ b/test/snapshot/__snapshots__/graceful.test.js.snap
@@ -71,15 +71,17 @@ Program {
     Class {
       "body": Array [
         ClassConstant {
-          "isAbstract": false,
-          "isFinal": false,
-          "isStatic": false,
+          "items": Array [
+            Constant {
+              "kind": "constant",
+              "name": "A",
+              "value": Number {
+                "kind": "number",
+                "value": "1",
+              },
+            },
+          ],
           "kind": "classconstant",
-          "name": "A",
-          "value": Number {
-            "kind": "number",
-            "value": "1",
-          },
           "visibility": "",
         },
       ],

--- a/test/snapshot/__snapshots__/location.test.js.snap
+++ b/test/snapshot/__snapshots__/location.test.js.snap
@@ -1930,6 +1930,197 @@ Program {
 }
 `;
 
+exports[`Test locations conststatement 1`] = `
+Program {
+  "children": Array [
+    ConstantStatement {
+      "items": Array [
+        Constant {
+          "kind": "constant",
+          "loc": Location {
+            "end": Position {
+              "column": 31,
+              "line": 1,
+              "offset": 31,
+            },
+            "source": "CONSTANT = \\"Hello world!\\"",
+            "start": Position {
+              "column": 6,
+              "line": 1,
+              "offset": 6,
+            },
+          },
+          "name": "CONSTANT",
+          "value": String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "loc": Location {
+              "end": Position {
+                "column": 31,
+                "line": 1,
+                "offset": 31,
+              },
+              "source": "\\"Hello world!\\"",
+              "start": Position {
+                "column": 17,
+                "line": 1,
+                "offset": 17,
+              },
+            },
+            "raw": "\\"Hello world!\\"",
+            "unicode": false,
+            "value": "Hello world!",
+          },
+        },
+      ],
+      "kind": "constantstatement",
+      "loc": Location {
+        "end": Position {
+          "column": 32,
+          "line": 1,
+          "offset": 32,
+        },
+        "source": "const CONSTANT = \\"Hello world!\\";",
+        "start": Position {
+          "column": 0,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+  "loc": Location {
+    "end": Position {
+      "column": 32,
+      "line": 1,
+      "offset": 32,
+    },
+    "source": "const CONSTANT = \\"Hello world!\\";",
+    "start": Position {
+      "column": 0,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+}
+`;
+
+exports[`Test locations conststatement multiple 1`] = `
+Program {
+  "children": Array [
+    ConstantStatement {
+      "items": Array [
+        Constant {
+          "kind": "constant",
+          "loc": Location {
+            "end": Position {
+              "column": 31,
+              "line": 1,
+              "offset": 31,
+            },
+            "source": "CONSTANT = \\"Hello world!\\"",
+            "start": Position {
+              "column": 6,
+              "line": 1,
+              "offset": 6,
+            },
+          },
+          "name": "CONSTANT",
+          "value": String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "loc": Location {
+              "end": Position {
+                "column": 31,
+                "line": 1,
+                "offset": 31,
+              },
+              "source": "\\"Hello world!\\"",
+              "start": Position {
+                "column": 17,
+                "line": 1,
+                "offset": 17,
+              },
+            },
+            "raw": "\\"Hello world!\\"",
+            "unicode": false,
+            "value": "Hello world!",
+          },
+        },
+        Constant {
+          "kind": "constant",
+          "loc": Location {
+            "end": Position {
+              "column": 70,
+              "line": 1,
+              "offset": 70,
+            },
+            "source": "OTHER_CONSTANT = \\"Other hello world!\\"",
+            "start": Position {
+              "column": 33,
+              "line": 1,
+              "offset": 33,
+            },
+          },
+          "name": "OTHER_CONSTANT",
+          "value": String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "loc": Location {
+              "end": Position {
+                "column": 70,
+                "line": 1,
+                "offset": 70,
+              },
+              "source": "\\"Other hello world!\\"",
+              "start": Position {
+                "column": 50,
+                "line": 1,
+                "offset": 50,
+              },
+            },
+            "raw": "\\"Other hello world!\\"",
+            "unicode": false,
+            "value": "Other hello world!",
+          },
+        },
+      ],
+      "kind": "constantstatement",
+      "loc": Location {
+        "end": Position {
+          "column": 71,
+          "line": 1,
+          "offset": 71,
+        },
+        "source": "const CONSTANT = \\"Hello world!\\", OTHER_CONSTANT = \\"Other hello world!\\";",
+        "start": Position {
+          "column": 0,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+  "loc": Location {
+    "end": Position {
+      "column": 71,
+      "line": 1,
+      "offset": 71,
+    },
+    "source": "const CONSTANT = \\"Hello world!\\", OTHER_CONSTANT = \\"Other hello world!\\";",
+    "start": Position {
+      "column": 0,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+}
+`;
+
 exports[`Test locations continue 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/classconstant.test.js
+++ b/test/snapshot/classconstant.test.js
@@ -1,0 +1,19 @@
+const parser = require('../main');
+
+describe('classconstant', () => {
+  it('simple', () => {
+    expect(parser.parseEval('class Foo { const CONSTANT = "Hello world!"; }')).toMatchSnapshot();
+  });
+  it('multiple', () => {
+    expect(parser.parseEval('class Foo { const CONSTANT = "Hello world!", OTHER_CONSTANT = "Other hello world!"; }')).toMatchSnapshot();
+  });
+  it('public', () => {
+    expect(parser.parseEval('class Foo { public const CONSTANT = "Hello world!"; }')).toMatchSnapshot();
+  });
+  it('protected', () => {
+    expect(parser.parseEval('class Foo { protected const CONSTANT = "Hello world!"; }')).toMatchSnapshot();
+  });
+  it('private', () => {
+    expect(parser.parseEval('class Foo { private const CONSTANT = "Hello world!"; }')).toMatchSnapshot();
+  });
+});

--- a/test/snapshot/constantstatement.test.js
+++ b/test/snapshot/constantstatement.test.js
@@ -1,0 +1,10 @@
+const parser = require('../main');
+
+describe('constantstatement', () => {
+  it('simple', () => {
+    expect(parser.parseEval('const CONSTANT = "Hello world!";')).toMatchSnapshot();
+  });
+  it('multiple', () => {
+    expect(parser.parseEval('const CONSTANT = "Hello world!", OTHER_CONSTANT = "Other hello world!";')).toMatchSnapshot();
+  });
+});

--- a/test/snapshot/location.test.js
+++ b/test/snapshot/location.test.js
@@ -1224,4 +1224,30 @@ string";`,
       )
     ).toMatchSnapshot();
   });
+  it('conststatement', function() {
+    expect(
+      parser.parseEval(
+        'const CONSTANT = "Hello world!";',
+        {
+          ast: {
+            withPositions: true,
+            withSource: true
+          }
+        }
+      )
+    ).toMatchSnapshot();
+  });
+  it('conststatement multiple', function() {
+    expect(
+      parser.parseEval(
+        'const CONSTANT = "Hello world!", OTHER_CONSTANT = "Other hello world!";',
+        {
+          ast: {
+            withPositions: true,
+            withSource: true
+          }
+        }
+      )
+    ).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
fixes #210

- Introduce `ConstantStatement` node
- `constant` node now have only `name` and `value`
- `ClassConstant` extends `ConstantStatement` and parse flags