### PR TITLE
fix: typereference

### DIFF
--- a/src/ast/typereference.js
+++ b/src/ast/typereference.js
@@ -33,7 +33,8 @@ TypeReference.types = [
   "object",
   "array",
   "callable",
-  "iterable"
+  "iterable",
+  "void"
 ];
 
 module.exports = TypeReference;

--- a/test/snapshot/__snapshots__/parentreference.test.js.snap
+++ b/test/snapshot/__snapshots__/parentreference.test.js.snap
@@ -1,5 +1,79 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`parentreference argument (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": ParentReference {
+            "kind": "parentreference",
+            "raw": "PARENT",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`parentreference argument 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": ParentReference {
+            "kind": "parentreference",
+            "raw": "parent",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`parentreference call 1`] = `
 Program {
   "children": Array [
@@ -44,7 +118,7 @@ Program {
 }
 `;
 
-exports[`parentreference parent (uppercase) 1`] = `
+exports[`parentreference return type declarations (uppercase) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -54,10 +128,7 @@ Program {
           "kind": "parameter",
           "name": "arg",
           "nullable": false,
-          "type": ParentReference {
-            "kind": "parentreference",
-            "raw": "PARENT",
-          },
+          "type": null,
           "value": null,
           "variadic": false,
         },
@@ -73,7 +144,10 @@ Program {
         "name": "fn",
       },
       "nullable": false,
-      "type": null,
+      "type": ParentReference {
+        "kind": "parentreference",
+        "raw": "PARENT",
+      },
     },
   ],
   "errors": Array [],
@@ -81,7 +155,7 @@ Program {
 }
 `;
 
-exports[`parentreference parent 1`] = `
+exports[`parentreference return type declarations 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -91,10 +165,7 @@ Program {
           "kind": "parameter",
           "name": "arg",
           "nullable": false,
-          "type": ParentReference {
-            "kind": "parentreference",
-            "raw": "parent",
-          },
+          "type": null,
           "value": null,
           "variadic": false,
         },
@@ -110,7 +181,10 @@ Program {
         "name": "fn",
       },
       "nullable": false,
-      "type": null,
+      "type": ParentReference {
+        "kind": "parentreference",
+        "raw": "parent",
+      },
     },
   ],
   "errors": Array [],

--- a/test/snapshot/__snapshots__/selfreference.test.js.snap
+++ b/test/snapshot/__snapshots__/selfreference.test.js.snap
@@ -1,5 +1,79 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`selfreference argument (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": SelfReference {
+            "kind": "selfreference",
+            "raw": "SELF",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`selfreference argument 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": SelfReference {
+            "kind": "selfreference",
+            "raw": "self",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`selfreference call 1`] = `
 Program {
   "children": Array [
@@ -44,7 +118,7 @@ Program {
 }
 `;
 
-exports[`selfreference parent (uppercase) 1`] = `
+exports[`selfreference return type declarations (uppercase) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -54,10 +128,7 @@ Program {
           "kind": "parameter",
           "name": "arg",
           "nullable": false,
-          "type": SelfReference {
-            "kind": "selfreference",
-            "raw": "SELF",
-          },
+          "type": null,
           "value": null,
           "variadic": false,
         },
@@ -73,7 +144,10 @@ Program {
         "name": "fn",
       },
       "nullable": false,
-      "type": null,
+      "type": SelfReference {
+        "kind": "selfreference",
+        "raw": "SELF",
+      },
     },
   ],
   "errors": Array [],
@@ -81,7 +155,7 @@ Program {
 }
 `;
 
-exports[`selfreference parent 1`] = `
+exports[`selfreference return type declarations 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -91,10 +165,7 @@ Program {
           "kind": "parameter",
           "name": "arg",
           "nullable": false,
-          "type": SelfReference {
-            "kind": "selfreference",
-            "raw": "self",
-          },
+          "type": null,
           "value": null,
           "variadic": false,
         },
@@ -110,7 +181,10 @@ Program {
         "name": "fn",
       },
       "nullable": false,
-      "type": null,
+      "type": SelfReference {
+        "kind": "selfreference",
+        "raw": "self",
+      },
     },
   ],
   "errors": Array [],

--- a/test/snapshot/__snapshots__/typereference.test.js.snap
+++ b/test/snapshot/__snapshots__/typereference.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`typereference array (uppercase) 1`] = `
+exports[`typereference array (argument) (uppercase) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -38,7 +38,7 @@ Program {
 }
 `;
 
-exports[`typereference array 1`] = `
+exports[`typereference array (argument) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -76,7 +76,83 @@ Program {
 }
 `;
 
-exports[`typereference bool (uppercase) 1`] = `
+exports[`typereference array (return type declarations) (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": TypeReference {
+        "kind": "typereference",
+        "name": "array",
+        "raw": "ARRAY",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference array (return type declarations) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": TypeReference {
+        "kind": "typereference",
+        "name": "array",
+        "raw": "array",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference bool (argument) (uppercase) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -114,7 +190,7 @@ Program {
 }
 `;
 
-exports[`typereference bool 1`] = `
+exports[`typereference bool (argument) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -152,7 +228,83 @@ Program {
 }
 `;
 
-exports[`typereference callable (uppercase) 1`] = `
+exports[`typereference bool (return type declarations) (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": TypeReference {
+        "kind": "typereference",
+        "name": "bool",
+        "raw": "BOOL",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference bool (return type declarations) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": TypeReference {
+        "kind": "typereference",
+        "name": "bool",
+        "raw": "bool",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference callable (argument) (uppercase) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -190,7 +342,7 @@ Program {
 }
 `;
 
-exports[`typereference callable 1`] = `
+exports[`typereference callable (argument) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -221,6 +373,82 @@ Program {
       },
       "nullable": false,
       "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference callable (return type declarations) (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": TypeReference {
+        "kind": "typereference",
+        "name": "callable",
+        "raw": "CALLABLE",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference callable (return type declarations) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": TypeReference {
+        "kind": "typereference",
+        "name": "callable",
+        "raw": "callable",
+      },
     },
   ],
   "errors": Array [],
@@ -266,6 +494,82 @@ Program {
 }
 `;
 
+exports[`typereference class (3) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": ClassReference {
+        "kind": "classreference",
+        "name": "Foo",
+        "resolution": "uqn",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference class (4) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": ClassReference {
+        "kind": "classreference",
+        "name": "Foo\\\\Foo",
+        "resolution": "qn",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`typereference class 1`] = `
 Program {
   "children": Array [
@@ -304,7 +608,7 @@ Program {
 }
 `;
 
-exports[`typereference float (uppercase) 1`] = `
+exports[`typereference float (argument) (uppercase) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -342,7 +646,7 @@ Program {
 }
 `;
 
-exports[`typereference float 1`] = `
+exports[`typereference float (argument) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -380,7 +684,83 @@ Program {
 }
 `;
 
-exports[`typereference int (uppercase) 1`] = `
+exports[`typereference float (return type declarations) (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": TypeReference {
+        "kind": "typereference",
+        "name": "float",
+        "raw": "FLOAT",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference float (return type declarations) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": TypeReference {
+        "kind": "typereference",
+        "name": "float",
+        "raw": "float",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference int (argument) (uppercase) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -418,7 +798,7 @@ Program {
 }
 `;
 
-exports[`typereference int 1`] = `
+exports[`typereference int (argument) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -456,7 +836,83 @@ Program {
 }
 `;
 
-exports[`typereference iterable (uppercase) 1`] = `
+exports[`typereference int (return type declarations) (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": TypeReference {
+        "kind": "typereference",
+        "name": "int",
+        "raw": "INT",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference int (return type declarations) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": TypeReference {
+        "kind": "typereference",
+        "name": "int",
+        "raw": "int",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference iterable (argument) (uppercase) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -494,7 +950,7 @@ Program {
 }
 `;
 
-exports[`typereference iterable 1`] = `
+exports[`typereference iterable (argument) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -532,7 +988,83 @@ Program {
 }
 `;
 
-exports[`typereference object (uppercase) 1`] = `
+exports[`typereference iterable (return type declarations) (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": TypeReference {
+        "kind": "typereference",
+        "name": "iterable",
+        "raw": "ITERABLE",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference iterable (return type declarations) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": TypeReference {
+        "kind": "typereference",
+        "name": "iterable",
+        "raw": "iterable",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference object (argument) (uppercase) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -570,7 +1102,7 @@ Program {
 }
 `;
 
-exports[`typereference object 1`] = `
+exports[`typereference object (argument) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -608,7 +1140,83 @@ Program {
 }
 `;
 
-exports[`typereference string (uppercase) 1`] = `
+exports[`typereference object (return type declarations) (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": TypeReference {
+        "kind": "typereference",
+        "name": "object",
+        "raw": "OBJECT",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference object (return type declarations) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": TypeReference {
+        "kind": "typereference",
+        "name": "object",
+        "raw": "object",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference string (argument) (uppercase) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -646,7 +1254,7 @@ Program {
 }
 `;
 
-exports[`typereference string 1`] = `
+exports[`typereference string (argument) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -677,6 +1285,234 @@ Program {
       },
       "nullable": false,
       "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference string (return type declarations) (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": TypeReference {
+        "kind": "typereference",
+        "name": "string",
+        "raw": "STRING",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference string (return type declarations) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": TypeReference {
+        "kind": "typereference",
+        "name": "string",
+        "raw": "string",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference void (argument) (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "void",
+            "raw": "VOID",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference void (argument) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "void",
+            "raw": "void",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference void (return type declarations) (uppercase) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": TypeReference {
+        "kind": "typereference",
+        "name": "void",
+        "raw": "VOID",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`typereference void (return type declarations) 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "byref": false,
+          "kind": "parameter",
+          "name": "arg",
+          "nullable": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "fn",
+      },
+      "nullable": false,
+      "type": TypeReference {
+        "kind": "typereference",
+        "name": "void",
+        "raw": "void",
+      },
     },
   ],
   "errors": Array [],

--- a/test/snapshot/parentreference.test.js
+++ b/test/snapshot/parentreference.test.js
@@ -13,10 +13,16 @@ describe("parentreference", function() {
   it("uppercase", function() {
     expect(parser.parseEval('PARENT::call();')).toMatchSnapshot();
   });
-  it("parent", function() {
+  it("argument", function() {
     expect(parser.parseEval('function fn(parent $arg) {}')).toMatchSnapshot();
   });
-  it("parent (uppercase)", function() {
+  it("argument (uppercase)", function() {
     expect(parser.parseEval('function fn(PARENT $arg) {}')).toMatchSnapshot();
+  });
+  it("return type declarations", function() {
+    expect(parser.parseEval('function fn($arg): parent {}')).toMatchSnapshot();
+  });
+  it("return type declarations (uppercase)", function() {
+    expect(parser.parseEval('function fn($arg): PARENT {}')).toMatchSnapshot();
   });
 });

--- a/test/snapshot/selfreference.test.js
+++ b/test/snapshot/selfreference.test.js
@@ -13,10 +13,16 @@ describe("selfreference", function() {
   it("uppercase", function() {
     expect(parser.parseEval('SELF::call();')).toMatchSnapshot();
   });
-  it("parent", function() {
+  it("argument", function() {
     expect(parser.parseEval('function fn(self $arg) {}')).toMatchSnapshot();
   });
-  it("parent (uppercase)", function() {
+  it("argument (uppercase)", function() {
     expect(parser.parseEval('function fn(SELF $arg) {}')).toMatchSnapshot();
+  });
+  it("return type declarations", function() {
+    expect(parser.parseEval('function fn($arg): self {}')).toMatchSnapshot();
+  });
+  it("return type declarations (uppercase)", function() {
+    expect(parser.parseEval('function fn($arg): SELF {}')).toMatchSnapshot();
   });
 });

--- a/test/snapshot/typereference.test.js
+++ b/test/snapshot/typereference.test.js
@@ -1,58 +1,124 @@
 const parser = require('../main');
 
 describe("typereference", function() {
-  it("int", function() {
+  it("int (argument)", function() {
     expect(parser.parseEval('function fn(int $arg) {}')).toMatchSnapshot();
   });
-  it("int (uppercase)", function() {
+  it("int (argument) (uppercase)", function() {
     expect(parser.parseEval('function fn(INT $arg) {}')).toMatchSnapshot();
   });
-  it("float", function() {
+  it("int (return type declarations)", function() {
+    expect(parser.parseEval('function fn($arg): int {}')).toMatchSnapshot();
+  });
+  it("int (return type declarations) (uppercase)", function() {
+    expect(parser.parseEval('function fn($arg): INT {}')).toMatchSnapshot();
+  });
+  it("float (argument)", function() {
     expect(parser.parseEval('function fn(float $arg) {}')).toMatchSnapshot();
   });
-  it("float (uppercase)", function() {
+  it("float (argument) (uppercase)", function() {
     expect(parser.parseEval('function fn(FLOAT $arg) {}')).toMatchSnapshot();
   });
-  it("bool", function() {
+  it("float (return type declarations)", function() {
+    expect(parser.parseEval('function fn($arg): float {}')).toMatchSnapshot();
+  });
+  it("float (return type declarations) (uppercase)", function() {
+    expect(parser.parseEval('function fn($arg): FLOAT {}')).toMatchSnapshot();
+  });
+  it("bool (argument)", function() {
     expect(parser.parseEval('function fn(bool $arg) {}')).toMatchSnapshot();
   });
-  it("bool (uppercase)", function() {
+  it("bool (argument) (uppercase)", function() {
     expect(parser.parseEval('function fn(BOOL $arg) {}')).toMatchSnapshot();
   });
-  it("string", function() {
+  it("bool (return type declarations)", function() {
+    expect(parser.parseEval('function fn($arg): bool {}')).toMatchSnapshot();
+  });
+  it("bool (return type declarations) (uppercase)", function() {
+    expect(parser.parseEval('function fn($arg): BOOL {}')).toMatchSnapshot();
+  });
+  it("string (argument)", function() {
     expect(parser.parseEval('function fn(string $arg) {}')).toMatchSnapshot();
   });
-  it("string (uppercase)", function() {
+  it("string (argument) (uppercase)", function() {
     expect(parser.parseEval('function fn(STRING $arg) {}')).toMatchSnapshot();
   });
-  it("array", function() {
+  it("string (return type declarations)", function() {
+    expect(parser.parseEval('function fn($arg): string {}')).toMatchSnapshot();
+  });
+  it("string (return type declarations) (uppercase)", function() {
+    expect(parser.parseEval('function fn($arg): STRING {}')).toMatchSnapshot();
+  });
+  it("array (argument)", function() {
     expect(parser.parseEval('function fn(array $arg) {}')).toMatchSnapshot();
   });
-  it("array (uppercase)", function() {
+  it("array (argument) (uppercase)", function() {
     expect(parser.parseEval('function fn(ARRAY $arg) {}')).toMatchSnapshot();
   });
-  it("callable", function() {
+  it("array (return type declarations)", function() {
+    expect(parser.parseEval('function fn($arg): array {}')).toMatchSnapshot();
+  });
+  it("array (return type declarations) (uppercase)", function() {
+    expect(parser.parseEval('function fn($arg): ARRAY {}')).toMatchSnapshot();
+  });
+  it("callable (argument)", function() {
     expect(parser.parseEval('function fn(callable $arg) {}')).toMatchSnapshot();
   });
-  it("callable (uppercase)", function() {
+  it("callable (argument) (uppercase)", function() {
     expect(parser.parseEval('function fn(CALLABLE $arg) {}')).toMatchSnapshot();
   });
-  it("object", function() {
+  it("callable (return type declarations)", function() {
+    expect(parser.parseEval('function fn($arg): callable {}')).toMatchSnapshot();
+  });
+  it("callable (return type declarations) (uppercase)", function() {
+    expect(parser.parseEval('function fn($arg): CALLABLE  {}')).toMatchSnapshot();
+  });
+  it("object (argument)", function() {
     expect(parser.parseEval('function fn(object $arg) {}')).toMatchSnapshot();
   });
-  it("object (uppercase)", function() {
+  it("object (argument) (uppercase)", function() {
     expect(parser.parseEval('function fn(OBJECT $arg) {}')).toMatchSnapshot();
   });
-  it("iterable", function() {
+  it("object (return type declarations)", function() {
+    expect(parser.parseEval('function fn($arg): object {}')).toMatchSnapshot();
+  });
+  it("object (return type declarations) (uppercase)", function() {
+    expect(parser.parseEval('function fn($arg): OBJECT {}')).toMatchSnapshot();
+  });
+  it("iterable (argument)", function() {
     expect(parser.parseEval('function fn(iterable $arg) {}')).toMatchSnapshot();
   });
-  it("iterable (uppercase)", function() {
+  it("iterable (argument) (uppercase)", function() {
     expect(parser.parseEval('function fn(ITERABLE $arg) {}')).toMatchSnapshot();
+  });
+  it("iterable (return type declarations)", function() {
+    expect(parser.parseEval('function fn($arg): iterable {}')).toMatchSnapshot();
+  });
+  it("iterable (return type declarations) (uppercase)", function() {
+    expect(parser.parseEval('function fn($arg): ITERABLE {}')).toMatchSnapshot();
+  });
+  it("void (argument)", function() {
+    expect(parser.parseEval('function fn(void $arg) {}')).toMatchSnapshot();
+  });
+  it("void (argument) (uppercase)", function() {
+    expect(parser.parseEval('function fn(VOID $arg) {}')).toMatchSnapshot();
+  });
+  it("void (return type declarations)", function() {
+    expect(parser.parseEval('function fn($arg): void {}')).toMatchSnapshot();
+  });
+  it("void (return type declarations) (uppercase)", function() {
+    expect(parser.parseEval('function fn($arg): VOID {}')).toMatchSnapshot();
   });
   it("class", function() {
     expect(parser.parseEval('function fn(Foo $arg) {}')).toMatchSnapshot();
   });
   it("class (2)", function() {
     expect(parser.parseEval('function fn(Foo\\Foo $arg) {}')).toMatchSnapshot();
+  });
+  it("class (3)", function() {
+    expect(parser.parseEval('function fn($arg): Foo {}')).toMatchSnapshot();
+  });
+  it("class (4)", function() {
+    expect(parser.parseEval('function fn($arg): Foo\\Foo {}')).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
- `void` is now `typereference` node
- better naming tests
- more tests