### PR TITLE
feat: improve `Declare` node and introduce `DeclareDirective` node

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -14,6 +14,7 @@ const Position = require("./ast/position");
  * - [Location](#location)
  * - [Position](#position)
  * - [Node](#node)
+ *   - [DeclareDirective](#declaredirective)
  *   - [EncapsedPart](#encapsedpart)
  *   - [Constant](#constant)
  *   - [Identifier](#identifier)
@@ -365,6 +366,7 @@ AST.prototype.prepare = function(kind, docs, parser) {
   require("./ast/continue"),
   require("./ast/declaration"),
   require("./ast/declare"),
+  require("./ast/declaredirective"),
   require("./ast/do"),
   require("./ast/echo"),
   require("./ast/empty"),

--- a/src/ast/declare.js
+++ b/src/ast/declare.js
@@ -12,19 +12,19 @@ const KIND = "declare";
  * The declare construct is used to set execution directives for a block of code
  * @constructor Declare
  * @extends {Block}
- * @property {Expression[]} what
+ * @property {Array[]} directives
  * @property {String} mode
  * @see http://php.net/manual/en/control-structures.declare.php
  */
 const Declare = Block.extends(KIND, function Declare(
-  what,
+  directives,
   body,
   mode,
   docs,
   location
 ) {
   Block.apply(this, [KIND, body, docs, location]);
-  this.what = what;
+  this.directives = directives;
   this.mode = mode;
 });
 

--- a/src/ast/declaredirective.js
+++ b/src/ast/declaredirective.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2018 Glayzzle (BSD3 License)
+ * @authors https://github.com/glayzzle/php-parser/graphs/contributors
+ * @url http://glayzzle.com
+ */
+"use strict";
+
+const Node = require("./node");
+const KIND = "declaredirective";
+
+/**
+ * Defines a constant
+ * @constructor DeclareDirective
+ * @extends {Node}
+ * @property {Identifier} name
+ * @property {Node|string|number|boolean|null} value
+ */
+module.exports = Node.extends(KIND, function DeclareDirective(
+  key,
+  value,
+  docs,
+  location
+) {
+  Node.apply(this, [KIND, docs, location]);
+  this.key = key;
+  this.value = value;
+});

--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -118,20 +118,24 @@ module.exports = {
   /**
    * Reads a list of constants declaration
    * ```ebnf
-   *   declare_list ::= T_STRING '=' expr (',' T_STRING '=' expr)*
+   *   declare_list ::= IDENTIFIER '=' expr (',' IDENTIFIER '=' expr)*
    * ```
-   * @retrurn {Object}
+   * @retrurn {Array}
    */
   read_declare_list: function() {
-    const result = {};
+    const result = [];
     while (this.token != this.EOF && this.token !== ")") {
       this.expect(this.tok.T_STRING);
-      const name = this.text().toLowerCase();
-      if (this.next().expect("=")) {
-        result[name] = this.next().read_expr();
-      } else {
-        result[name] = null;
+      const directive = this.node("declaredirective");
+      let key = this.node("identifier");
+      const name = this.text();
+      this.next();
+      key = key(name);
+      let value = null;
+      if (this.expect("=")) {
+        value = this.next().read_expr();
       }
+      result.push(directive(key, value));
       if (this.token !== ",") break;
       this.next();
     }
@@ -299,7 +303,7 @@ module.exports = {
         const body = [];
         let mode;
         this.next().expect("(") && this.next();
-        const what = this.read_declare_list();
+        const directives = this.read_declare_list();
         this.expect(")") && this.next();
         if (this.token === ":") {
           this.next();
@@ -325,7 +329,7 @@ module.exports = {
           this.expect(";") && this.next();
           mode = this.ast.declare.MODE_NONE;
         }
-        return result(what, body, mode);
+        return result(directives, body, mode);
       }
 
       case this.tok.T_TRY:

--- a/test/snapshot/__snapshots__/acid.test.js.snap
+++ b/test/snapshot/__snapshots__/acid.test.js.snap
@@ -80,6 +80,58 @@ Program {
     },
     Declare {
       "children": Array [],
+      "directives": Array [
+        DeclareDirective {
+          "key": Identifier {
+            "kind": "identifier",
+            "loc": Location {
+              "end": Position {
+                "column": 20,
+                "line": 4,
+                "offset": 63,
+              },
+              "source": "strict_types",
+              "start": Position {
+                "column": 8,
+                "line": 4,
+                "offset": 51,
+              },
+            },
+            "name": "strict_types",
+          },
+          "kind": "declaredirective",
+          "loc": Location {
+            "end": Position {
+              "column": 22,
+              "line": 4,
+              "offset": 65,
+            },
+            "source": "strict_types=1",
+            "start": Position {
+              "column": 8,
+              "line": 4,
+              "offset": 51,
+            },
+          },
+          "value": Number {
+            "kind": "number",
+            "loc": Location {
+              "end": Position {
+                "column": 22,
+                "line": 4,
+                "offset": 65,
+              },
+              "source": "1",
+              "start": Position {
+                "column": 21,
+                "line": 4,
+                "offset": 64,
+              },
+            },
+            "value": "1",
+          },
+        },
+      ],
       "kind": "declare",
       "loc": Location {
         "end": Position {
@@ -95,25 +147,6 @@ Program {
         },
       },
       "mode": "none",
-      "what": Object {
-        "strict_types": Number {
-          "kind": "number",
-          "loc": Location {
-            "end": Position {
-              "column": 22,
-              "line": 4,
-              "offset": 65,
-            },
-            "source": "1",
-            "start": Position {
-              "column": 21,
-              "line": 4,
-              "offset": 64,
-            },
-          },
-          "value": "1",
-        },
-      },
     },
     ExpressionStatement {
       "expression": Include {

--- a/test/snapshot/__snapshots__/declare.test.js.snap
+++ b/test/snapshot/__snapshots__/declare.test.js.snap
@@ -1,0 +1,197 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`declare encoding 1`] = `
+Program {
+  "children": Array [
+    Declare {
+      "children": Array [],
+      "directives": Array [
+        DeclareDirective {
+          "key": Identifier {
+            "kind": "identifier",
+            "name": "encoding",
+          },
+          "kind": "declaredirective",
+          "value": String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'ISO-8859-1'",
+            "unicode": false,
+            "value": "ISO-8859-1",
+          },
+        },
+      ],
+      "kind": "declare",
+      "mode": "none",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`declare mode short 1`] = `
+Program {
+  "children": Array [
+    Declare {
+      "children": Array [
+        Echo {
+          "expressions": Array [
+            String {
+              "isDoubleQuote": true,
+              "kind": "string",
+              "raw": "\\"something\\"",
+              "unicode": false,
+              "value": "something",
+            },
+          ],
+          "kind": "echo",
+          "shortForm": false,
+        },
+      ],
+      "directives": Array [
+        DeclareDirective {
+          "key": Identifier {
+            "kind": "identifier",
+            "name": "ticks",
+          },
+          "kind": "declaredirective",
+          "value": Number {
+            "kind": "number",
+            "value": "1",
+          },
+        },
+      ],
+      "kind": "declare",
+      "mode": "short",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`declare multiple 1`] = `
+Program {
+  "children": Array [
+    Declare {
+      "children": Array [],
+      "directives": Array [
+        DeclareDirective {
+          "key": Identifier {
+            "kind": "identifier",
+            "name": "A",
+          },
+          "kind": "declaredirective",
+          "value": String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'B'",
+            "unicode": false,
+            "value": "B",
+          },
+        },
+        DeclareDirective {
+          "key": Identifier {
+            "kind": "identifier",
+            "name": "C",
+          },
+          "kind": "declaredirective",
+          "value": String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'D'",
+            "unicode": false,
+            "value": "D",
+          },
+        },
+      ],
+      "kind": "declare",
+      "mode": "block",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`declare nested 1`] = `
+Program {
+  "children": Array [
+    Declare {
+      "children": Array [],
+      "directives": Array [
+        DeclareDirective {
+          "key": Identifier {
+            "kind": "identifier",
+            "name": "ticks",
+          },
+          "kind": "declaredirective",
+          "value": Number {
+            "kind": "number",
+            "value": "1",
+          },
+        },
+      ],
+      "kind": "declare",
+      "mode": "block",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`declare strict_types 1`] = `
+Program {
+  "children": Array [
+    Declare {
+      "children": Array [],
+      "directives": Array [
+        DeclareDirective {
+          "key": Identifier {
+            "kind": "identifier",
+            "name": "strict_types",
+          },
+          "kind": "declaredirective",
+          "value": Number {
+            "kind": "number",
+            "value": "1",
+          },
+        },
+      ],
+      "kind": "declare",
+      "mode": "none",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`declare ticks 1`] = `
+Program {
+  "children": Array [
+    Declare {
+      "children": Array [],
+      "directives": Array [
+        DeclareDirective {
+          "key": Identifier {
+            "kind": "identifier",
+            "name": "ticks",
+          },
+          "kind": "declaredirective",
+          "value": Number {
+            "kind": "number",
+            "value": "1",
+          },
+        },
+      ],
+      "kind": "declare",
+      "mode": "none",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;

--- a/test/snapshot/__snapshots__/location.test.js.snap
+++ b/test/snapshot/__snapshots__/location.test.js.snap
@@ -2165,6 +2165,58 @@ Program {
   "children": Array [
     Declare {
       "children": Array [],
+      "directives": Array [
+        DeclareDirective {
+          "key": Identifier {
+            "kind": "identifier",
+            "loc": Location {
+              "end": Position {
+                "column": 13,
+                "line": 1,
+                "offset": 13,
+              },
+              "source": "ticks",
+              "start": Position {
+                "column": 8,
+                "line": 1,
+                "offset": 8,
+              },
+            },
+            "name": "ticks",
+          },
+          "kind": "declaredirective",
+          "loc": Location {
+            "end": Position {
+              "column": 15,
+              "line": 1,
+              "offset": 15,
+            },
+            "source": "ticks=1",
+            "start": Position {
+              "column": 8,
+              "line": 1,
+              "offset": 8,
+            },
+          },
+          "value": Number {
+            "kind": "number",
+            "loc": Location {
+              "end": Position {
+                "column": 15,
+                "line": 1,
+                "offset": 15,
+              },
+              "source": "1",
+              "start": Position {
+                "column": 14,
+                "line": 1,
+                "offset": 14,
+              },
+            },
+            "value": "1",
+          },
+        },
+      ],
       "kind": "declare",
       "loc": Location {
         "end": Position {
@@ -2180,25 +2232,6 @@ Program {
         },
       },
       "mode": "none",
-      "what": Object {
-        "ticks": Number {
-          "kind": "number",
-          "loc": Location {
-            "end": Position {
-              "column": 15,
-              "line": 1,
-              "offset": 15,
-            },
-            "source": "1",
-            "start": Position {
-              "column": 14,
-              "line": 1,
-              "offset": 14,
-            },
-          },
-          "value": "1",
-        },
-      },
     },
   ],
   "errors": Array [],
@@ -2264,6 +2297,58 @@ Program {
           "shortForm": false,
         },
       ],
+      "directives": Array [
+        DeclareDirective {
+          "key": Identifier {
+            "kind": "identifier",
+            "loc": Location {
+              "end": Position {
+                "column": 13,
+                "line": 1,
+                "offset": 13,
+              },
+              "source": "ticks",
+              "start": Position {
+                "column": 8,
+                "line": 1,
+                "offset": 8,
+              },
+            },
+            "name": "ticks",
+          },
+          "kind": "declaredirective",
+          "loc": Location {
+            "end": Position {
+              "column": 15,
+              "line": 1,
+              "offset": 15,
+            },
+            "source": "ticks=1",
+            "start": Position {
+              "column": 8,
+              "line": 1,
+              "offset": 8,
+            },
+          },
+          "value": Number {
+            "kind": "number",
+            "loc": Location {
+              "end": Position {
+                "column": 15,
+                "line": 1,
+                "offset": 15,
+              },
+              "source": "1",
+              "start": Position {
+                "column": 14,
+                "line": 1,
+                "offset": 14,
+              },
+            },
+            "value": "1",
+          },
+        },
+      ],
       "kind": "declare",
       "loc": Location {
         "end": Position {
@@ -2279,25 +2364,6 @@ Program {
         },
       },
       "mode": "block",
-      "what": Object {
-        "ticks": Number {
-          "kind": "number",
-          "loc": Location {
-            "end": Position {
-              "column": 15,
-              "line": 1,
-              "offset": 15,
-            },
-            "source": "1",
-            "start": Position {
-              "column": 14,
-              "line": 1,
-              "offset": 14,
-            },
-          },
-          "value": "1",
-        },
-      },
     },
   ],
   "errors": Array [],
@@ -2315,6 +2381,77 @@ Program {
       "offset": 0,
     },
   },
+}
+`;
+
+exports[`Test locations declare directive (multiple) 1`] = `
+Program {
+  "children": Array [
+    Declare {
+      "children": Array [],
+      "directives": Array [
+        DeclareDirective {
+          "key": Identifier {
+            "kind": "identifier",
+            "name": "A",
+          },
+          "kind": "declaredirective",
+          "value": String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'B'",
+            "unicode": false,
+            "value": "B",
+          },
+        },
+        DeclareDirective {
+          "key": Identifier {
+            "kind": "identifier",
+            "name": "C",
+          },
+          "kind": "declaredirective",
+          "value": String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'D'",
+            "unicode": false,
+            "value": "D",
+          },
+        },
+      ],
+      "kind": "declare",
+      "mode": "block",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test locations declare directive 1`] = `
+Program {
+  "children": Array [
+    Declare {
+      "children": Array [],
+      "directives": Array [
+        DeclareDirective {
+          "key": Identifier {
+            "kind": "identifier",
+            "name": "strict_types",
+          },
+          "kind": "declaredirective",
+          "value": Number {
+            "kind": "number",
+            "value": "1",
+          },
+        },
+      ],
+      "kind": "declare",
+      "mode": "none",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
 }
 `;
 

--- a/test/snapshot/__snapshots__/namespace.test.js.snap
+++ b/test/snapshot/__snapshots__/namespace.test.js.snap
@@ -1346,14 +1346,21 @@ Program {
   "children": Array [
     Declare {
       "children": Array [],
+      "directives": Array [
+        DeclareDirective {
+          "key": Identifier {
+            "kind": "identifier",
+            "name": "strict_types",
+          },
+          "kind": "declaredirective",
+          "value": Number {
+            "kind": "number",
+            "value": "1",
+          },
+        },
+      ],
       "kind": "declare",
       "mode": "none",
-      "what": Object {
-        "strict_types": Number {
-          "kind": "number",
-          "value": "1",
-        },
-      },
     },
     Namespace {
       "children": Array [

--- a/test/snapshot/__snapshots__/statement.test.js.snap
+++ b/test/snapshot/__snapshots__/statement.test.js.snap
@@ -97,14 +97,21 @@ Program {
         "children": Array [
           Declare {
             "children": Array [],
+            "directives": Array [
+              DeclareDirective {
+                "key": Identifier {
+                  "kind": "identifier",
+                  "name": "ticks",
+                },
+                "kind": "declaredirective",
+                "value": Number {
+                  "kind": "number",
+                  "value": "1",
+                },
+              },
+            ],
             "kind": "declare",
             "mode": "none",
-            "what": Object {
-              "ticks": Number {
-                "kind": "number",
-                "value": "1",
-              },
-            },
           },
         ],
         "kind": "block",
@@ -136,38 +143,52 @@ Program {
     },
     Declare {
       "children": Array [],
-      "kind": "declare",
-      "mode": "none",
-      "what": Object {
-        "encoding": Bin {
-          "kind": "bin",
-          "left": Bin {
+      "directives": Array [
+        DeclareDirective {
+          "key": Identifier {
+            "kind": "identifier",
+            "name": "ticks",
+          },
+          "kind": "declaredirective",
+          "value": Number {
+            "kind": "number",
+            "value": "2",
+          },
+        },
+        DeclareDirective {
+          "key": Identifier {
+            "kind": "identifier",
+            "name": "encoding",
+          },
+          "kind": "declaredirective",
+          "value": Bin {
             "kind": "bin",
-            "left": Identifier {
-              "kind": "identifier",
-              "name": ClassReference {
-                "kind": "classreference",
-                "name": "ISO",
-                "resolution": "uqn",
+            "left": Bin {
+              "kind": "bin",
+              "left": Identifier {
+                "kind": "identifier",
+                "name": ClassReference {
+                  "kind": "classreference",
+                  "name": "ISO",
+                  "resolution": "uqn",
+                },
               },
+              "right": Number {
+                "kind": "number",
+                "value": "8859",
+              },
+              "type": "-",
             },
             "right": Number {
               "kind": "number",
-              "value": "8859",
+              "value": "1",
             },
             "type": "-",
           },
-          "right": Number {
-            "kind": "number",
-            "value": "1",
-          },
-          "type": "-",
         },
-        "ticks": Number {
-          "kind": "number",
-          "value": "2",
-        },
-      },
+      ],
+      "kind": "declare",
+      "mode": "none",
     },
     ExpressionStatement {
       "expression": Assign {
@@ -206,14 +227,21 @@ Program {
           "kind": "expressionstatement",
         },
       ],
+      "directives": Array [
+        DeclareDirective {
+          "key": Identifier {
+            "kind": "identifier",
+            "name": "ticks",
+          },
+          "kind": "declaredirective",
+          "value": Number {
+            "kind": "number",
+            "value": "1",
+          },
+        },
+      ],
       "kind": "declare",
       "mode": "block",
-      "what": Object {
-        "ticks": Number {
-          "kind": "number",
-          "value": "1",
-        },
-      },
     },
     Declare {
       "children": Array [
@@ -235,17 +263,24 @@ Program {
           "kind": "expressionstatement",
         },
       ],
+      "directives": Array [
+        DeclareDirective {
+          "key": Identifier {
+            "kind": "identifier",
+            "name": "encoding",
+          },
+          "kind": "declaredirective",
+          "value": String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "raw": "\\"UTF-8\\"",
+            "unicode": false,
+            "value": "UTF-8",
+          },
+        },
+      ],
       "kind": "declare",
       "mode": "short",
-      "what": Object {
-        "encoding": String {
-          "isDoubleQuote": true,
-          "kind": "string",
-          "raw": "\\"UTF-8\\"",
-          "unicode": false,
-          "value": "UTF-8",
-        },
-      },
     },
     ExpressionStatement {
       "expression": Assign {

--- a/test/snapshot/declare.test.js
+++ b/test/snapshot/declare.test.js
@@ -1,0 +1,26 @@
+const parser = require("../main");
+
+describe("declare", function() {
+  it("strict_types", function() {
+    expect(parser.parseEval("declare (strict_types=1);")).toMatchSnapshot();
+  });
+  it("ticks", function() {
+    expect(parser.parseEval("declare(ticks=1);")).toMatchSnapshot();
+  });
+  it("encoding", function() {
+    expect(
+      parser.parseEval("declare(encoding='ISO-8859-1');")
+    ).toMatchSnapshot();
+  });
+  it("nested", function() {
+    expect(parser.parseEval("declare(ticks=1) { }")).toMatchSnapshot();
+  });
+  it("mode short", function() {
+    expect(
+      parser.parseEval('declare(ticks=1): echo "something"; enddeclare;')
+    ).toMatchSnapshot();
+  });
+  it("multiple", function() {
+    expect(parser.parseEval("declare (A='B', C='D') { }")).toMatchSnapshot();
+  });
+});

--- a/test/snapshot/location.test.js
+++ b/test/snapshot/location.test.js
@@ -1250,4 +1250,10 @@ string";`,
       )
     ).toMatchSnapshot();
   });
+  it("declare directive", function() {
+    expect(parser.parseEval("declare (strict_types=1);")).toMatchSnapshot();
+  });
+  it("declare directive (multiple)", function() {
+    expect(parser.parseEval("declare (A='B', C='D') { }")).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
- Introduce `DeclareDirective` node ( `key` (is `identifier`)/`value`)
- Rename `what` to `directives` for `Declare` node
- `Declare` can have multiple directive (now it is array).
- Tests