### PR TITLE
fix: location for staticlookup and offsetlookup

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -369,7 +369,7 @@ AST.prototype.prepare = function(kind, docs, parser) {
     }
     AST.stack[++AST.stackUid] = {
       position: start,
-      stack: (new Error()).stack.split("\n").slice(3, 5)
+      stack: new Error().stack.split("\n").slice(3, 5)
     };
     result.stackUid = AST.stackUid;
   }
@@ -410,7 +410,7 @@ AST.prototype.prepare = function(kind, docs, parser) {
         parser._docIndex = parser._docs.length - docs.length;
       }
     }
-    if(parser.debug) {
+    if (parser.debug) {
       delete AST.stack[result.stackUid];
     }
   };
@@ -418,8 +418,8 @@ AST.prototype.prepare = function(kind, docs, parser) {
 };
 
 AST.prototype.checkNodes = function() {
-  let errors = [];
-  for(let k in AST.stack) {
+  const errors = [];
+  for (const k in AST.stack) {
     if (AST.stack.hasOwnProperty(k)) {
       errors.push(AST.stack[k]);
     }

--- a/src/ast.js
+++ b/src/ast.js
@@ -176,14 +176,30 @@ AST.prototype.swapLocations = function(target, first, last, parser) {
     target.loc.start = first.loc.start;
     target.loc.end = last.loc.end;
     if (this.withSource) {
-      const startOffset = target.loc.start.offset;
-      let endOffset = target.loc.end.offset;
+      target.loc.source = parser.lexer._input.substring(
+        target.loc.start.offset,
+        target.loc.end.offset
+      );
+    }
+  }
+};
 
-      if (target.kind === "offsetlookup") {
-        endOffset = endOffset + 1;
-      }
-
-      target.loc.source = parser.lexer._input.substring(startOffset, endOffset);
+/**
+ * Includes locations from first & last into the target
+ */
+AST.prototype.resolveLocations = function(target, first, last, parser) {
+  if (this.withPositions) {
+    if (target.loc.start.offset > first.loc.start.offset) {
+      target.loc.start = first.loc.start;
+    }
+    if (target.loc.end.offset < last.loc.end.offset) {
+      target.loc.end = last.loc.end;
+    }
+    if (this.withSource) {
+      target.loc.source = parser.lexer._input.substring(
+        target.loc.start.offset,
+        target.loc.end.offset
+      );
     }
   }
 };
@@ -196,14 +212,14 @@ AST.prototype.resolvePrecedence = function(result, parser) {
   // handling precendence
   if (result.kind === "call") {
     // including what argument into location
-    this.swapLocations(result, result.what, result, parser);
+    this.resolveLocations(result, result.what, result, parser);
   } else if (
     result.kind === "propertylookup" ||
     result.kind === "staticlookup" ||
     result.kind === "offsetlookup"
   ) {
     // including what argument into location
-    this.swapLocations(result, result.what, result.offset, parser);
+    this.resolveLocations(result, result.what, result.offset, parser);
   } else if (result.kind === "bin") {
     if (result.right && !result.right.parenthesizedExpression) {
       if (result.right.kind === "bin") {

--- a/src/ast.js
+++ b/src/ast.js
@@ -176,10 +176,14 @@ AST.prototype.swapLocations = function(target, first, last, parser) {
     target.loc.start = first.loc.start;
     target.loc.end = last.loc.end;
     if (this.withSource) {
-      target.loc.source = parser.lexer._input.substring(
-        target.loc.start.offset,
-        target.loc.end.offset
-      );
+      const startOffset = target.loc.start.offset;
+      let endOffset = target.loc.end.offset;
+
+      if (target.kind === "offsetlookup") {
+        endOffset = endOffset + 1;
+      }
+
+      target.loc.source = parser.lexer._input.substring(startOffset, endOffset);
     }
   }
 };
@@ -193,7 +197,11 @@ AST.prototype.resolvePrecedence = function(result, parser) {
   if (result.kind === "call") {
     // including what argument into location
     this.swapLocations(result, result.what, result, parser);
-  } else if (result.kind === "propertylookup") {
+  } else if (
+    result.kind === "propertylookup" ||
+    result.kind === "staticlookup" ||
+    result.kind === "offsetlookup"
+  ) {
     // including what argument into location
     this.swapLocations(result, result.what, result.offset, parser);
   } else if (result.kind === "bin") {

--- a/src/ast.js
+++ b/src/ast.js
@@ -304,8 +304,12 @@ AST.prototype.resolvePrecedence = function(result, parser) {
         result = buffer;
       }
     }
-  } else if (result.kind === "silent" && result.expr.right && !result.expr.parenthesizedExpression) {
-    // overall least precedence 
+  } else if (
+    result.kind === "silent" &&
+    result.expr.right &&
+    !result.expr.parenthesizedExpression
+  ) {
+    // overall least precedence
     buffer = result.expr;
     result.expr = buffer.left;
     buffer.left = result;

--- a/src/ast.js
+++ b/src/ast.js
@@ -296,6 +296,13 @@ AST.prototype.resolvePrecedence = function(result, parser) {
         result = buffer;
       }
     }
+  } else if (result.kind === "silent" && result.expr.right && !result.expr.parenthesizedExpression) {
+    // overall least precedence 
+    buffer = result.expr;
+    result.expr = buffer.left;
+    buffer.left = result;
+    this.swapLocations(buffer, buffer.left, buffer.right, parser);
+    result = buffer;
   }
   return result;
 };

--- a/src/ast/classreference.js
+++ b/src/ast/classreference.js
@@ -26,7 +26,7 @@ const ClassReference = Reference.extends(KIND, function ClassReference(
     this.resolution = ClassReference.RELATIVE_NAME;
   } else if (name.length === 1) {
     this.resolution = ClassReference.UNQUALIFIED_NAME;
-  } else if (name[0] === "") {
+  } else if (!name[0]) {
     this.resolution = ClassReference.FULL_QUALIFIED_NAME;
   } else {
     this.resolution = ClassReference.QUALIFIED_NAME;

--- a/src/ast/node.js
+++ b/src/ast/node.js
@@ -32,6 +32,38 @@ Node.prototype.setTrailingComments = function(docs) {
 };
 
 /**
+ * Destroying an unused node
+ */
+Node.prototype.destroy = function(node) {
+  if (!node) {
+    throw new Error(
+      "Node already initialized, you must swap with another node"
+    );
+  }
+  if (this.leadingComments) {
+    if (node.leadingComments) {
+      node.leadingComments = Array.concat(
+        this.leadingComments,
+        node.leadingComments
+      );
+    } else {
+      node.leadingComments = this.leadingComments;
+    }
+  }
+  if (this.trailingComments) {
+    if (node.trailingComments) {
+      node.trailingComments = Array.concat(
+        this.trailingComments,
+        node.trailingComments
+      );
+    } else {
+      node.trailingComments = this.trailingComments;
+    }
+  }
+  return node;
+};
+
+/**
  * Includes current token position of the parser
  * @param {*} parser
  */

--- a/src/parser.js
+++ b/src/parser.js
@@ -416,7 +416,7 @@ parser.prototype.node = function(name) {
           const offset = this.prev[2];
           let max = this._docIndex;
           for (; max < this._docs.length; max++) {
-            if (this._docs[max].loc.start.offset > offset) {
+            if (this._docs[max].offset > offset) {
               break;
             }
           }

--- a/src/parser.js
+++ b/src/parser.js
@@ -300,7 +300,7 @@ parser.prototype.parse = function(code, filename) {
       throw new Error('Some nodes are not closed');
     }
   }
-  return
+  return result;
 };
 
 /**

--- a/src/parser.js
+++ b/src/parser.js
@@ -289,15 +289,22 @@ parser.prototype.parse = function(code, filename) {
     this.lexer.yylloc.last_column,
     this.lexer.offset
   ];
-  let result = program(childs, this._errors, this._docs, this._tokens);
+  const result = program(childs, this._errors, this._docs, this._tokens);
   if (this.debug) {
-    let errors = this.ast.checkNodes();
+    const errors = this.ast.checkNodes();
     if (errors.length > 0) {
       errors.forEach(function(error) {
-        console.log('Node at line ' + error.position.line + ', column ' + error.position.column);
+        // eslint-disable-next-line no-console
+        console.log(
+          "Node at line " +
+            error.position.line +
+            ", column " +
+            error.position.column
+        );
+        // eslint-disable-next-line no-console
         console.log(error.stack.join("\n"));
       });
-      throw new Error('Some nodes are not closed');
+      throw new Error("Some nodes are not closed");
     }
   }
   return result;
@@ -406,16 +413,18 @@ parser.prototype.node = function(name) {
     node.postBuild = function(self) {
       if (this._docIndex < this._docs.length) {
         if (this._lastNode) {
-          let offset = this.prev[2];
-          let max = this._docIndex; 
-          for(;max < this._docs.length; max++) {
+          const offset = this.prev[2];
+          let max = this._docIndex;
+          for (; max < this._docs.length; max++) {
             if (this._docs[max].loc.start.offset > offset) {
               break;
             }
           }
           if (max > this._docIndex) {
             // inject trailing comment on child node
-            this._lastNode.setTrailingComments(this._docs.slice(this._docIndex, max - 1));
+            this._lastNode.setTrailingComments(
+              this._docs.slice(this._docIndex, max)
+            );
             this._docIndex = max;
           }
         } else if (this.token === this.EOF) {

--- a/src/parser/comment.js
+++ b/src/parser/comment.js
@@ -16,6 +16,7 @@ module.exports = {
       null,
       this
     );
+    const offset = this.lexer.yylloc.first_offset;
     // handle location on comment
     const prev = this.prev;
     this.prev = [
@@ -25,6 +26,7 @@ module.exports = {
     ];
     this.lex();
     result = result(text);
+    result.offset = offset;
     this.prev = prev;
     return result;
   },
@@ -33,6 +35,7 @@ module.exports = {
    */
   read_doc_comment: function() {
     let result = this.ast.prepare("commentblock", null, this);
+    const offset = this.lexer.yylloc.first_offset;
     const text = this.text();
     const prev = this.prev;
     this.prev = [
@@ -42,6 +45,7 @@ module.exports = {
     ];
     this.lex();
     result = result(text);
+    result.offset = offset;
     this.prev = prev;
     return result;
   }

--- a/src/parser/namespace.js
+++ b/src/parser/namespace.js
@@ -42,6 +42,7 @@ module.exports = {
         // resolve ambuiguity between namespace & function call
         name.resolution = this.ast.reference.RELATIVE_NAME;
         name.name = name.name.substring(1);
+        result.destroy();
         return this.node("call")(name, this.read_function_argument_list());
       } else {
         this.error(["{", ";"]);

--- a/src/parser/scalar.js
+++ b/src/parser/scalar.js
@@ -206,7 +206,7 @@ module.exports = {
         // check if lookup an offset
         // https://github.com/php/php-src/blob/master/Zend/zend_language_parser.y#L1243
         if (this.token === "[") {
-          name = name(varName, false);
+          name = name(varName, false, false);
           node = this.node("offsetlookup");
           offset = this.next().read_expr();
           this.expect("]") && this.next();

--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -359,6 +359,7 @@ module.exports = {
         }
 
         // default fallback expr / T_STRING '::' (etc...)
+        result.destroy();
         this.lexer.tokens.push(current);
         const statement = this.node("expressionstatement");
         const expr = this.next().read_expr();

--- a/src/parser/variable.js
+++ b/src/parser/variable.js
@@ -51,11 +51,9 @@ module.exports = {
         // @see parser.js line 130 : resolves a conflict with scalar
         const literal = name.name.toLowerCase();
         if (literal === "true") {
-          name.destroy();
-          result = result("boolean", true, name.name);
+          result = name.destroy(result("boolean", true, name.name));
         } else if (literal === "false") {
-          name.destroy();
-          result = result("boolean", false, name.name);
+          result = name.destroy(result("boolean", false, name.name));
         } else {
           // @todo null keyword ?
           result = result("identifier", name);

--- a/src/parser/variable.js
+++ b/src/parser/variable.js
@@ -51,8 +51,10 @@ module.exports = {
         // @see parser.js line 130 : resolves a conflict with scalar
         const literal = name.name.toLowerCase();
         if (literal === "true") {
+          name.destroy();
           result = result("boolean", true, name.name);
         } else if (literal === "false") {
+          name.destroy();
           result = result("boolean", false, name.name);
         } else {
           // @todo null keyword ?
@@ -60,6 +62,7 @@ module.exports = {
         }
       } else {
         // @fixme possible #193 bug
+        result.destroy(name);
         result = name;
       }
     } else if (this.token === this.tok.T_STATIC) {

--- a/src/parser/variable.js
+++ b/src/parser/variable.js
@@ -96,8 +96,10 @@ module.exports = {
       this.next();
       offset = offset(name);
     } else if (this.token === "{") {
-      offset = this.next().read_expr();
+      offset = this.node("literal");
+      name = this.next().read_expr();
       this.expect("}") && this.next();
+      offset = offset("literal", name, null);
       this.expect("(");
     } else {
       this.error([this.tok.T_VARIABLE, this.tok.T_STRING]);
@@ -152,22 +154,24 @@ module.exports = {
         what = what(name, false, false);
         break;
       case "$":
-        what = this.node("variable");
+        what = this.node();
         this.next().expect(["$", "{", this.tok.T_VARIABLE]);
         if (this.token === "{") {
           // $obj->${$varname}
           name = this.next().read_expr();
           this.expect("}") && this.next();
-          what = what(name, false, true);
+          what = what("literal", "literal", name, null);
         } else {
           // $obj->$$varname
           name = this.read_expr();
-          what = what(name, false, false);
+          what = what("variable", name, false, false);
         }
         break;
       case "{":
-        what = this.next().read_expr();
+        what = this.node("literal");
+        name = this.next().read_expr();
         this.expect("}") && this.next();
+        what = what("literal", name, null);
         break;
       default:
         this.error([this.tok.T_STRING, this.tok.T_VARIABLE, "$", "{"]);
@@ -302,6 +306,7 @@ module.exports = {
         result = node("offsetlookup", result, offset);
       } else */
       if (this.token == "{" && !encapsed) {
+        // @fixme check coverage, not sure thats working
         offset = this.next().read_expr();
         this.expect("}") && this.next();
         result = node("offsetlookup", result, offset);
@@ -339,7 +344,8 @@ module.exports = {
           break;
         }
         case "$": // $$$var
-          result = result(this.read_simple_variable(false), byref);
+          // @fixme check coverage here
+          result = result(this.read_simple_variable(false), byref, false);
           break;
         case this.tok.T_VARIABLE: {
           // $$var

--- a/src/parser/variable.js
+++ b/src/parser/variable.js
@@ -152,14 +152,17 @@ module.exports = {
         what = what(name, false, false);
         break;
       case "$":
+        what = this.node("variable");
         this.next().expect(["$", "{", this.tok.T_VARIABLE]);
         if (this.token === "{") {
           // $obj->${$varname}
-          what = this.next().read_expr();
+          name = this.next().read_expr();
           this.expect("}") && this.next();
+          what = what(name, false, true);
         } else {
           // $obj->$$varname
-          what = this.read_expr();
+          name = this.read_expr();
+          what = what(name, false, false);
         }
         break;
       case "{":

--- a/test/debug.js
+++ b/test/debug.js
@@ -17,7 +17,7 @@
 const util = require('util');
 const parser = require("../src/index");
 const ast = parser.parseEval(`
-$this->{foo};
+$obj = new \\Foo();
 `, { 
     parser: {
       debug: true,

--- a/test/debug.js
+++ b/test/debug.js
@@ -17,11 +17,7 @@
 const util = require('util');
 const parser = require("../src/index");
 const ast = parser.parseEval(`
-// leading
-foo();
-// bar
-bar() /* inner */ ;
-// trailing
+get_class($var)::$$property;
 `, { 
     parser: {
       debug: true,

--- a/test/debug.js
+++ b/test/debug.js
@@ -17,7 +17,7 @@
 const util = require('util');
 const parser = require("../src/index");
 const ast = parser.parseEval(`
-get_class($var)::$$property;
+$this->{foo};
 `, { 
     parser: {
       debug: true,

--- a/test/debug.js
+++ b/test/debug.js
@@ -17,7 +17,7 @@
 const util = require('util');
 const parser = require("../src/index");
 const ast = parser.parseEval(`
-@foo() || bar();
+$var[ 'foo' ];
 `, { 
     parser: {
       debug: true,

--- a/test/debug.js
+++ b/test/debug.js
@@ -16,9 +16,16 @@
  */
 const util = require('util');
 const parser = require("../src/index");
-const ast = parser.parseEval(`$var1 + $var2 + $var3;`, { 
+const ast = parser.parseEval(`
+// leading
+foo();
+// bar
+bar() /* inner */ ;
+// trailing
+`, { 
     parser: {
-      debug: true
+      debug: true,
+      extractDoc: true
     },
     ast: {
       withPositions: true,

--- a/test/debug.js
+++ b/test/debug.js
@@ -17,7 +17,7 @@
 const util = require('util');
 const parser = require("../src/index");
 const ast = parser.parseEval(`
-$obj = new \\Foo();
+@foo() || bar();
 `, { 
     parser: {
       debug: true,

--- a/test/precedence.test.js
+++ b/test/precedence.test.js
@@ -122,6 +122,12 @@ describe("Test precedence", function() {
   it("test static lookup offsets", function() {
     shouldBeSame("(Foo::$bar)['baz']();", "Foo::$bar['baz']();");
   });
+  it("test silent node / bin", function() {
+    shouldBeSame("@foo() || @foo();", "(@foo()) || (@foo());");
+  });
+  it("test silent node / div", function() {
+    shouldBeSame("@$i / 0;", "@($i) / 0;");
+  });
   it("test cast", function() {
     shouldBeSame("$a = (string)$b . $c", "$a = ((string)$b) . $c");
     shouldBeSame("$a = (string)$b->foo . $c", "$a = ((string)$b->foo) . $c");

--- a/test/snapshot/__snapshots__/acid.test.js.snap
+++ b/test/snapshot/__snapshots__/acid.test.js.snap
@@ -201,25 +201,6 @@ Program {
           "offset": 68,
         },
       },
-      "trailingComments": Array [
-        CommentBlock {
-          "kind": "commentblock",
-          "loc": Location {
-            "end": Position {
-              "column": 46,
-              "line": 7,
-              "offset": 139,
-            },
-            "source": "/** a comment before the namespace comment **/",
-            "start": Position {
-              "column": 0,
-              "line": 7,
-              "offset": 93,
-            },
-          },
-          "value": "/** a comment before the namespace comment **/",
-        },
-      ],
     },
     Namespace {
       "children": Array [
@@ -239,27 +220,6 @@ Program {
             },
           },
           "raw": "Hello",
-          "trailingComments": Array [
-            CommentLine {
-              "kind": "commentline",
-              "loc": Location {
-                "end": Position {
-                  "column": 0,
-                  "line": 11,
-                  "offset": 199,
-                },
-                "source": "# single line comment
-",
-                "start": Position {
-                  "column": 2,
-                  "line": 10,
-                  "offset": 177,
-                },
-              },
-              "value": "# single line comment
-",
-            },
-          ],
           "value": "Hello",
         },
         UseGroup {
@@ -284,6 +244,7 @@ Program {
                       "offset": 224,
                     },
                   },
+                  "offset": 224,
                   "value": "// sample code
 ",
                 },
@@ -324,6 +285,7 @@ Program {
                       "offset": 252,
                     },
                   },
+                  "offset": 252,
                   "value": "// with alias
 ",
                 },
@@ -346,6 +308,28 @@ Program {
             },
           ],
           "kind": "usegroup",
+          "leadingComments": Array [
+            CommentLine {
+              "kind": "commentline",
+              "loc": Location {
+                "end": Position {
+                  "column": 0,
+                  "line": 11,
+                  "offset": 199,
+                },
+                "source": "# single line comment
+",
+                "start": Position {
+                  "column": 2,
+                  "line": 10,
+                  "offset": 177,
+                },
+              },
+              "offset": 177,
+              "value": "# single line comment
+",
+            },
+          ],
           "loc": Location {
             "end": Position {
               "column": 3,
@@ -464,6 +448,7 @@ Program {
                   "offset": 312,
                 },
               },
+              "offset": 312,
               "value": "// generic constant
 ",
             },
@@ -481,29 +466,6 @@ Program {
               "offset": 334,
             },
           },
-          "trailingComments": Array [
-            CommentBlock {
-              "kind": "commentblock",
-              "loc": Location {
-                "end": Position {
-                  "column": 5,
-                  "line": 24,
-                  "offset": 387,
-                },
-                "source": "/**
-   * a class
-   */",
-                "start": Position {
-                  "column": 2,
-                  "line": 22,
-                  "offset": 365,
-                },
-              },
-              "value": "/**
-   * a class
-   */",
-            },
-          ],
         },
         Class {
           "body": Array [
@@ -1229,6 +1191,7 @@ Program {
                             "offset": 744,
                           },
                         },
+                        "offset": 744,
                         "value": "// do not wanna do
 ",
                       },
@@ -1440,6 +1403,7 @@ Program {
                       "offset": 654,
                     },
                   },
+                  "offset": 654,
                   "value": "/**
      * Something is done here
      */",
@@ -1505,6 +1469,30 @@ Program {
           "isAnonymous": false,
           "isFinal": false,
           "kind": "class",
+          "leadingComments": Array [
+            CommentBlock {
+              "kind": "commentblock",
+              "loc": Location {
+                "end": Position {
+                  "column": 5,
+                  "line": 24,
+                  "offset": 387,
+                },
+                "source": "/**
+   * a class
+   */",
+                "start": Position {
+                  "column": 2,
+                  "line": 22,
+                  "offset": 365,
+                },
+              },
+              "offset": 365,
+              "value": "/**
+   * a class
+   */",
+            },
+          ],
           "loc": Location {
             "end": Position {
               "column": 3,
@@ -2838,27 +2826,6 @@ Program {
             },
             "name": "Line",
           },
-          "trailingComments": Array [
-            CommentLine {
-              "kind": "commentline",
-              "loc": Location {
-                "end": Position {
-                  "column": 0,
-                  "line": 79,
-                  "offset": 1591,
-                },
-                "source": "// this is SPARTA !
-",
-                "start": Position {
-                  "column": 2,
-                  "line": 78,
-                  "offset": 1571,
-                },
-              },
-              "value": "// this is SPARTA !
-",
-            },
-          ],
         },
         _Function {
           "arguments": Array [],
@@ -3792,6 +3759,28 @@ next:
           },
           "byref": false,
           "kind": "function",
+          "leadingComments": Array [
+            CommentLine {
+              "kind": "commentline",
+              "loc": Location {
+                "end": Position {
+                  "column": 0,
+                  "line": 79,
+                  "offset": 1591,
+                },
+                "source": "// this is SPARTA !
+",
+                "start": Position {
+                  "column": 2,
+                  "line": 78,
+                  "offset": 1571,
+                },
+              },
+              "offset": 1571,
+              "value": "// this is SPARTA !
+",
+            },
+          ],
           "loc": Location {
             "end": Position {
               "column": 3,
@@ -4427,27 +4416,6 @@ next:
                                   "offset": 2679,
                                 },
                               },
-                              "trailingComments": Array [
-                                CommentLine {
-                                  "kind": "commentline",
-                                  "loc": Location {
-                                    "end": Position {
-                                      "column": 0,
-                                      "line": 128,
-                                      "offset": 2803,
-                                    },
-                                    "source": "// @todo $this->a_$foo
-",
-                                    "start": Position {
-                                      "column": 6,
-                                      "line": 127,
-                                      "offset": 2780,
-                                    },
-                                  },
-                                  "value": "// @todo $this->a_$foo
-",
-                                },
-                              ],
                             },
                             "increment": Array [
                               Post {
@@ -4761,6 +4729,28 @@ next:
                               "type": "??",
                             },
                             "kind": "return",
+                            "leadingComments": Array [
+                              CommentLine {
+                                "kind": "commentline",
+                                "loc": Location {
+                                  "end": Position {
+                                    "column": 0,
+                                    "line": 128,
+                                    "offset": 2803,
+                                  },
+                                  "source": "// @todo $this->a_$foo
+",
+                                  "start": Position {
+                                    "column": 6,
+                                    "line": 127,
+                                    "offset": 2780,
+                                  },
+                                },
+                                "offset": 2780,
+                                "value": "// @todo $this->a_$foo
+",
+                              },
+                            ],
                             "loc": Location {
                               "end": Position {
                                 "column": 28,
@@ -6871,27 +6861,6 @@ next:
             },
             "name": "foo",
           },
-          "trailingComments": Array [
-            CommentLine {
-              "kind": "commentline",
-              "loc": Location {
-                "end": Position {
-                  "column": 0,
-                  "line": 140,
-                  "offset": 2977,
-                },
-                "source": "// list version
-",
-                "start": Position {
-                  "column": 2,
-                  "line": 139,
-                  "offset": 2961,
-                },
-              },
-              "value": "// list version
-",
-            },
-          ],
         },
         ExpressionStatement {
           "expression": Assign {
@@ -7097,6 +7066,28 @@ next:
             },
           },
           "kind": "expressionstatement",
+          "leadingComments": Array [
+            CommentLine {
+              "kind": "commentline",
+              "loc": Location {
+                "end": Position {
+                  "column": 0,
+                  "line": 140,
+                  "offset": 2977,
+                },
+                "source": "// list version
+",
+                "start": Position {
+                  "column": 2,
+                  "line": 139,
+                  "offset": 2961,
+                },
+              },
+              "offset": 2961,
+              "value": "// list version
+",
+            },
+          ],
           "loc": Location {
             "end": Position {
               "column": 40,
@@ -7586,6 +7577,26 @@ FOO
         },
       ],
       "kind": "namespace",
+      "leadingComments": Array [
+        CommentBlock {
+          "kind": "commentblock",
+          "loc": Location {
+            "end": Position {
+              "column": 46,
+              "line": 7,
+              "offset": 139,
+            },
+            "source": "/** a comment before the namespace comment **/",
+            "start": Position {
+              "column": 0,
+              "line": 7,
+              "offset": 93,
+            },
+          },
+          "offset": 93,
+          "value": "/** a comment before the namespace comment **/",
+        },
+      ],
       "loc": Location {
         "end": Position {
           "column": 1,
@@ -7785,6 +7796,7 @@ THE END ...
           "offset": 93,
         },
       },
+      "offset": 93,
       "value": "/** a comment before the namespace comment **/",
     },
     CommentLine {
@@ -7803,6 +7815,7 @@ THE END ...
           "offset": 177,
         },
       },
+      "offset": 177,
       "value": "# single line comment
 ",
     },
@@ -7822,6 +7835,7 @@ THE END ...
           "offset": 224,
         },
       },
+      "offset": 224,
       "value": "// sample code
 ",
     },
@@ -7841,6 +7855,7 @@ THE END ...
           "offset": 252,
         },
       },
+      "offset": 252,
       "value": "// with alias
 ",
     },
@@ -7860,6 +7875,7 @@ THE END ...
           "offset": 312,
         },
       },
+      "offset": 312,
       "value": "// generic constant
 ",
     },
@@ -7880,6 +7896,7 @@ THE END ...
           "offset": 365,
         },
       },
+      "offset": 365,
       "value": "/**
    * a class
    */",
@@ -7901,6 +7918,7 @@ THE END ...
           "offset": 654,
         },
       },
+      "offset": 654,
       "value": "/**
      * Something is done here
      */",
@@ -7921,6 +7939,7 @@ THE END ...
           "offset": 744,
         },
       },
+      "offset": 744,
       "value": "// do not wanna do
 ",
     },
@@ -7940,6 +7959,7 @@ THE END ...
           "offset": 1571,
         },
       },
+      "offset": 1571,
       "value": "// this is SPARTA !
 ",
     },
@@ -7959,6 +7979,7 @@ THE END ...
           "offset": 2780,
         },
       },
+      "offset": 2780,
       "value": "// @todo $this->a_$foo
 ",
     },
@@ -7978,6 +7999,7 @@ THE END ...
           "offset": 2961,
         },
       },
+      "offset": 2961,
       "value": "// list version
 ",
     },

--- a/test/snapshot/__snapshots__/acid.test.js.snap
+++ b/test/snapshot/__snapshots__/acid.test.js.snap
@@ -3011,9 +3011,9 @@ Program {
                     "kind": "offsetlookup",
                     "loc": Location {
                       "end": Position {
-                        "column": 29,
+                        "column": 30,
                         "line": 84,
-                        "offset": 1695,
+                        "offset": 1696,
                       },
                       "source": "$persians[++$index]",
                       "start": Position {
@@ -4259,9 +4259,9 @@ next:
                                         "kind": "offsetlookup",
                                         "loc": Location {
                                           "end": Position {
-                                            "column": 30,
+                                            "column": 31,
                                             "line": 125,
-                                            "offset": 2746,
+                                            "offset": 2747,
                                           },
                                           "source": "$this->$x[++$i]",
                                           "start": Position {

--- a/test/snapshot/__snapshots__/acid.test.js.snap
+++ b/test/snapshot/__snapshots__/acid.test.js.snap
@@ -1353,7 +1353,7 @@ Program {
                           },
                         },
                         "name": "\\\\ComeToHome",
-                        "resolution": "qn",
+                        "resolution": "fqn",
                       },
                     },
                   },

--- a/test/snapshot/__snapshots__/acid.test.js.snap
+++ b/test/snapshot/__snapshots__/acid.test.js.snap
@@ -3011,15 +3011,15 @@ Program {
                     "kind": "offsetlookup",
                     "loc": Location {
                       "end": Position {
-                        "column": 30,
+                        "column": 29,
                         "line": 84,
-                        "offset": 1696,
+                        "offset": 1695,
                       },
-                      "source": "[++$index]",
+                      "source": "$persians[++$index]",
                       "start": Position {
-                        "column": 20,
+                        "column": 11,
                         "line": 84,
-                        "offset": 1686,
+                        "offset": 1677,
                       },
                     },
                     "offset": Pre {
@@ -4259,15 +4259,15 @@ next:
                                         "kind": "offsetlookup",
                                         "loc": Location {
                                           "end": Position {
-                                            "column": 31,
+                                            "column": 30,
                                             "line": 125,
-                                            "offset": 2747,
+                                            "offset": 2746,
                                           },
-                                          "source": "[++$i]",
+                                          "source": "$this->$x[++$i]",
                                           "start": Position {
-                                            "column": 25,
+                                            "column": 16,
                                             "line": 125,
-                                            "offset": 2741,
+                                            "offset": 2732,
                                           },
                                         },
                                         "offset": Pre {
@@ -6321,11 +6321,11 @@ next:
                             "line": 97,
                             "offset": 1982,
                           },
-                          "source": "::NUMBAR",
+                          "source": "fooBar::NUMBAR",
                           "start": Position {
-                            "column": 20,
+                            "column": 14,
                             "line": 97,
-                            "offset": 1974,
+                            "offset": 1968,
                           },
                         },
                         "offset": Identifier {

--- a/test/snapshot/__snapshots__/call.test.js.snap
+++ b/test/snapshot/__snapshots__/call.test.js.snap
@@ -340,11 +340,9 @@ Program {
     ExpressionStatement {
       "expression": StaticLookup {
         "kind": "staticlookup",
-        "offset": Variable {
-          "byref": false,
-          "curly": true,
-          "kind": "variable",
-          "name": Variable {
+        "offset": Literal {
+          "kind": "literal",
+          "value": Variable {
             "byref": false,
             "curly": false,
             "kind": "variable",
@@ -382,11 +380,9 @@ Program {
     ExpressionStatement {
       "expression": StaticLookup {
         "kind": "staticlookup",
-        "offset": Variable {
-          "byref": false,
-          "curly": true,
-          "kind": "variable",
-          "name": Variable {
+        "offset": Literal {
+          "kind": "literal",
+          "value": Variable {
             "byref": false,
             "curly": false,
             "kind": "variable",
@@ -395,11 +391,9 @@ Program {
         },
         "what": StaticLookup {
           "kind": "staticlookup",
-          "offset": Variable {
-            "byref": false,
-            "curly": true,
-            "kind": "variable",
-            "name": Variable {
+          "offset": Literal {
+            "kind": "literal",
+            "value": Variable {
               "byref": false,
               "curly": false,
               "kind": "variable",
@@ -408,11 +402,9 @@ Program {
           },
           "what": StaticLookup {
             "kind": "staticlookup",
-            "offset": Variable {
-              "byref": false,
-              "curly": true,
-              "kind": "variable",
-              "name": Variable {
+            "offset": Literal {
+              "kind": "literal",
+              "value": Variable {
                 "byref": false,
                 "curly": false,
                 "kind": "variable",
@@ -452,11 +444,9 @@ Program {
     ExpressionStatement {
       "expression": StaticLookup {
         "kind": "staticlookup",
-        "offset": Variable {
-          "byref": false,
-          "curly": true,
-          "kind": "variable",
-          "name": String {
+        "offset": Literal {
+          "kind": "literal",
+          "value": String {
             "isDoubleQuote": true,
             "kind": "string",
             "raw": "\\"property\\"",
@@ -495,11 +485,9 @@ Program {
     ExpressionStatement {
       "expression": StaticLookup {
         "kind": "staticlookup",
-        "offset": Variable {
-          "byref": false,
-          "curly": true,
-          "kind": "variable",
-          "name": Variable {
+        "offset": Literal {
+          "kind": "literal",
+          "value": Variable {
             "byref": false,
             "curly": false,
             "kind": "variable",
@@ -572,13 +560,16 @@ Program {
         "kind": "call",
         "what": StaticLookup {
           "kind": "staticlookup",
-          "offset": Call {
-            "arguments": Array [],
-            "kind": "call",
-            "what": ClassReference {
-              "kind": "classreference",
-              "name": "call",
-              "resolution": "uqn",
+          "offset": Literal {
+            "kind": "literal",
+            "value": Call {
+              "arguments": Array [],
+              "kind": "call",
+              "what": ClassReference {
+                "kind": "classreference",
+                "name": "call",
+                "resolution": "uqn",
+              },
             },
           },
           "what": ClassReference {

--- a/test/snapshot/__snapshots__/call.test.js.snap
+++ b/test/snapshot/__snapshots__/call.test.js.snap
@@ -342,9 +342,14 @@ Program {
         "kind": "staticlookup",
         "offset": Variable {
           "byref": false,
-          "curly": false,
+          "curly": true,
           "kind": "variable",
-          "name": "property",
+          "name": Variable {
+            "byref": false,
+            "curly": false,
+            "kind": "variable",
+            "name": "property",
+          },
         },
         "what": Call {
           "arguments": Array [
@@ -379,25 +384,40 @@ Program {
         "kind": "staticlookup",
         "offset": Variable {
           "byref": false,
-          "curly": false,
+          "curly": true,
           "kind": "variable",
-          "name": "property",
-        },
-        "what": StaticLookup {
-          "kind": "staticlookup",
-          "offset": Variable {
+          "name": Variable {
             "byref": false,
             "curly": false,
             "kind": "variable",
             "name": "property",
           },
-          "what": StaticLookup {
-            "kind": "staticlookup",
-            "offset": Variable {
+        },
+        "what": StaticLookup {
+          "kind": "staticlookup",
+          "offset": Variable {
+            "byref": false,
+            "curly": true,
+            "kind": "variable",
+            "name": Variable {
               "byref": false,
               "curly": false,
               "kind": "variable",
               "name": "property",
+            },
+          },
+          "what": StaticLookup {
+            "kind": "staticlookup",
+            "offset": Variable {
+              "byref": false,
+              "curly": true,
+              "kind": "variable",
+              "name": Variable {
+                "byref": false,
+                "curly": false,
+                "kind": "variable",
+                "name": "property",
+              },
             },
             "what": Call {
               "arguments": Array [
@@ -432,12 +452,17 @@ Program {
     ExpressionStatement {
       "expression": StaticLookup {
         "kind": "staticlookup",
-        "offset": String {
-          "isDoubleQuote": true,
-          "kind": "string",
-          "raw": "\\"property\\"",
-          "unicode": false,
-          "value": "property",
+        "offset": Variable {
+          "byref": false,
+          "curly": true,
+          "kind": "variable",
+          "name": String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "raw": "\\"property\\"",
+            "unicode": false,
+            "value": "property",
+          },
         },
         "what": Call {
           "arguments": Array [
@@ -472,9 +497,14 @@ Program {
         "kind": "staticlookup",
         "offset": Variable {
           "byref": false,
-          "curly": false,
+          "curly": true,
           "kind": "variable",
-          "name": "property",
+          "name": Variable {
+            "byref": false,
+            "curly": false,
+            "kind": "variable",
+            "name": "property",
+          },
         },
         "what": Call {
           "arguments": Array [

--- a/test/snapshot/__snapshots__/class.test.js.snap
+++ b/test/snapshot/__snapshots__/class.test.js.snap
@@ -27,24 +27,6 @@ Program {
             },
           ],
           "kind": "traituse",
-          "trailingComments": Array [
-            CommentLine {
-              "kind": "commentline",
-              "value": "// comment
-",
-            },
-            CommentBlock {
-              "kind": "commentblock",
-              "value": "/* boo */",
-            },
-            CommentBlock {
-              "kind": "commentblock",
-              "value": "/** doc
-         * data
-           foo
-         */",
-            },
-          ],
           "traits": Array [
             ClassReference {
               "kind": "classreference",
@@ -58,6 +40,27 @@ Program {
           "isFinal": false,
           "isStatic": false,
           "kind": "property",
+          "leadingComments": Array [
+            CommentLine {
+              "kind": "commentline",
+              "offset": 87,
+              "value": "// comment
+",
+            },
+            CommentBlock {
+              "kind": "commentblock",
+              "offset": 106,
+              "value": "/* boo */",
+            },
+            CommentBlock {
+              "kind": "commentblock",
+              "offset": 124,
+              "value": "/** doc
+         * data
+           foo
+         */",
+            },
+          ],
           "name": "var",
           "value": Boolean {
             "kind": "boolean",
@@ -139,6 +142,7 @@ Program {
           "leadingComments": Array [
             CommentLine {
               "kind": "commentline",
+              "offset": 332,
               "value": "// some doc
 ",
             },
@@ -156,6 +160,7 @@ Program {
           "leadingComments": Array [
             CommentBlock {
               "kind": "commentblock",
+              "offset": 375,
               "value": "/** foo */",
             },
           ],
@@ -198,6 +203,7 @@ Program {
           "leadingComments": Array [
             CommentLine {
               "kind": "commentline",
+              "offset": 455,
               "value": "// some doc
 ",
             },
@@ -231,15 +237,18 @@ Program {
   "comments": Array [
     CommentLine {
       "kind": "commentline",
+      "offset": 87,
       "value": "// comment
 ",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 106,
       "value": "/* boo */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 124,
       "value": "/** doc
          * data
            foo
@@ -247,15 +256,18 @@ Program {
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 332,
       "value": "// some doc
 ",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 375,
       "value": "/** foo */",
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 455,
       "value": "// some doc
 ",
     },

--- a/test/snapshot/__snapshots__/comment.test.js.snap
+++ b/test/snapshot/__snapshots__/comment.test.js.snap
@@ -1373,7 +1373,7 @@ Program {
                 },
               ],
               "name": "\\\\Exception",
-              "resolution": "qn",
+              "resolution": "fqn",
             },
             ClassReference {
               "kind": "classreference",
@@ -1390,7 +1390,7 @@ Program {
                 },
               ],
               "name": "\\\\Foo",
-              "resolution": "qn",
+              "resolution": "fqn",
             },
           ],
         },

--- a/test/snapshot/__snapshots__/comment.test.js.snap
+++ b/test/snapshot/__snapshots__/comment.test.js.snap
@@ -15,6 +15,7 @@ Program {
               "leadingComments": Array [
                 CommentLine {
                   "kind": "commentline",
+                  "offset": 51,
                   "value": "// inner statements
 ",
                 },
@@ -27,16 +28,17 @@ Program {
               "raw": "true",
               "value": true,
             },
-            "trailingComments": Array [
-              CommentLine {
-                "kind": "commentline",
-                "value": "// another comment
-",
-              },
-            ],
           },
         ],
         "kind": "block",
+        "trailingComments": Array [
+          CommentLine {
+            "kind": "commentline",
+            "offset": 88,
+            "value": "// another comment
+",
+          },
+        ],
       },
       "kind": "if",
       "shortForm": true,
@@ -48,6 +50,7 @@ Program {
       "trailingComments": Array [
         CommentLine {
           "kind": "commentline",
+          "offset": 122,
           "value": "// 2nd comment
 ",
         },
@@ -57,16 +60,19 @@ Program {
   "comments": Array [
     CommentLine {
       "kind": "commentline",
+      "offset": 51,
       "value": "// inner statements
 ",
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 88,
       "value": "// another comment
 ",
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 122,
       "value": "// 2nd comment
 ",
     },
@@ -96,19 +102,21 @@ Program {
                 "operator": "=",
                 "right": Number {
                   "kind": "number",
-                  "trailingComments": Array [
-                    CommentBlock {
-                      "kind": "commentblock",
-                      "value": "/* trailing 2 */",
-                    },
-                  ],
                   "value": "2",
                 },
+                "trailingComments": Array [
+                  CommentBlock {
+                    "kind": "commentblock",
+                    "offset": 119,
+                    "value": "/* trailing 2 */",
+                  },
+                ],
               },
               "kind": "expressionstatement",
               "trailingComments": Array [
                 CommentLine {
                   "kind": "commentline",
+                  "offset": 148,
                   "value": "// trailing assing
 ",
                 },
@@ -116,15 +124,16 @@ Program {
             },
           ],
           "kind": "block",
-          "trailingComments": Array [
-            CommentLine {
-              "kind": "commentline",
-              "value": "// trailing elseif
-",
-            },
-          ],
         },
         "kind": "if",
+        "leadingComments": Array [
+          CommentLine {
+            "kind": "commentline",
+            "offset": 57,
+            "value": "// Don't parsed :(
+",
+          },
+        ],
         "shortForm": false,
         "test": Boolean {
           "kind": "boolean",
@@ -153,13 +162,6 @@ Program {
           },
         ],
         "kind": "block",
-        "trailingComments": Array [
-          CommentLine {
-            "kind": "commentline",
-            "value": "// Don't parsed :(
-",
-          },
-        ],
       },
       "kind": "if",
       "shortForm": false,
@@ -168,25 +170,37 @@ Program {
         "raw": "true",
         "value": true,
       },
+      "trailingComments": Array [
+        CommentLine {
+          "kind": "commentline",
+          "offset": 185,
+          "value": "// trailing elseif
+",
+        },
+      ],
     },
   ],
   "comments": Array [
     CommentLine {
       "kind": "commentline",
+      "offset": 57,
       "value": "// Don't parsed :(
 ",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 119,
       "value": "/* trailing 2 */",
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 148,
       "value": "// trailing assing
 ",
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 185,
       "value": "// trailing elseif
 ",
     },
@@ -211,19 +225,20 @@ Program {
         "operator": "=",
         "right": Bin {
           "kind": "bin",
+          "leadingComments": Array [
+            CommentLine {
+              "kind": "commentline",
+              "offset": 30,
+              "value": "// Comment 1
+",
+            },
+          ],
           "left": Bin {
             "kind": "bin",
             "left": String {
               "isDoubleQuote": false,
               "kind": "string",
               "raw": "'string1'",
-              "trailingComments": Array [
-                CommentLine {
-                  "kind": "commentline",
-                  "value": "// Comment 1
-",
-                },
-              ],
               "unicode": false,
               "value": "string1",
             },
@@ -231,18 +246,6 @@ Program {
               "isDoubleQuote": false,
               "kind": "string",
               "raw": "'string2'",
-              "trailingComments": Array [
-                CommentLine {
-                  "kind": "commentline",
-                  "value": "// Comment 2
-",
-                },
-                CommentLine {
-                  "kind": "commentline",
-                  "value": "// Comment 3
-",
-                },
-              ],
               "unicode": false,
               "value": "string2",
             },
@@ -251,6 +254,20 @@ Program {
           "right": String {
             "isDoubleQuote": false,
             "kind": "string",
+            "leadingComments": Array [
+              CommentLine {
+                "kind": "commentline",
+                "offset": 61,
+                "value": "// Comment 2
+",
+              },
+              CommentLine {
+                "kind": "commentline",
+                "offset": 80,
+                "value": "// Comment 3
+",
+              },
+            ],
             "raw": "'string3'",
             "unicode": false,
             "value": "string3",
@@ -264,16 +281,19 @@ Program {
   "comments": Array [
     CommentLine {
       "kind": "commentline",
+      "offset": 30,
       "value": "// Comment 1
 ",
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 61,
       "value": "// Comment 2
 ",
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 80,
       "value": "// Comment 3
 ",
     },
@@ -301,11 +321,20 @@ Program {
           "kind": "call",
           "what": PropertyLookup {
             "kind": "propertylookup",
+            "leadingComments": Array [
+              CommentLine {
+                "kind": "commentline",
+                "offset": 29,
+                "value": "// Comment Before
+",
+              },
+            ],
             "offset": Identifier {
               "kind": "identifier",
               "leadingComments": Array [
                 CommentLine {
                   "kind": "commentline",
+                  "offset": 70,
                   "value": "// Comment After
 ",
                 },
@@ -317,13 +346,6 @@ Program {
               "curly": false,
               "kind": "variable",
               "name": "var",
-              "trailingComments": Array [
-                CommentLine {
-                  "kind": "commentline",
-                  "value": "// Comment Before
-",
-                },
-              ],
             },
           },
         },
@@ -334,17 +356,315 @@ Program {
   "comments": Array [
     CommentLine {
       "kind": "commentline",
+      "offset": 29,
       "value": "// Comment Before
 ",
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 70,
       "value": "// Comment After
 ",
     },
   ],
   "errors": Array [],
   "kind": "program",
+}
+`;
+
+exports[`Test comments issues fix #250 : Leading comments are treated as trailing comments 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Call {
+        "arguments": Array [],
+        "kind": "call",
+        "loc": Location {
+          "end": Position {
+            "column": 6,
+            "line": 3,
+            "offset": 18,
+          },
+          "source": "foo();",
+          "start": Position {
+            "column": 0,
+            "line": 3,
+            "offset": 12,
+          },
+        },
+        "what": ClassReference {
+          "kind": "classreference",
+          "loc": Location {
+            "end": Position {
+              "column": 3,
+              "line": 3,
+              "offset": 15,
+            },
+            "source": "foo",
+            "start": Position {
+              "column": 0,
+              "line": 3,
+              "offset": 12,
+            },
+          },
+          "name": "foo",
+          "resolution": "uqn",
+        },
+      },
+      "kind": "expressionstatement",
+      "leadingComments": Array [
+        CommentLine {
+          "kind": "commentline",
+          "loc": Location {
+            "end": Position {
+              "column": 0,
+              "line": 3,
+              "offset": 12,
+            },
+            "source": "// leading
+",
+            "start": Position {
+              "column": 0,
+              "line": 2,
+              "offset": 1,
+            },
+          },
+          "offset": 1,
+          "value": "// leading
+",
+        },
+      ],
+      "loc": Location {
+        "end": Position {
+          "column": 6,
+          "line": 3,
+          "offset": 18,
+        },
+        "source": "();",
+        "start": Position {
+          "column": 3,
+          "line": 3,
+          "offset": 15,
+        },
+      },
+    },
+    ExpressionStatement {
+      "expression": Call {
+        "arguments": Array [],
+        "kind": "call",
+        "loc": Location {
+          "end": Position {
+            "column": 19,
+            "line": 5,
+            "offset": 45,
+          },
+          "source": "bar() /* inner */ ;",
+          "start": Position {
+            "column": 0,
+            "line": 5,
+            "offset": 26,
+          },
+        },
+        "trailingComments": Array [
+          CommentBlock {
+            "kind": "commentblock",
+            "loc": Location {
+              "end": Position {
+                "column": 17,
+                "line": 5,
+                "offset": 43,
+              },
+              "source": "/* inner */",
+              "start": Position {
+                "column": 6,
+                "line": 5,
+                "offset": 32,
+              },
+            },
+            "offset": 32,
+            "value": "/* inner */",
+          },
+        ],
+        "what": ClassReference {
+          "kind": "classreference",
+          "loc": Location {
+            "end": Position {
+              "column": 3,
+              "line": 5,
+              "offset": 29,
+            },
+            "source": "bar",
+            "start": Position {
+              "column": 0,
+              "line": 5,
+              "offset": 26,
+            },
+          },
+          "name": "bar",
+          "resolution": "uqn",
+        },
+      },
+      "kind": "expressionstatement",
+      "leadingComments": Array [
+        CommentLine {
+          "kind": "commentline",
+          "loc": Location {
+            "end": Position {
+              "column": 0,
+              "line": 5,
+              "offset": 26,
+            },
+            "source": "// bar
+",
+            "start": Position {
+              "column": 0,
+              "line": 4,
+              "offset": 19,
+            },
+          },
+          "offset": 19,
+          "value": "// bar
+",
+        },
+      ],
+      "loc": Location {
+        "end": Position {
+          "column": 19,
+          "line": 5,
+          "offset": 45,
+        },
+        "source": "() /* inner */ ;",
+        "start": Position {
+          "column": 3,
+          "line": 5,
+          "offset": 29,
+        },
+      },
+      "trailingComments": Array [
+        CommentLine {
+          "kind": "commentline",
+          "loc": Location {
+            "end": Position {
+              "column": 0,
+              "line": 7,
+              "offset": 58,
+            },
+            "source": "// trailing
+",
+            "start": Position {
+              "column": 0,
+              "line": 6,
+              "offset": 46,
+            },
+          },
+          "offset": 46,
+          "value": "// trailing
+",
+        },
+      ],
+    },
+  ],
+  "comments": Array [
+    CommentLine {
+      "kind": "commentline",
+      "loc": Location {
+        "end": Position {
+          "column": 0,
+          "line": 3,
+          "offset": 12,
+        },
+        "source": "// leading
+",
+        "start": Position {
+          "column": 0,
+          "line": 2,
+          "offset": 1,
+        },
+      },
+      "offset": 1,
+      "value": "// leading
+",
+    },
+    CommentLine {
+      "kind": "commentline",
+      "loc": Location {
+        "end": Position {
+          "column": 0,
+          "line": 5,
+          "offset": 26,
+        },
+        "source": "// bar
+",
+        "start": Position {
+          "column": 0,
+          "line": 4,
+          "offset": 19,
+        },
+      },
+      "offset": 19,
+      "value": "// bar
+",
+    },
+    CommentBlock {
+      "kind": "commentblock",
+      "loc": Location {
+        "end": Position {
+          "column": 17,
+          "line": 5,
+          "offset": 43,
+        },
+        "source": "/* inner */",
+        "start": Position {
+          "column": 6,
+          "line": 5,
+          "offset": 32,
+        },
+      },
+      "offset": 32,
+      "value": "/* inner */",
+    },
+    CommentLine {
+      "kind": "commentline",
+      "loc": Location {
+        "end": Position {
+          "column": 0,
+          "line": 7,
+          "offset": 58,
+        },
+        "source": "// trailing
+",
+        "start": Position {
+          "column": 0,
+          "line": 6,
+          "offset": 46,
+        },
+      },
+      "offset": 46,
+      "value": "// trailing
+",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+  "loc": Location {
+    "end": Position {
+      "column": 8,
+      "line": 7,
+      "offset": 66,
+    },
+    "source": "
+// leading
+foo();
+// bar
+bar() /* inner */ ;
+// trailing
+        ",
+    "start": Position {
+      "column": 0,
+      "line": 1,
+      "offset": 0,
+    },
+  },
 }
 `;
 
@@ -359,12 +679,6 @@ Program {
           "curly": false,
           "kind": "variable",
           "name": "foo",
-          "trailingComments": Array [
-            CommentBlock {
-              "kind": "commentblock",
-              "value": "/* trail foo */",
-            },
-          ],
         },
         "operator": "=",
         "right": Number {
@@ -372,30 +686,31 @@ Program {
           "leadingComments": Array [
             CommentBlock {
               "kind": "commentblock",
-              "value": "/* lead 1 */",
+              "offset": 37,
+              "value": "/* trail foo */",
             },
-          ],
-          "trailingComments": Array [
             CommentBlock {
               "kind": "commentblock",
-              "value": "/* trail 1 */",
+              "offset": 55,
+              "value": "/* lead 1 */",
             },
           ],
           "value": "1",
         },
+        "trailingComments": Array [
+          CommentBlock {
+            "kind": "commentblock",
+            "offset": 70,
+            "value": "/* trail 1 */",
+          },
+        ],
       },
       "kind": "expressionstatement",
       "leadingComments": Array [
         CommentLine {
           "kind": "commentline",
+          "offset": 9,
           "value": "// lead assign
-",
-        },
-      ],
-      "trailingComments": Array [
-        CommentLine {
-          "kind": "commentline",
-          "value": "// lead call
 ",
         },
       ],
@@ -409,6 +724,7 @@ Program {
             "leadingComments": Array [
               CommentBlock {
                 "kind": "commentblock",
+                "offset": 123,
                 "value": "/* lead arg */",
               },
             ],
@@ -416,6 +732,7 @@ Program {
             "trailingComments": Array [
               CommentBlock {
                 "kind": "commentblock",
+                "offset": 144,
                 "value": "/* trail arg */",
               },
             ],
@@ -427,6 +744,7 @@ Program {
         "trailingComments": Array [
           CommentBlock {
             "kind": "commentblock",
+            "offset": 162,
             "value": "/* trail call */",
           },
         ],
@@ -437,9 +755,18 @@ Program {
         },
       },
       "kind": "expressionstatement",
+      "leadingComments": Array [
+        CommentLine {
+          "kind": "commentline",
+          "offset": 93,
+          "value": "// lead call
+",
+        },
+      ],
       "trailingComments": Array [
         CommentBlock {
           "kind": "commentblock",
+          "offset": 189,
           "value": "/* trail program */",
         },
       ],
@@ -448,40 +775,49 @@ Program {
   "comments": Array [
     CommentLine {
       "kind": "commentline",
+      "offset": 9,
       "value": "// lead assign
 ",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 37,
       "value": "/* trail foo */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 55,
       "value": "/* lead 1 */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 70,
       "value": "/* trail 1 */",
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 93,
       "value": "// lead call
 ",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 123,
       "value": "/* lead arg */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 144,
       "value": "/* trail arg */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 162,
       "value": "/* trail call */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 189,
       "value": "/* trail program */",
     },
   ],
@@ -501,6 +837,7 @@ Program {
           "leadingComments": Array [
             CommentBlock {
               "kind": "commentblock",
+              "offset": 98,
               "value": "/* @var something */",
             },
           ],
@@ -522,6 +859,7 @@ Program {
               "trailingComments": Array [
                 CommentBlock {
                   "kind": "commentblock",
+                  "offset": 168,
                   "value": "/* ignore */",
                 },
               ],
@@ -530,6 +868,7 @@ Program {
             "leadingComments": Array [
               CommentLine {
                 "kind": "commentline",
+                "offset": 137,
                 "value": "// inner
 ",
               },
@@ -543,6 +882,7 @@ Program {
       "leadingComments": Array [
         CommentBlock {
           "kind": "commentblock",
+          "offset": 9,
           "value": "/**
          * Description
          */",
@@ -553,10 +893,12 @@ Program {
         "leadingComments": Array [
           CommentBlock {
             "kind": "commentblock",
+            "offset": 65,
             "value": "/* ignore */",
           },
           CommentBlock {
             "kind": "commentblock",
+            "offset": 80,
             "value": "/* ignore */",
           },
         ],
@@ -569,29 +911,35 @@ Program {
   "comments": Array [
     CommentBlock {
       "kind": "commentblock",
+      "offset": 9,
       "value": "/**
          * Description
          */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 65,
       "value": "/* ignore */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 80,
       "value": "/* ignore */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 98,
       "value": "/* @var something */",
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 137,
       "value": "// inner
 ",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 168,
       "value": "/* ignore */",
     },
   ],
@@ -612,6 +960,12 @@ Program {
             "leadingComments": Array [
               CommentBlock {
                 "kind": "commentblock",
+                "offset": 351,
+                "value": "/* ignore */",
+              },
+              CommentBlock {
+                "kind": "commentblock",
+                "offset": 369,
                 "value": "/* ignore */",
               },
             ],
@@ -622,31 +976,46 @@ Program {
             "leadingComments": Array [
               CommentBlock {
                 "kind": "commentblock",
+                "offset": 284,
                 "value": "/* ignore */",
               },
               CommentBlock {
                 "kind": "commentblock",
+                "offset": 297,
                 "value": "/* ignore */",
               },
-            ],
-            "trailingComments": Array [
               CommentBlock {
                 "kind": "commentblock",
+                "offset": 311,
+                "value": "/* ignore */",
+              },
+              CommentBlock {
+                "kind": "commentblock",
+                "offset": 324,
                 "value": "/* ignore */",
               },
             ],
           },
           "kind": "if",
+          "leadingComments": Array [
+            CommentBlock {
+              "kind": "commentblock",
+              "offset": 231,
+              "value": "/* ignore */",
+            },
+          ],
           "shortForm": false,
           "test": Boolean {
             "kind": "boolean",
             "leadingComments": Array [
               CommentBlock {
                 "kind": "commentblock",
+                "offset": 251,
                 "value": "/* ignore */",
               },
               CommentBlock {
                 "kind": "commentblock",
+                "offset": 265,
                 "value": "/* ignore */",
               },
             ],
@@ -660,12 +1029,12 @@ Program {
           "leadingComments": Array [
             CommentBlock {
               "kind": "commentblock",
+              "offset": 190,
               "value": "/* ignore */",
             },
-          ],
-          "trailingComments": Array [
             CommentBlock {
               "kind": "commentblock",
+              "offset": 204,
               "value": "/* ignore */",
             },
           ],
@@ -674,10 +1043,17 @@ Program {
         "leadingComments": Array [
           CommentBlock {
             "kind": "commentblock",
+            "offset": 89,
+            "value": "/* ignore */",
+          },
+          CommentBlock {
+            "kind": "commentblock",
+            "offset": 107,
             "value": "/* ignore */",
           },
           CommentLine {
             "kind": "commentline",
+            "offset": 128,
             "value": "// else with a inner if single statement :
 ",
           },
@@ -695,17 +1071,7 @@ Program {
         "leadingComments": Array [
           CommentBlock {
             "kind": "commentblock",
-            "value": "/* ignore */",
-          },
-        ],
-        "trailingComments": Array [
-          CommentLine {
-            "kind": "commentline",
-            "value": "# inner statement
-",
-          },
-          CommentBlock {
-            "kind": "commentblock",
+            "offset": 38,
             "value": "/* ignore */",
           },
         ],
@@ -717,14 +1083,24 @@ Program {
         "leadingComments": Array [
           CommentBlock {
             "kind": "commentblock",
+            "offset": 12,
             "value": "/* ignore */",
           },
           CommentBlock {
             "kind": "commentblock",
+            "offset": 26,
             "value": "/* */",
           },
         ],
         "raw": "true",
+        "trailingComments": Array [
+          CommentLine {
+            "kind": "commentline",
+            "offset": 61,
+            "value": "# inner statement
+",
+          },
+        ],
         "value": true,
       },
     },
@@ -736,14 +1112,29 @@ Program {
         "leadingComments": Array [
           CommentBlock {
             "kind": "commentblock",
+            "offset": 415,
             "value": "/* ignore */",
           },
           CommentBlock {
             "kind": "commentblock",
+            "offset": 430,
             "value": "/* ignore */",
           },
           CommentBlock {
             "kind": "commentblock",
+            "offset": 451,
+            "value": "/* ignore */",
+          },
+        ],
+        "trailingComments": Array [
+          CommentBlock {
+            "kind": "commentblock",
+            "offset": 470,
+            "value": "/* ignore */",
+          },
+          CommentBlock {
+            "kind": "commentblock",
+            "offset": 483,
             "value": "/* ignore */",
           },
         ],
@@ -755,111 +1146,124 @@ Program {
         "raw": "false",
         "value": false,
       },
-      "trailingComments": Array [
-        CommentBlock {
-          "kind": "commentblock",
-          "value": "/* ignore */",
-        },
-        CommentBlock {
-          "kind": "commentblock",
-          "value": "/* ignore */",
-        },
-      ],
     },
   ],
   "comments": Array [
     CommentBlock {
       "kind": "commentblock",
+      "offset": 12,
       "value": "/* ignore */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 26,
       "value": "/* */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 38,
       "value": "/* ignore */",
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 61,
       "value": "# inner statement
 ",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 89,
       "value": "/* ignore */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 107,
       "value": "/* ignore */",
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 128,
       "value": "// else with a inner if single statement :
 ",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 190,
       "value": "/* ignore */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 204,
       "value": "/* ignore */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 231,
       "value": "/* ignore */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 251,
       "value": "/* ignore */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 265,
       "value": "/* ignore */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 284,
       "value": "/* ignore */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 297,
       "value": "/* ignore */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 311,
       "value": "/* ignore */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 324,
       "value": "/* ignore */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 351,
       "value": "/* ignore */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 369,
       "value": "/* ignore */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 415,
       "value": "/* ignore */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 430,
       "value": "/* ignore */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 451,
       "value": "/* ignore */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 470,
       "value": "/* ignore */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 483,
       "value": "/* ignore */",
     },
   ],
@@ -878,18 +1282,13 @@ Program {
         "leadingComments": Array [
           CommentBlock {
             "kind": "commentblock",
-            "value": "/* yy */",
+            "offset": 182,
+            "value": "/* zz */",
           },
-        ],
-        "trailingComments": Array [
           CommentBlock {
             "kind": "commentblock",
-            "value": "/* ignore */",
-          },
-          CommentLine {
-            "kind": "commentline",
-            "value": "// end
-",
+            "offset": 199,
+            "value": "/* yy */",
           },
         ],
       },
@@ -899,18 +1298,8 @@ Program {
         "leadingComments": Array [
           CommentBlock {
             "kind": "commentblock",
+            "offset": 13,
             "value": "/* ignore */",
-          },
-        ],
-        "trailingComments": Array [
-          CommentLine {
-            "kind": "commentline",
-            "value": "# inner statement
-",
-          },
-          CommentBlock {
-            "kind": "commentblock",
-            "value": "/* dd */",
           },
         ],
       },
@@ -922,30 +1311,54 @@ Program {
             "leadingComments": Array [
               CommentBlock {
                 "kind": "commentblock",
+                "offset": 134,
+                "value": "/* bb */",
+              },
+              CommentBlock {
+                "kind": "commentblock",
+                "offset": 144,
                 "value": "/* dd */",
-              },
-            ],
-            "trailingComments": Array [
-              CommentBlock {
-                "kind": "commentblock",
-                "value": "/* ee */",
-              },
-              CommentBlock {
-                "kind": "commentblock",
-                "value": "/* zz */",
               },
             ],
           },
           "kind": "catch",
+          "leadingComments": Array [
+            CommentLine {
+              "kind": "commentline",
+              "offset": 36,
+              "value": "# inner statement
+",
+            },
+            CommentBlock {
+              "kind": "commentblock",
+              "offset": 64,
+              "value": "/* dd */",
+            },
+          ],
+          "trailingComments": Array [
+            CommentBlock {
+              "kind": "commentblock",
+              "offset": 218,
+              "value": "/* ignore */",
+            },
+          ],
           "variable": Variable {
             "byref": false,
             "curly": false,
             "kind": "variable",
+            "leadingComments": Array [
+              CommentBlock {
+                "kind": "commentblock",
+                "offset": 122,
+                "value": "/* aa */",
+              },
+            ],
             "name": "e",
             "trailingComments": Array [
               CommentBlock {
                 "kind": "commentblock",
-                "value": "/* bb */",
+                "offset": 163,
+                "value": "/* ee */",
               },
             ],
           },
@@ -955,97 +1368,114 @@ Program {
               "leadingComments": Array [
                 CommentBlock {
                   "kind": "commentblock",
+                  "offset": 79,
                   "value": "/* zz */",
                 },
               ],
               "name": "\\\\Exception",
               "resolution": "qn",
-              "trailingComments": Array [
-                CommentBlock {
-                  "kind": "commentblock",
-                  "value": "/* 1 */",
-                },
-              ],
             },
             ClassReference {
               "kind": "classreference",
               "leadingComments": Array [
                 CommentBlock {
                   "kind": "commentblock",
+                  "offset": 99,
+                  "value": "/* 1 */",
+                },
+                CommentBlock {
+                  "kind": "commentblock",
+                  "offset": 109,
                   "value": "/* 2 */",
                 },
               ],
               "name": "\\\\Foo",
               "resolution": "qn",
-              "trailingComments": Array [
-                CommentBlock {
-                  "kind": "commentblock",
-                  "value": "/* aa */",
-                },
-              ],
             },
           ],
         },
       ],
       "kind": "try",
+      "trailingComments": Array [
+        CommentLine {
+          "kind": "commentline",
+          "offset": 241,
+          "value": "// end
+",
+        },
+      ],
     },
   ],
   "comments": Array [
     CommentBlock {
       "kind": "commentblock",
+      "offset": 13,
       "value": "/* ignore */",
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 36,
       "value": "# inner statement
 ",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 64,
       "value": "/* dd */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 79,
       "value": "/* zz */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 99,
       "value": "/* 1 */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 109,
       "value": "/* 2 */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 122,
       "value": "/* aa */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 134,
       "value": "/* bb */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 144,
       "value": "/* dd */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 163,
       "value": "/* ee */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 182,
       "value": "/* zz */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 199,
       "value": "/* yy */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 218,
       "value": "/* ignore */",
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 241,
       "value": "// end
 ",
     },
@@ -1066,8 +1496,14 @@ Program {
           "isStatic": false,
           "kind": "property",
           "leadingComments": Array [
+            CommentBlock {
+              "kind": "commentblock",
+              "offset": 72,
+              "value": "/* hehe */",
+            },
             CommentLine {
               "kind": "commentline",
+              "offset": 94,
               "value": "// @var test
 ",
             },
@@ -1093,11 +1529,13 @@ Program {
           "leadingComments": Array [
             CommentLine {
               "kind": "commentline",
+              "offset": 149,
               "value": "// ignored comment
 ",
             },
             CommentBlock {
               "kind": "commentblock",
+              "offset": 177,
               "value": "/** @var Class */",
             },
           ],
@@ -1122,10 +1560,12 @@ Program {
           "leadingComments": Array [
             CommentBlock {
               "kind": "commentblock",
+              "offset": 239,
               "value": "/** ignored also **/",
             },
             CommentBlock {
               "kind": "commentblock",
+              "offset": 269,
               "value": "/**
           * @return void
           */",
@@ -1149,6 +1589,7 @@ Program {
       "leadingComments": Array [
         CommentBlock {
           "kind": "commentblock",
+          "offset": 7,
           "value": "/**
        * Description
        */",
@@ -1159,54 +1600,57 @@ Program {
         "leadingComments": Array [
           CommentBlock {
             "kind": "commentblock",
+            "offset": 54,
             "value": "/* ignore */",
           },
         ],
         "name": "name",
-        "trailingComments": Array [
-          CommentBlock {
-            "kind": "commentblock",
-            "value": "/* hehe */",
-          },
-        ],
       },
     },
   ],
   "comments": Array [
     CommentBlock {
       "kind": "commentblock",
+      "offset": 7,
       "value": "/**
        * Description
        */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 54,
       "value": "/* ignore */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 72,
       "value": "/* hehe */",
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 94,
       "value": "// @var test
 ",
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 149,
       "value": "// ignored comment
 ",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 177,
       "value": "/** @var Class */",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 239,
       "value": "/** ignored also **/",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 269,
       "value": "/**
           * @return void
           */",
@@ -1232,25 +1676,28 @@ Program {
         "operator": "=",
         "right": Number {
           "kind": "number",
-          "trailingComments": Array [
-            CommentLine {
-              "kind": "commentline",
-              "value": "// 123
-",
-            },
-          ],
           "value": "123",
         },
+        "trailingComments": Array [
+          CommentLine {
+            "kind": "commentline",
+            "offset": 65,
+            "value": "// 123
+",
+          },
+        ],
       },
       "kind": "expressionstatement",
       "leadingComments": Array [
         CommentLine {
           "kind": "commentline",
+          "offset": 7,
           "value": "# some information
 ",
         },
         CommentLine {
           "kind": "commentline",
+          "offset": 32,
           "value": "// another line
 ",
         },
@@ -1258,6 +1705,7 @@ Program {
       "trailingComments": Array [
         CommentBlock {
           "kind": "commentblock",
+          "offset": 80,
           "value": "/* done */",
         },
       ],
@@ -1266,21 +1714,25 @@ Program {
   "comments": Array [
     CommentLine {
       "kind": "commentline",
+      "offset": 7,
       "value": "# some information
 ",
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 32,
       "value": "// another line
 ",
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 65,
       "value": "// 123
 ",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 80,
       "value": "/* done */",
     },
   ],

--- a/test/snapshot/__snapshots__/encapsed.test.js.snap
+++ b/test/snapshot/__snapshots__/encapsed.test.js.snap
@@ -1138,6 +1138,156 @@ Program {
 }
 `;
 
+exports[`encapsed staticlookup (4) (complex syntax) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Encapsed {
+        "kind": "encapsed",
+        "raw": "\\"string {$var::$target::$resource::$binary::$foo::$bar::$foobar::$bar::$foo::$foobar::$bar::$foo} string\\"",
+        "type": "string",
+        "value": Array [
+          EncapsedPart {
+            "curly": false,
+            "expression": String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "string ",
+              "unicode": false,
+              "value": "string ",
+            },
+            "kind": "encapsedpart",
+          },
+          EncapsedPart {
+            "curly": true,
+            "expression": StaticLookup {
+              "kind": "staticlookup",
+              "offset": Variable {
+                "byref": false,
+                "curly": false,
+                "kind": "variable",
+                "name": "foo",
+              },
+              "what": StaticLookup {
+                "kind": "staticlookup",
+                "offset": Variable {
+                  "byref": false,
+                  "curly": false,
+                  "kind": "variable",
+                  "name": "bar",
+                },
+                "what": StaticLookup {
+                  "kind": "staticlookup",
+                  "offset": Variable {
+                    "byref": false,
+                    "curly": false,
+                    "kind": "variable",
+                    "name": "foobar",
+                  },
+                  "what": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Variable {
+                      "byref": false,
+                      "curly": false,
+                      "kind": "variable",
+                      "name": "foo",
+                    },
+                    "what": StaticLookup {
+                      "kind": "staticlookup",
+                      "offset": Variable {
+                        "byref": false,
+                        "curly": false,
+                        "kind": "variable",
+                        "name": "bar",
+                      },
+                      "what": StaticLookup {
+                        "kind": "staticlookup",
+                        "offset": Variable {
+                          "byref": false,
+                          "curly": false,
+                          "kind": "variable",
+                          "name": "foobar",
+                        },
+                        "what": StaticLookup {
+                          "kind": "staticlookup",
+                          "offset": Variable {
+                            "byref": false,
+                            "curly": false,
+                            "kind": "variable",
+                            "name": "bar",
+                          },
+                          "what": StaticLookup {
+                            "kind": "staticlookup",
+                            "offset": Variable {
+                              "byref": false,
+                              "curly": false,
+                              "kind": "variable",
+                              "name": "foo",
+                            },
+                            "what": StaticLookup {
+                              "kind": "staticlookup",
+                              "offset": Variable {
+                                "byref": false,
+                                "curly": false,
+                                "kind": "variable",
+                                "name": "binary",
+                              },
+                              "what": StaticLookup {
+                                "kind": "staticlookup",
+                                "offset": Variable {
+                                  "byref": false,
+                                  "curly": false,
+                                  "kind": "variable",
+                                  "name": "resource",
+                                },
+                                "what": StaticLookup {
+                                  "kind": "staticlookup",
+                                  "offset": Variable {
+                                    "byref": false,
+                                    "curly": false,
+                                    "kind": "variable",
+                                    "name": "target",
+                                  },
+                                  "what": Variable {
+                                    "byref": false,
+                                    "curly": false,
+                                    "kind": "variable",
+                                    "name": "var",
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "kind": "encapsedpart",
+          },
+          EncapsedPart {
+            "curly": false,
+            "expression": String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": " string",
+              "unicode": false,
+              "value": " string",
+            },
+            "kind": "encapsedpart",
+          },
+        ],
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`encapsed staticlookup (complex syntax) 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/__snapshots__/encapsed.test.js.snap
+++ b/test/snapshot/__snapshots__/encapsed.test.js.snap
@@ -766,17 +766,20 @@ Program {
             "curly": true,
             "expression": PropertyLookup {
               "kind": "propertylookup",
-              "offset": OffsetLookup {
-                "kind": "offsetlookup",
-                "offset": Number {
-                  "kind": "number",
-                  "value": "1",
-                },
-                "what": Variable {
-                  "byref": false,
-                  "curly": false,
-                  "kind": "variable",
-                  "name": "array",
+              "offset": Literal {
+                "kind": "literal",
+                "value": OffsetLookup {
+                  "kind": "offsetlookup",
+                  "offset": Number {
+                    "kind": "number",
+                    "value": "1",
+                  },
+                  "what": Variable {
+                    "byref": false,
+                    "curly": false,
+                    "kind": "variable",
+                    "name": "array",
+                  },
                 },
               },
               "what": Variable {

--- a/test/snapshot/__snapshots__/expr.test.js.snap
+++ b/test/snapshot/__snapshots__/expr.test.js.snap
@@ -2230,7 +2230,7 @@ Program {
           "what": ClassReference {
             "kind": "classreference",
             "name": "\\\\foo",
-            "resolution": "qn",
+            "resolution": "fqn",
           },
         },
       },

--- a/test/snapshot/__snapshots__/function.test.js.snap
+++ b/test/snapshot/__snapshots__/function.test.js.snap
@@ -137,6 +137,13 @@ Program {
         Parameter {
           "byref": false,
           "kind": "parameter",
+          "leadingComments": Array [
+            CommentBlock {
+              "kind": "commentblock",
+              "offset": 18,
+              "value": "/* f */",
+            },
+          ],
           "name": "a",
           "nullable": false,
           "type": null,
@@ -153,12 +160,6 @@ Program {
       "name": Identifier {
         "kind": "identifier",
         "name": "f",
-        "trailingComments": Array [
-          CommentBlock {
-            "kind": "commentblock",
-            "value": "/* f */",
-          },
-        ],
       },
       "nullable": false,
       "type": null,
@@ -167,6 +168,7 @@ Program {
   "comments": Array [
     CommentBlock {
       "kind": "commentblock",
+      "offset": 18,
       "value": "/* f */",
     },
   ],

--- a/test/snapshot/__snapshots__/graceful.test.js.snap
+++ b/test/snapshot/__snapshots__/graceful.test.js.snap
@@ -120,13 +120,16 @@ Program {
         "kind": "new",
         "what": StaticLookup {
           "kind": "staticlookup",
-          "offset": Call {
-            "arguments": Array [],
-            "kind": "call",
-            "what": ClassReference {
-              "kind": "classreference",
-              "name": "call",
-              "resolution": "uqn",
+          "offset": Literal {
+            "kind": "literal",
+            "value": Call {
+              "arguments": Array [],
+              "kind": "call",
+              "what": ClassReference {
+                "kind": "classreference",
+                "name": "call",
+                "resolution": "uqn",
+              },
             },
           },
           "what": ClassReference {
@@ -150,13 +153,16 @@ Program {
     ExpressionStatement {
       "expression": StaticLookup {
         "kind": "staticlookup",
-        "offset": Call {
-          "arguments": Array [],
-          "kind": "call",
-          "what": ClassReference {
-            "kind": "classreference",
-            "name": "call",
-            "resolution": "uqn",
+        "offset": Literal {
+          "kind": "literal",
+          "value": Call {
+            "arguments": Array [],
+            "kind": "call",
+            "what": ClassReference {
+              "kind": "classreference",
+              "name": "call",
+              "resolution": "uqn",
+            },
           },
         },
         "what": ClassReference {

--- a/test/snapshot/__snapshots__/lexer.test.js.snap
+++ b/test/snapshot/__snapshots__/lexer.test.js.snap
@@ -122,46 +122,50 @@ Program {
       "kind": "inline",
       "raw": "
       ",
-      "trailingComments": Array [
-        CommentLine {
-          "kind": "commentline",
-          "value": "// simple comment ",
-        },
-      ],
       "value": "
       ",
     },
     Inline {
       "kind": "inline",
-      "raw": "
-      ",
-      "trailingComments": Array [
+      "leadingComments": Array [
         CommentLine {
           "kind": "commentline",
+          "offset": 20,
+          "value": "// simple comment ",
+        },
+      ],
+      "raw": "
+      ",
+      "value": "      ",
+    },
+    Inline {
+      "kind": "inline",
+      "leadingComments": Array [
+        CommentLine {
+          "kind": "commentline",
+          "offset": 57,
           "value": "// another line ",
         },
       ],
+      "raw": "
+      ",
       "value": "      ",
     },
     Inline {
       "kind": "inline",
-      "raw": "
-      ",
-      "trailingComments": Array [
+      "leadingComments": Array [
         CommentBlock {
           "kind": "commentblock",
+          "offset": 92,
           "value": "/**/",
         },
       ],
-      "value": "      ",
-    },
-    Inline {
-      "kind": "inline",
       "raw": "
       ",
       "trailingComments": Array [
         CommentLine {
           "kind": "commentline",
+          "offset": 112,
           "value": "// last comment
 ",
         },
@@ -172,18 +176,22 @@ Program {
   "comments": Array [
     CommentLine {
       "kind": "commentline",
+      "offset": 20,
       "value": "// simple comment ",
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 57,
       "value": "// another line ",
     },
     CommentBlock {
       "kind": "commentblock",
+      "offset": 92,
       "value": "/**/",
     },
     CommentLine {
       "kind": "commentline",
+      "offset": 112,
       "value": "// last comment
 ",
     },

--- a/test/snapshot/__snapshots__/location.test.js.snap
+++ b/test/snapshot/__snapshots__/location.test.js.snap
@@ -7979,11 +7979,11 @@ Program {
           "end": Position {
             "column": 18,
             "line": 10,
-            "offset": 210,
+            "offset": 212,
           },
           "source": "$var = $var
           // Comment
-          ['foo'] // Comment
+          [ 'foo' ] // Comment
           // Comment
           ['bar'] // Comment
           // Comment
@@ -8001,13 +8001,13 @@ Program {
           "kind": "offsetlookup",
           "loc": Location {
             "end": Position {
-              "column": 16,
+              "column": 17,
               "line": 10,
-              "offset": 208,
+              "offset": 211,
             },
             "source": "$var
           // Comment
-          ['foo'] // Comment
+          [ 'foo' ] // Comment
           // Comment
           ['bar'] // Comment
           // Comment
@@ -8027,13 +8027,13 @@ Program {
               "end": Position {
                 "column": 16,
                 "line": 10,
-                "offset": 208,
+                "offset": 210,
               },
               "source": "'qqq'",
               "start": Position {
                 "column": 11,
                 "line": 10,
-                "offset": 203,
+                "offset": 205,
               },
             },
             "raw": "'qqq'",
@@ -8044,13 +8044,13 @@ Program {
             "kind": "offsetlookup",
             "loc": Location {
               "end": Position {
-                "column": 16,
+                "column": 17,
                 "line": 8,
-                "offset": 158,
+                "offset": 161,
               },
               "source": "$var
           // Comment
-          ['foo'] // Comment
+          [ 'foo' ] // Comment
           // Comment
           ['bar'] // Comment
           // Comment
@@ -8068,13 +8068,13 @@ Program {
                 "end": Position {
                   "column": 16,
                   "line": 8,
-                  "offset": 158,
+                  "offset": 160,
                 },
                 "source": "'baz'",
                 "start": Position {
                   "column": 11,
                   "line": 8,
-                  "offset": 153,
+                  "offset": 155,
                 },
               },
               "raw": "'baz'",
@@ -8085,13 +8085,13 @@ Program {
               "kind": "offsetlookup",
               "loc": Location {
                 "end": Position {
-                  "column": 16,
+                  "column": 17,
                   "line": 6,
-                  "offset": 108,
+                  "offset": 111,
                 },
                 "source": "$var
           // Comment
-          ['foo'] // Comment
+          [ 'foo' ] // Comment
           // Comment
           ['bar']",
                 "start": Position {
@@ -8107,13 +8107,13 @@ Program {
                   "end": Position {
                     "column": 16,
                     "line": 6,
-                    "offset": 108,
+                    "offset": 110,
                   },
                   "source": "'bar'",
                   "start": Position {
                     "column": 11,
                     "line": 6,
-                    "offset": 103,
+                    "offset": 105,
                   },
                 },
                 "raw": "'bar'",
@@ -8124,13 +8124,13 @@ Program {
                 "kind": "offsetlookup",
                 "loc": Location {
                   "end": Position {
-                    "column": 16,
+                    "column": 19,
                     "line": 4,
-                    "offset": 58,
+                    "offset": 61,
                   },
                   "source": "$var
           // Comment
-          ['foo']",
+          [ 'foo' ]",
                   "start": Position {
                     "column": 15,
                     "line": 2,
@@ -8142,15 +8142,15 @@ Program {
                   "kind": "string",
                   "loc": Location {
                     "end": Position {
-                      "column": 16,
+                      "column": 17,
                       "line": 4,
-                      "offset": 58,
+                      "offset": 59,
                     },
                     "source": "'foo'",
                     "start": Position {
-                      "column": 11,
+                      "column": 12,
                       "line": 4,
-                      "offset": 53,
+                      "offset": 54,
                     },
                   },
                   "raw": "'foo'",
@@ -8186,11 +8186,11 @@ Program {
         "end": Position {
           "column": 18,
           "line": 10,
-          "offset": 210,
+          "offset": 212,
         },
         "source": "$var = $var
           // Comment
-          ['foo'] // Comment
+          [ 'foo' ] // Comment
           // Comment
           ['bar'] // Comment
           // Comment
@@ -8211,12 +8211,12 @@ Program {
     "end": Position {
       "column": 8,
       "line": 11,
-      "offset": 219,
+      "offset": 221,
     },
     "source": "
         $var = $var
           // Comment
-          ['foo'] // Comment
+          [ 'foo' ] // Comment
           // Comment
           ['bar'] // Comment
           // Comment

--- a/test/snapshot/__snapshots__/location.test.js.snap
+++ b/test/snapshot/__snapshots__/location.test.js.snap
@@ -7950,6 +7950,289 @@ Program {
 }
 `;
 
+exports[`Test locations offsetlookup 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "loc": Location {
+            "end": Position {
+              "column": 12,
+              "line": 2,
+              "offset": 13,
+            },
+            "source": "$var",
+            "start": Position {
+              "column": 8,
+              "line": 2,
+              "offset": 9,
+            },
+          },
+          "name": "var",
+        },
+        "loc": Location {
+          "end": Position {
+            "column": 18,
+            "line": 10,
+            "offset": 210,
+          },
+          "source": "$var = $var
+          // Comment
+          ['foo'] // Comment
+          // Comment
+          ['bar'] // Comment
+          // Comment
+          ['baz'] // Comment
+          // Comment
+          ['qqq'];",
+          "start": Position {
+            "column": 8,
+            "line": 2,
+            "offset": 9,
+          },
+        },
+        "operator": "=",
+        "right": OffsetLookup {
+          "kind": "offsetlookup",
+          "loc": Location {
+            "end": Position {
+              "column": 16,
+              "line": 10,
+              "offset": 208,
+            },
+            "source": "$var
+          // Comment
+          ['foo'] // Comment
+          // Comment
+          ['bar'] // Comment
+          // Comment
+          ['baz'] // Comment
+          // Comment
+          ['qqq']",
+            "start": Position {
+              "column": 15,
+              "line": 2,
+              "offset": 16,
+            },
+          },
+          "offset": String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "loc": Location {
+              "end": Position {
+                "column": 16,
+                "line": 10,
+                "offset": 208,
+              },
+              "source": "'qqq'",
+              "start": Position {
+                "column": 11,
+                "line": 10,
+                "offset": 203,
+              },
+            },
+            "raw": "'qqq'",
+            "unicode": false,
+            "value": "qqq",
+          },
+          "what": OffsetLookup {
+            "kind": "offsetlookup",
+            "loc": Location {
+              "end": Position {
+                "column": 16,
+                "line": 8,
+                "offset": 158,
+              },
+              "source": "$var
+          // Comment
+          ['foo'] // Comment
+          // Comment
+          ['bar'] // Comment
+          // Comment
+          ['baz']",
+              "start": Position {
+                "column": 15,
+                "line": 2,
+                "offset": 16,
+              },
+            },
+            "offset": String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "loc": Location {
+                "end": Position {
+                  "column": 16,
+                  "line": 8,
+                  "offset": 158,
+                },
+                "source": "'baz'",
+                "start": Position {
+                  "column": 11,
+                  "line": 8,
+                  "offset": 153,
+                },
+              },
+              "raw": "'baz'",
+              "unicode": false,
+              "value": "baz",
+            },
+            "what": OffsetLookup {
+              "kind": "offsetlookup",
+              "loc": Location {
+                "end": Position {
+                  "column": 16,
+                  "line": 6,
+                  "offset": 108,
+                },
+                "source": "$var
+          // Comment
+          ['foo'] // Comment
+          // Comment
+          ['bar']",
+                "start": Position {
+                  "column": 15,
+                  "line": 2,
+                  "offset": 16,
+                },
+              },
+              "offset": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "loc": Location {
+                  "end": Position {
+                    "column": 16,
+                    "line": 6,
+                    "offset": 108,
+                  },
+                  "source": "'bar'",
+                  "start": Position {
+                    "column": 11,
+                    "line": 6,
+                    "offset": 103,
+                  },
+                },
+                "raw": "'bar'",
+                "unicode": false,
+                "value": "bar",
+              },
+              "what": OffsetLookup {
+                "kind": "offsetlookup",
+                "loc": Location {
+                  "end": Position {
+                    "column": 16,
+                    "line": 4,
+                    "offset": 58,
+                  },
+                  "source": "$var
+          // Comment
+          ['foo']",
+                  "start": Position {
+                    "column": 15,
+                    "line": 2,
+                    "offset": 16,
+                  },
+                },
+                "offset": String {
+                  "isDoubleQuote": false,
+                  "kind": "string",
+                  "loc": Location {
+                    "end": Position {
+                      "column": 16,
+                      "line": 4,
+                      "offset": 58,
+                    },
+                    "source": "'foo'",
+                    "start": Position {
+                      "column": 11,
+                      "line": 4,
+                      "offset": 53,
+                    },
+                  },
+                  "raw": "'foo'",
+                  "unicode": false,
+                  "value": "foo",
+                },
+                "what": Variable {
+                  "byref": false,
+                  "curly": false,
+                  "kind": "variable",
+                  "loc": Location {
+                    "end": Position {
+                      "column": 19,
+                      "line": 2,
+                      "offset": 20,
+                    },
+                    "source": "$var",
+                    "start": Position {
+                      "column": 15,
+                      "line": 2,
+                      "offset": 16,
+                    },
+                  },
+                  "name": "var",
+                },
+              },
+            },
+          },
+        },
+      },
+      "kind": "expressionstatement",
+      "loc": Location {
+        "end": Position {
+          "column": 18,
+          "line": 10,
+          "offset": 210,
+        },
+        "source": "$var = $var
+          // Comment
+          ['foo'] // Comment
+          // Comment
+          ['bar'] // Comment
+          // Comment
+          ['baz'] // Comment
+          // Comment
+          ['qqq'];",
+        "start": Position {
+          "column": 8,
+          "line": 2,
+          "offset": 9,
+        },
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+  "loc": Location {
+    "end": Position {
+      "column": 8,
+      "line": 11,
+      "offset": 219,
+    },
+    "source": "
+        $var = $var
+          // Comment
+          ['foo'] // Comment
+          // Comment
+          ['bar'] // Comment
+          // Comment
+          ['baz'] // Comment
+          // Comment
+          ['qqq'];
+        ",
+    "start": Position {
+      "column": 0,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+}
+`;
+
 exports[`Test locations parameter 1`] = `
 Program {
   "children": Array [
@@ -8295,6 +8578,365 @@ Program {
       "offset": 18,
     },
     "source": "print \\"something\\";",
+    "start": Position {
+      "column": 0,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+}
+`;
+
+exports[`Test locations propertylookup 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "loc": Location {
+            "end": Position {
+              "column": 12,
+              "line": 2,
+              "offset": 13,
+            },
+            "source": "$var",
+            "start": Position {
+              "column": 8,
+              "line": 2,
+              "offset": 9,
+            },
+          },
+          "name": "var",
+        },
+        "loc": Location {
+          "end": Position {
+            "column": 19,
+            "line": 10,
+            "offset": 214,
+          },
+          "source": "$var = $var
+          // Comment
+          ->each() // Comment
+          // Comment
+          ->map() // Comment
+          // Comment
+          ->first() // Comment
+          // Comment
+          ->dump();",
+          "start": Position {
+            "column": 8,
+            "line": 2,
+            "offset": 9,
+          },
+        },
+        "operator": "=",
+        "right": Call {
+          "arguments": Array [],
+          "kind": "call",
+          "loc": Location {
+            "end": Position {
+              "column": 18,
+              "line": 10,
+              "offset": 213,
+            },
+            "source": "$var
+          // Comment
+          ->each() // Comment
+          // Comment
+          ->map() // Comment
+          // Comment
+          ->first() // Comment
+          // Comment
+          ->dump()",
+            "start": Position {
+              "column": 15,
+              "line": 2,
+              "offset": 16,
+            },
+          },
+          "what": PropertyLookup {
+            "kind": "propertylookup",
+            "loc": Location {
+              "end": Position {
+                "column": 16,
+                "line": 10,
+                "offset": 211,
+              },
+              "source": "$var
+          // Comment
+          ->each() // Comment
+          // Comment
+          ->map() // Comment
+          // Comment
+          ->first() // Comment
+          // Comment
+          ->dump",
+              "start": Position {
+                "column": 15,
+                "line": 2,
+                "offset": 16,
+              },
+            },
+            "offset": Identifier {
+              "kind": "identifier",
+              "loc": Location {
+                "end": Position {
+                  "column": 16,
+                  "line": 10,
+                  "offset": 211,
+                },
+                "source": "dump",
+                "start": Position {
+                  "column": 12,
+                  "line": 10,
+                  "offset": 207,
+                },
+              },
+              "name": "dump",
+            },
+            "what": Call {
+              "arguments": Array [],
+              "kind": "call",
+              "loc": Location {
+                "end": Position {
+                  "column": 19,
+                  "line": 8,
+                  "offset": 162,
+                },
+                "source": "$var
+          // Comment
+          ->each() // Comment
+          // Comment
+          ->map() // Comment
+          // Comment
+          ->first()",
+                "start": Position {
+                  "column": 15,
+                  "line": 2,
+                  "offset": 16,
+                },
+              },
+              "what": PropertyLookup {
+                "kind": "propertylookup",
+                "loc": Location {
+                  "end": Position {
+                    "column": 17,
+                    "line": 8,
+                    "offset": 160,
+                  },
+                  "source": "$var
+          // Comment
+          ->each() // Comment
+          // Comment
+          ->map() // Comment
+          // Comment
+          ->first",
+                  "start": Position {
+                    "column": 15,
+                    "line": 2,
+                    "offset": 16,
+                  },
+                },
+                "offset": Identifier {
+                  "kind": "identifier",
+                  "loc": Location {
+                    "end": Position {
+                      "column": 17,
+                      "line": 8,
+                      "offset": 160,
+                    },
+                    "source": "first",
+                    "start": Position {
+                      "column": 12,
+                      "line": 8,
+                      "offset": 155,
+                    },
+                  },
+                  "name": "first",
+                },
+                "what": Call {
+                  "arguments": Array [],
+                  "kind": "call",
+                  "loc": Location {
+                    "end": Position {
+                      "column": 17,
+                      "line": 6,
+                      "offset": 110,
+                    },
+                    "source": "$var
+          // Comment
+          ->each() // Comment
+          // Comment
+          ->map()",
+                    "start": Position {
+                      "column": 15,
+                      "line": 2,
+                      "offset": 16,
+                    },
+                  },
+                  "what": PropertyLookup {
+                    "kind": "propertylookup",
+                    "loc": Location {
+                      "end": Position {
+                        "column": 15,
+                        "line": 6,
+                        "offset": 108,
+                      },
+                      "source": "$var
+          // Comment
+          ->each() // Comment
+          // Comment
+          ->map",
+                      "start": Position {
+                        "column": 15,
+                        "line": 2,
+                        "offset": 16,
+                      },
+                    },
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "loc": Location {
+                        "end": Position {
+                          "column": 15,
+                          "line": 6,
+                          "offset": 108,
+                        },
+                        "source": "map",
+                        "start": Position {
+                          "column": 12,
+                          "line": 6,
+                          "offset": 105,
+                        },
+                      },
+                      "name": "map",
+                    },
+                    "what": Call {
+                      "arguments": Array [],
+                      "kind": "call",
+                      "loc": Location {
+                        "end": Position {
+                          "column": 18,
+                          "line": 4,
+                          "offset": 60,
+                        },
+                        "source": "$var
+          // Comment
+          ->each()",
+                        "start": Position {
+                          "column": 15,
+                          "line": 2,
+                          "offset": 16,
+                        },
+                      },
+                      "what": PropertyLookup {
+                        "kind": "propertylookup",
+                        "loc": Location {
+                          "end": Position {
+                            "column": 16,
+                            "line": 4,
+                            "offset": 58,
+                          },
+                          "source": "$var
+          // Comment
+          ->each",
+                          "start": Position {
+                            "column": 15,
+                            "line": 2,
+                            "offset": 16,
+                          },
+                        },
+                        "offset": Identifier {
+                          "kind": "identifier",
+                          "loc": Location {
+                            "end": Position {
+                              "column": 16,
+                              "line": 4,
+                              "offset": 58,
+                            },
+                            "source": "each",
+                            "start": Position {
+                              "column": 12,
+                              "line": 4,
+                              "offset": 54,
+                            },
+                          },
+                          "name": "each",
+                        },
+                        "what": Variable {
+                          "byref": false,
+                          "curly": false,
+                          "kind": "variable",
+                          "loc": Location {
+                            "end": Position {
+                              "column": 19,
+                              "line": 2,
+                              "offset": 20,
+                            },
+                            "source": "$var",
+                            "start": Position {
+                              "column": 15,
+                              "line": 2,
+                              "offset": 16,
+                            },
+                          },
+                          "name": "var",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      "kind": "expressionstatement",
+      "loc": Location {
+        "end": Position {
+          "column": 19,
+          "line": 10,
+          "offset": 214,
+        },
+        "source": "$var = $var
+          // Comment
+          ->each() // Comment
+          // Comment
+          ->map() // Comment
+          // Comment
+          ->first() // Comment
+          // Comment
+          ->dump();",
+        "start": Position {
+          "column": 8,
+          "line": 2,
+          "offset": 9,
+        },
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+  "loc": Location {
+    "end": Position {
+      "column": 8,
+      "line": 11,
+      "offset": 223,
+    },
+    "source": "
+        $var = $var
+          // Comment
+          ->each() // Comment
+          // Comment
+          ->map() // Comment
+          // Comment
+          ->first() // Comment
+          // Comment
+          ->dump();
+        ",
     "start": Position {
       "column": 0,
       "line": 1,
@@ -9303,6 +9945,365 @@ Program {
       "offset": 30,
     },
     "source": "static $a = 1, $b = 2, $c = 3;",
+    "start": Position {
+      "column": 0,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+}
+`;
+
+exports[`Test locations staticlookup 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "loc": Location {
+            "end": Position {
+              "column": 12,
+              "line": 2,
+              "offset": 13,
+            },
+            "source": "$var",
+            "start": Position {
+              "column": 8,
+              "line": 2,
+              "offset": 9,
+            },
+          },
+          "name": "var",
+        },
+        "loc": Location {
+          "end": Position {
+            "column": 19,
+            "line": 10,
+            "offset": 214,
+          },
+          "source": "$var = $var
+          // Comment
+          ::each() // Comment
+          // Comment
+          ::map() // Comment
+          // Comment
+          ::first() // Comment
+          // Comment
+          ::dump();",
+          "start": Position {
+            "column": 8,
+            "line": 2,
+            "offset": 9,
+          },
+        },
+        "operator": "=",
+        "right": Call {
+          "arguments": Array [],
+          "kind": "call",
+          "loc": Location {
+            "end": Position {
+              "column": 18,
+              "line": 10,
+              "offset": 213,
+            },
+            "source": "$var
+          // Comment
+          ::each() // Comment
+          // Comment
+          ::map() // Comment
+          // Comment
+          ::first() // Comment
+          // Comment
+          ::dump()",
+            "start": Position {
+              "column": 15,
+              "line": 2,
+              "offset": 16,
+            },
+          },
+          "what": StaticLookup {
+            "kind": "staticlookup",
+            "loc": Location {
+              "end": Position {
+                "column": 16,
+                "line": 10,
+                "offset": 211,
+              },
+              "source": "$var
+          // Comment
+          ::each() // Comment
+          // Comment
+          ::map() // Comment
+          // Comment
+          ::first() // Comment
+          // Comment
+          ::dump",
+              "start": Position {
+                "column": 15,
+                "line": 2,
+                "offset": 16,
+              },
+            },
+            "offset": Identifier {
+              "kind": "identifier",
+              "loc": Location {
+                "end": Position {
+                  "column": 16,
+                  "line": 10,
+                  "offset": 211,
+                },
+                "source": "dump",
+                "start": Position {
+                  "column": 12,
+                  "line": 10,
+                  "offset": 207,
+                },
+              },
+              "name": "dump",
+            },
+            "what": Call {
+              "arguments": Array [],
+              "kind": "call",
+              "loc": Location {
+                "end": Position {
+                  "column": 19,
+                  "line": 8,
+                  "offset": 162,
+                },
+                "source": "$var
+          // Comment
+          ::each() // Comment
+          // Comment
+          ::map() // Comment
+          // Comment
+          ::first()",
+                "start": Position {
+                  "column": 15,
+                  "line": 2,
+                  "offset": 16,
+                },
+              },
+              "what": StaticLookup {
+                "kind": "staticlookup",
+                "loc": Location {
+                  "end": Position {
+                    "column": 17,
+                    "line": 8,
+                    "offset": 160,
+                  },
+                  "source": "$var
+          // Comment
+          ::each() // Comment
+          // Comment
+          ::map() // Comment
+          // Comment
+          ::first",
+                  "start": Position {
+                    "column": 15,
+                    "line": 2,
+                    "offset": 16,
+                  },
+                },
+                "offset": Identifier {
+                  "kind": "identifier",
+                  "loc": Location {
+                    "end": Position {
+                      "column": 17,
+                      "line": 8,
+                      "offset": 160,
+                    },
+                    "source": "first",
+                    "start": Position {
+                      "column": 12,
+                      "line": 8,
+                      "offset": 155,
+                    },
+                  },
+                  "name": "first",
+                },
+                "what": Call {
+                  "arguments": Array [],
+                  "kind": "call",
+                  "loc": Location {
+                    "end": Position {
+                      "column": 17,
+                      "line": 6,
+                      "offset": 110,
+                    },
+                    "source": "$var
+          // Comment
+          ::each() // Comment
+          // Comment
+          ::map()",
+                    "start": Position {
+                      "column": 15,
+                      "line": 2,
+                      "offset": 16,
+                    },
+                  },
+                  "what": StaticLookup {
+                    "kind": "staticlookup",
+                    "loc": Location {
+                      "end": Position {
+                        "column": 15,
+                        "line": 6,
+                        "offset": 108,
+                      },
+                      "source": "$var
+          // Comment
+          ::each() // Comment
+          // Comment
+          ::map",
+                      "start": Position {
+                        "column": 15,
+                        "line": 2,
+                        "offset": 16,
+                      },
+                    },
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "loc": Location {
+                        "end": Position {
+                          "column": 15,
+                          "line": 6,
+                          "offset": 108,
+                        },
+                        "source": "map",
+                        "start": Position {
+                          "column": 12,
+                          "line": 6,
+                          "offset": 105,
+                        },
+                      },
+                      "name": "map",
+                    },
+                    "what": Call {
+                      "arguments": Array [],
+                      "kind": "call",
+                      "loc": Location {
+                        "end": Position {
+                          "column": 18,
+                          "line": 4,
+                          "offset": 60,
+                        },
+                        "source": "$var
+          // Comment
+          ::each()",
+                        "start": Position {
+                          "column": 15,
+                          "line": 2,
+                          "offset": 16,
+                        },
+                      },
+                      "what": StaticLookup {
+                        "kind": "staticlookup",
+                        "loc": Location {
+                          "end": Position {
+                            "column": 16,
+                            "line": 4,
+                            "offset": 58,
+                          },
+                          "source": "$var
+          // Comment
+          ::each",
+                          "start": Position {
+                            "column": 15,
+                            "line": 2,
+                            "offset": 16,
+                          },
+                        },
+                        "offset": Identifier {
+                          "kind": "identifier",
+                          "loc": Location {
+                            "end": Position {
+                              "column": 16,
+                              "line": 4,
+                              "offset": 58,
+                            },
+                            "source": "each",
+                            "start": Position {
+                              "column": 12,
+                              "line": 4,
+                              "offset": 54,
+                            },
+                          },
+                          "name": "each",
+                        },
+                        "what": Variable {
+                          "byref": false,
+                          "curly": false,
+                          "kind": "variable",
+                          "loc": Location {
+                            "end": Position {
+                              "column": 19,
+                              "line": 2,
+                              "offset": 20,
+                            },
+                            "source": "$var",
+                            "start": Position {
+                              "column": 15,
+                              "line": 2,
+                              "offset": 16,
+                            },
+                          },
+                          "name": "var",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      "kind": "expressionstatement",
+      "loc": Location {
+        "end": Position {
+          "column": 19,
+          "line": 10,
+          "offset": 214,
+        },
+        "source": "$var = $var
+          // Comment
+          ::each() // Comment
+          // Comment
+          ::map() // Comment
+          // Comment
+          ::first() // Comment
+          // Comment
+          ::dump();",
+        "start": Position {
+          "column": 8,
+          "line": 2,
+          "offset": 9,
+        },
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+  "loc": Location {
+    "end": Position {
+      "column": 8,
+      "line": 11,
+      "offset": 223,
+    },
+    "source": "
+        $var = $var
+          // Comment
+          ::each() // Comment
+          // Comment
+          ::map() // Comment
+          // Comment
+          ::first() // Comment
+          // Comment
+          ::dump();
+        ",
     "start": Position {
       "column": 0,
       "line": 1,

--- a/test/snapshot/__snapshots__/namespace.test.js.snap
+++ b/test/snapshot/__snapshots__/namespace.test.js.snap
@@ -491,6 +491,7 @@ Program {
                   "offset": 68,
                 },
               },
+              "offset": 68,
               "value": "/**
        * @property \\\\Test\\\\test $test
        */",
@@ -562,6 +563,7 @@ Program {
           "offset": 68,
         },
       },
+      "offset": 68,
       "value": "/**
        * @property \\\\Test\\\\test $test
        */",

--- a/test/snapshot/__snapshots__/namespace.test.js.snap
+++ b/test/snapshot/__snapshots__/namespace.test.js.snap
@@ -62,7 +62,7 @@ Program {
       "name": ClassReference {
         "kind": "classreference",
         "name": "",
-        "resolution": "qn",
+        "resolution": "fqn",
       },
       "withBrackets": false,
     },
@@ -86,6 +86,37 @@ Program {
       "token": "'$var' (T_VARIABLE)",
     },
   ],
+  "kind": "program",
+}
+`;
+
+exports[`Test namespace statements fix #246 - doesn't work properly for \`FULL_QUALIFIED_NAME\` 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "obj",
+        },
+        "operator": "=",
+        "right": New {
+          "arguments": Array [],
+          "kind": "new",
+          "what": ClassReference {
+            "kind": "classreference",
+            "name": "\\\\Foo",
+            "resolution": "fqn",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
   "kind": "program",
 }
 `;
@@ -1119,7 +1150,7 @@ Program {
       "name": ClassReference {
         "kind": "classreference",
         "name": "",
-        "resolution": "qn",
+        "resolution": "fqn",
       },
       "withBrackets": false,
     },
@@ -1316,7 +1347,7 @@ Program {
               "name": ClassReference {
                 "kind": "classreference",
                 "name": "\\\\barBaz",
-                "resolution": "qn",
+                "resolution": "fqn",
               },
             },
           },

--- a/test/snapshot/__snapshots__/new.test.js.snap
+++ b/test/snapshot/__snapshots__/new.test.js.snap
@@ -201,7 +201,7 @@ Program {
         "what": ClassReference {
           "kind": "classreference",
           "name": "\\\\Foo",
-          "resolution": "qn",
+          "resolution": "fqn",
         },
       },
       "kind": "expressionstatement",
@@ -243,7 +243,7 @@ Program {
         "what": ClassReference {
           "kind": "classreference",
           "name": "\\\\Foo\\\\Foo",
-          "resolution": "qn",
+          "resolution": "fqn",
         },
       },
       "kind": "expressionstatement",

--- a/test/snapshot/__snapshots__/propertylookup.test.js.snap
+++ b/test/snapshot/__snapshots__/propertylookup.test.js.snap
@@ -29,6 +29,54 @@ Program {
 }
 `;
 
+exports[`propertylookup fix 128 - Don't have curly for propertylookup 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": PropertyLookup {
+        "kind": "propertylookup",
+        "offset": Literal {
+          "kind": "literal",
+          "value": Identifier {
+            "kind": "identifier",
+            "name": ClassReference {
+              "kind": "classreference",
+              "name": "foo",
+              "resolution": "uqn",
+            },
+          },
+        },
+        "what": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "this",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": PropertyLookup {
+        "kind": "propertylookup",
+        "offset": Identifier {
+          "kind": "identifier",
+          "name": "bar",
+        },
+        "what": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "this",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`propertylookup multiple 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/__snapshots__/string.test.js.snap
+++ b/test/snapshot/__snapshots__/string.test.js.snap
@@ -1114,6 +1114,82 @@ bar",
 }
 `;
 
+exports[`Test strings fix #251 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": Encapsed {
+          "kind": "encapsed",
+          "raw": "\\"string \${juices['FOO']} string\\"",
+          "type": "string",
+          "value": Array [
+            EncapsedPart {
+              "curly": false,
+              "expression": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "string ",
+                "unicode": false,
+                "value": "string ",
+              },
+              "kind": "encapsedpart",
+            },
+            EncapsedPart {
+              "curly": false,
+              "expression": Variable {
+                "byref": false,
+                "curly": true,
+                "kind": "variable",
+                "name": OffsetLookup {
+                  "kind": "offsetlookup",
+                  "offset": String {
+                    "isDoubleQuote": false,
+                    "kind": "string",
+                    "raw": "'FOO'",
+                    "unicode": false,
+                    "value": "FOO",
+                  },
+                  "what": Variable {
+                    "byref": false,
+                    "curly": false,
+                    "kind": "variable",
+                    "name": "juices",
+                  },
+                },
+              },
+              "kind": "encapsedpart",
+            },
+            EncapsedPart {
+              "curly": false,
+              "expression": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": " string",
+                "unicode": false,
+                "value": " string",
+              },
+              "kind": "encapsedpart",
+            },
+          ],
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`Test strings implement #116 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/__snapshots__/variable.test.js.snap
+++ b/test/snapshot/__snapshots__/variable.test.js.snap
@@ -1184,6 +1184,107 @@ Program {
 }
 `;
 
+exports[`Test variables fix 248 - broken ast for \`$$$$$\` 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": StaticLookup {
+        "kind": "staticlookup",
+        "offset": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": Variable {
+            "byref": false,
+            "curly": false,
+            "kind": "variable",
+            "name": "property",
+          },
+        },
+        "what": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "foo",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": StaticLookup {
+        "kind": "staticlookup",
+        "offset": Variable {
+          "byref": false,
+          "curly": true,
+          "kind": "variable",
+          "name": Variable {
+            "byref": false,
+            "curly": false,
+            "kind": "variable",
+            "name": "property",
+          },
+        },
+        "what": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "foo",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": PropertyLookup {
+        "kind": "propertylookup",
+        "offset": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": Variable {
+            "byref": false,
+            "curly": false,
+            "kind": "variable",
+            "name": "property",
+          },
+        },
+        "what": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "bar",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": PropertyLookup {
+        "kind": "propertylookup",
+        "offset": Variable {
+          "byref": false,
+          "curly": true,
+          "kind": "variable",
+          "name": Variable {
+            "byref": false,
+            "curly": false,
+            "kind": "variable",
+            "name": "property",
+          },
+        },
+        "what": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "bar",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`Test variables fix 253 - can't be parsed \`global\` with multiple \`$\` 1`] = `
 Program {
   "children": Array [
@@ -1231,7 +1332,12 @@ Program {
                 "byref": false,
                 "curly": false,
                 "kind": "variable",
-                "name": "property",
+                "name": Variable {
+                  "byref": false,
+                  "curly": false,
+                  "kind": "variable",
+                  "name": "property",
+                },
               },
             },
           },

--- a/test/snapshot/__snapshots__/variable.test.js.snap
+++ b/test/snapshot/__snapshots__/variable.test.js.snap
@@ -1184,6 +1184,31 @@ Program {
 }
 `;
 
+exports[`Test variables fix 253 - can't be parsed \`global\` with multiple \`$\` 1`] = `
+Program {
+  "children": Array [
+    Global {
+      "items": Array [
+        Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": Variable {
+            "byref": false,
+            "curly": false,
+            "kind": "variable",
+            "name": "foo",
+          },
+        },
+      ],
+      "kind": "global",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`Test variables valid offset lookup 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/__snapshots__/variable.test.js.snap
+++ b/test/snapshot/__snapshots__/variable.test.js.snap
@@ -1285,6 +1285,91 @@ Program {
 }
 `;
 
+exports[`Test variables fix 248 - test curly 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": PropertyLookup {
+        "kind": "propertylookup",
+        "offset": PropertyLookup {
+          "kind": "propertylookup",
+          "offset": Identifier {
+            "kind": "identifier",
+            "name": "foo",
+          },
+          "what": Variable {
+            "byref": false,
+            "curly": false,
+            "kind": "variable",
+            "name": "property",
+          },
+        },
+        "what": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "bar",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": PropertyLookup {
+        "kind": "propertylookup",
+        "offset": Variable {
+          "byref": false,
+          "curly": true,
+          "kind": "variable",
+          "name": Variable {
+            "byref": false,
+            "curly": false,
+            "kind": "variable",
+            "name": "property",
+          },
+        },
+        "what": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "bar",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": PropertyLookup {
+        "kind": "propertylookup",
+        "offset": Encapsed {
+          "kind": "encapsed",
+          "type": "offset",
+          "value": Array [
+            Identifier {
+              "kind": "identifier",
+              "name": "foo_",
+            },
+            Variable {
+              "byref": false,
+              "curly": false,
+              "kind": "variable",
+              "name": "property",
+            },
+          ],
+        },
+        "what": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "name": "bar",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`Test variables fix 253 - can't be parsed \`global\` with multiple \`$\` 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/__snapshots__/variable.test.js.snap
+++ b/test/snapshot/__snapshots__/variable.test.js.snap
@@ -889,20 +889,23 @@ Program {
           "kind": "call",
           "what": StaticLookup {
             "kind": "staticlookup",
-            "offset": OffsetLookup {
-              "kind": "offsetlookup",
-              "offset": String {
-                "isDoubleQuote": false,
-                "kind": "string",
-                "raw": "'baz'",
-                "unicode": false,
-                "value": "baz",
-              },
-              "what": Variable {
-                "byref": false,
-                "curly": false,
-                "kind": "variable",
-                "name": "bar",
+            "offset": Literal {
+              "kind": "literal",
+              "value": OffsetLookup {
+                "kind": "offsetlookup",
+                "offset": String {
+                  "isDoubleQuote": false,
+                  "kind": "string",
+                  "raw": "'baz'",
+                  "unicode": false,
+                  "value": "baz",
+                },
+                "what": Variable {
+                  "byref": false,
+                  "curly": false,
+                  "kind": "variable",
+                  "name": "bar",
+                },
               },
             },
             "what": ClassReference {
@@ -1259,11 +1262,9 @@ Program {
     ExpressionStatement {
       "expression": PropertyLookup {
         "kind": "propertylookup",
-        "offset": Variable {
-          "byref": false,
-          "curly": true,
-          "kind": "variable",
-          "name": Variable {
+        "offset": Literal {
+          "kind": "literal",
+          "value": Variable {
             "byref": false,
             "curly": false,
             "kind": "variable",
@@ -1291,17 +1292,20 @@ Program {
     ExpressionStatement {
       "expression": PropertyLookup {
         "kind": "propertylookup",
-        "offset": PropertyLookup {
-          "kind": "propertylookup",
-          "offset": Identifier {
-            "kind": "identifier",
-            "name": "foo",
-          },
-          "what": Variable {
-            "byref": false,
-            "curly": false,
-            "kind": "variable",
-            "name": "property",
+        "offset": Literal {
+          "kind": "literal",
+          "value": PropertyLookup {
+            "kind": "propertylookup",
+            "offset": Identifier {
+              "kind": "identifier",
+              "name": "foo",
+            },
+            "what": Variable {
+              "byref": false,
+              "curly": false,
+              "kind": "variable",
+              "name": "property",
+            },
           },
         },
         "what": Variable {
@@ -1316,11 +1320,9 @@ Program {
     ExpressionStatement {
       "expression": PropertyLookup {
         "kind": "propertylookup",
-        "offset": Variable {
-          "byref": false,
-          "curly": true,
-          "kind": "variable",
-          "name": Variable {
+        "offset": Literal {
+          "kind": "literal",
+          "value": Variable {
             "byref": false,
             "curly": false,
             "kind": "variable",

--- a/test/snapshot/comment.test.js
+++ b/test/snapshot/comment.test.js
@@ -2,6 +2,28 @@ const parser = require('../main');
 
 describe("Test comments", function() {
   describe("issues", function() {
+    it("fix #250 : Leading comments are treated as trailing comments", function() {
+      expect(parser.parseEval(
+        `
+// leading
+foo();
+// bar
+bar() /* inner */ ;
+// trailing
+        `,
+        {
+          parser: {
+            extractDoc: true
+            // debug: true
+          },
+          ast: {
+            withPositions: true,
+            withSource: true
+          }
+        }
+      )).toMatchSnapshot();
+    });
+
     it("fix #126 : new option", function() {
       const ast = parser.parseEval(
         `

--- a/test/snapshot/encapsed.test.js
+++ b/test/snapshot/encapsed.test.js
@@ -97,4 +97,7 @@ describe("encapsed", function() {
   it("staticlookup (3) (complex syntax)", function() {
     expect(parser.parseEval('"string {$obj::$var::$var} string";')).toMatchSnapshot();
   });
+  it("staticlookup (4) (complex syntax)", function() {
+    expect(parser.parseEval('"string {$var::$target::$resource::$binary::$foo::$bar::$foobar::$bar::$foo::$foobar::$bar::$foo} string";')).toMatchSnapshot();
+  });
 });

--- a/test/snapshot/location.test.js
+++ b/test/snapshot/location.test.js
@@ -1,10 +1,21 @@
-const parser = require('../main');
+const parser = require("../main");
 
-describe('Test locations', function() {
-  it('#230 : check location', function() {
+describe("Test locations", function() {
+  it("#230 : check location", function() {
+    expect(
+      parser.parseEval("$var1 + $var2 + $var3;", {
+        ast: {
+          withPositions: true,
+          withSource: true
+        }
+      })
+    ).toMatchSnapshot();
+  });
+  it("#230 : check location on retif", function() {
     expect(
       parser.parseEval(
-        '$var1 + $var2 + $var3;', {
+        "$var1 + $var2 ? true : $false ? $innerTrue : $innerFalse;",
+        {
           ast: {
             withPositions: true,
             withSource: true
@@ -13,67 +24,47 @@ describe('Test locations', function() {
       )
     ).toMatchSnapshot();
   });
-  it('#230 : check location on retif', function() {
+  it("#230 : check location on cast", function() {
     expect(
-      parser.parseEval(
-        '$var1 + $var2 ? true : $false ? $innerTrue : $innerFalse;', {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("(string)$var1 + $var2;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('#230 : check location on cast', function() {
+  it("#202 : include calling argument", function() {
     expect(
-      parser.parseEval(
-        '(string)$var1 + $var2;', {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("$foo->bar->baz($arg);", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('#202 : include calling argument', function() {
+  it("#164 : expr must include ;", function() {
     expect(
-      parser.parseEval(
-        '$foo->bar->baz($arg);', {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("$a = $b + 1;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('#164 : expr must include ;', function() {
+  it("#164 : expr should avoid ?>", function() {
     expect(
-      parser.parseEval(
-        '$a = $b + 1;', {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseCode("<?php $a = $b + 1 ?>", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('#164 : expr should avoid ?>', function() {
-    expect(
-      parser.parseCode(
-        '<?php $a = $b + 1 ?>', {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it('if/elseif/else', function() {
+  it("if/elseif/else", function() {
     expect(
       parser.parseEval(
         'if ($a > $b) echo "something"; elseif ($a < $b) echo "something"; else echo "something";',
@@ -86,7 +77,7 @@ describe('Test locations', function() {
       )
     ).toMatchSnapshot();
   });
-  it('if/elseif/else block', function() {
+  it("if/elseif/else block", function() {
     expect(
       parser.parseEval(
         'if ($a > $b) { echo "something"; } elseif ($a < $b) { echo "something"; } else { echo "something"; }',
@@ -99,867 +90,669 @@ describe('Test locations', function() {
       )
     ).toMatchSnapshot();
   });
-  it('switch', function() {
+  it("switch", function() {
     expect(
-      parser.parseEval(
-        'switch ($i) {}',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("switch ($i) {}", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('switch case', function() {
+  it("switch case", function() {
     expect(
-      parser.parseEval(
-        'switch ($i) { case 0: echo "something"; break; }',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('switch ($i) { case 0: echo "something"; break; }', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('switch default', function() {
+  it("switch default", function() {
     expect(
-      parser.parseEval(
-        'switch ($i) { default: echo "something"; }',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('switch ($i) { default: echo "something"; }', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('for', function() {
+  it("for", function() {
     expect(
-      parser.parseEval(
-        'for ($i = 1; $i <= 10; $i++) echo "something";',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('for ($i = 1; $i <= 10; $i++) echo "something";', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('for block', function() {
+  it("for block", function() {
     expect(
-      parser.parseEval(
-        'for ($i = 1; $i <= 10; $i++) { echo "something"; }',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('for ($i = 1; $i <= 10; $i++) { echo "something"; }', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('foreach', function() {
+  it("foreach", function() {
     expect(
-      parser.parseEval(
-        'foreach ($arr as $value) echo "something";',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('foreach ($arr as $value) echo "something";', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('foreach block', function() {
+  it("foreach block", function() {
     expect(
-      parser.parseEval(
-        'foreach ($arr as $value) { echo "something"; }',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('foreach ($arr as $value) { echo "something"; }', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('while', function() {
+  it("while", function() {
     expect(
-      parser.parseEval(
-        'while(true) echo "something";',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('while(true) echo "something";', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('while block', function() {
+  it("while block", function() {
     expect(
-      parser.parseEval(
-        'while(true) { echo "something"; }',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('while(true) { echo "something"; }', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('do', function() {
+  it("do", function() {
     expect(
-      parser.parseEval(
-        'do { echo $i; } while(true);',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("do { echo $i; } while(true);", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('return', function() {
+  it("return", function() {
     expect(
-      parser.parseEval(
-        'return 1;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("return 1;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
 
-  it('break', function() {
+  it("break", function() {
     expect(
-      parser.parseEval(
-        'break;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("break;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
 
-  it('continue', function() {
+  it("continue", function() {
     expect(
-      parser.parseEval(
-        'continue;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("continue;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('global', function() {
+  it("global", function() {
     expect(
-      parser.parseEval(
-        'global $a;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("global $a;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('static', function() {
+  it("static", function() {
     expect(
-      parser.parseEval(
-        'static $a = 1;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("static $a = 1;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('static multiple', function() {
+  it("static multiple", function() {
     expect(
-      parser.parseEval(
-        'static $a = 1, $b = 2, $c = 3;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("static $a = 1, $b = 2, $c = 3;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('echo', function() {
+  it("echo", function() {
     expect(
-      parser.parseEval(
-        'echo "something";',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('echo "something";', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('unset', function() {
+  it("unset", function() {
     expect(
-      parser.parseEval(
-        'unset($foo);',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("unset($foo);", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('declare', function() {
+  it("declare", function() {
     expect(
-      parser.parseEval(
-        'declare(ticks=1);',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("declare(ticks=1);", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('declare block', function() {
+  it("declare block", function() {
     expect(
-      parser.parseEval(
-        'declare(ticks=1) { echo "something"; }',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('declare(ticks=1) { echo "something"; }', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('try', function() {
+  it("try", function() {
     expect(
-      parser.parseEval(
-        'try new Exception();',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("try new Exception();", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('goto', function() {
+  it("goto", function() {
     expect(
-      parser.parseEval(
-        'goto a;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("goto a;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('label', function() {
+  it("label", function() {
     expect(
-      parser.parseEval(
-        'a: echo "something";',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('a: echo "something";', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('function', function() {
+  it("function", function() {
     expect(
-      parser.parseEval(
-        'function fn() { echo "something"; }',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('function fn() { echo "something"; }', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('class', function() {
+  it("class", function() {
     expect(
-      parser.parseEval(
-        'class Foo {}',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("class Foo {}", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('abstract class', function() {
+  it("abstract class", function() {
     expect(
-      parser.parseEval(
-        'abstract class Foo {}',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("abstract class Foo {}", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('final class', function() {
+  it("final class", function() {
     expect(
-      parser.parseEval(
-        'final class Foo {}',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("final class Foo {}", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('class (inner statement)', function() {
+  it("class (inner statement)", function() {
     expect(
-      parser.parseEval(
-        'function fn() { class Foo {} }',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("function fn() { class Foo {} }", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('abstract class (inner statement)', function() {
+  it("abstract class (inner statement)", function() {
     expect(
-      parser.parseEval(
-        'function fn() { abstract class Foo {} }',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("function fn() { abstract class Foo {} }", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('final class (inner statement)', function() {
+  it("final class (inner statement)", function() {
     expect(
-      parser.parseEval(
-        'function fn() { final class Foo {} }',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("function fn() { final class Foo {} }", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('interface', function() {
+  it("interface", function() {
     expect(
-      parser.parseEval(
-        'interface Foo {}',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("interface Foo {}", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('trait', function() {
+  it("trait", function() {
     expect(
-      parser.parseEval(
-        'trait Foo {}',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("trait Foo {}", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('namespace', function() {
+  it("namespace", function() {
     expect(
-      parser.parseEval(
-        'namespace my\\name;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("namespace my\\name;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('namespace backets', function() {
+  it("namespace backets", function() {
     expect(
-      parser.parseEval(
-        'namespace my\\name { echo "something"; }',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('namespace my\\name { echo "something"; }', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('string double quotes', function() {
+  it("string double quotes", function() {
     expect(
-      parser.parseEval(
-        '"string";',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('"string";', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('string single quotes', function() {
+  it("string single quotes", function() {
     expect(
-      parser.parseEval(
-        '\'string\';',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("'string';", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('number', function() {
+  it("number", function() {
     expect(
-      parser.parseEval(
-        '2112;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("2112;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('negative number', function() {
+  it("negative number", function() {
     expect(
-      parser.parseEval(
-        '-2112;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("-2112;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('magic', function() {
+  it("magic", function() {
     expect(
-      parser.parseEval(
-        '__DIR__;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("__DIR__;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('ternary', function() {
+  it("ternary", function() {
     expect(
-      parser.parseEval(
-        '$valid ? "yes" : "no";',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('$valid ? "yes" : "no";', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('ternary no true expression', function() {
+  it("ternary no true expression", function() {
     expect(
-      parser.parseEval(
-        '$valid ?: "no";',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('$valid ?: "no";', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('variable', function() {
+  it("variable", function() {
     expect(
-      parser.parseEval(
-        '$var;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("$var;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('assign', function() {
+  it("assign", function() {
     expect(
-      parser.parseEval(
-        '$var = true;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("$var = true;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('assign mutliple', function() {
+  it("assign mutliple", function() {
     expect(
-      parser.parseEval(
-        '$var = $other = true;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("$var = $other = true;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('unary', function() {
+  it("unary", function() {
     expect(
-      parser.parseEval(
-        '!$var;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("!$var;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('pre', function() {
+  it("pre", function() {
     expect(
-      parser.parseEval(
-        '++$var;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("++$var;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('post', function() {
+  it("post", function() {
     expect(
-      parser.parseEval(
-        '$var++;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("$var++;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('yield', function() {
+  it("yield", function() {
     expect(
-      parser.parseEval(
-        'yield $var;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("yield $var;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('yield from', function() {
+  it("yield from", function() {
     expect(
-      parser.parseEval(
-        'yield from from();',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("yield from from();", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('bin', function() {
+  it("bin", function() {
     expect(
-      parser.parseEval(
-        '$var = $var + 100;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("$var = $var + 100;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('array', function() {
+  it("array", function() {
     expect(
-      parser.parseEval(
-        'array(1, 2, 3);',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("array(1, 2, 3);", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('array nested', function() {
+  it("array nested", function() {
     expect(
-      parser.parseEval(
-        'array(array(1, 2, 3));',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("array(array(1, 2, 3));", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('array short form', function() {
+  it("array short form", function() {
     expect(
-      parser.parseEval(
-        '[1, 2, 3];',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("[1, 2, 3];", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('array short form nested', function() {
+  it("array short form nested", function() {
     expect(
-      parser.parseEval(
-        '[[1, 2, 3]];',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("[[1, 2, 3]];", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('clone', function() {
+  it("clone", function() {
     expect(
-      parser.parseEval(
-        'clone $var;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("clone $var;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('new', function() {
+  it("new", function() {
     expect(
-      parser.parseEval(
-        'new Foo();',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("new Foo();", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('new anonymous class', function() {
+  it("new anonymous class", function() {
     expect(
-      parser.parseEval(
-        '$var = new class {};',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("$var = new class {};", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('eval', function() {
+  it("eval", function() {
     expect(
-      parser.parseEval(
-        'eval("code");',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('eval("code");', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('exit', function() {
+  it("exit", function() {
     expect(
-      parser.parseEval(
-        'exit(1);',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("exit(1);", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('print', function() {
+  it("print", function() {
     expect(
-      parser.parseEval(
-        'print "something";',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('print "something";', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('include', function() {
+  it("include", function() {
     expect(
-      parser.parseEval(
-        'include "something";',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('include "something";', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('isset', function() {
+  it("isset", function() {
     expect(
-      parser.parseEval(
-        '$var = isset($var);',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("$var = isset($var);", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('empty', function() {
+  it("empty", function() {
     expect(
-      parser.parseEval(
-        '$var = empty($var);',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("$var = empty($var);", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('silent', function() {
+  it("silent", function() {
     expect(
-      parser.parseEval(
-        '$var = @call();',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("$var = @call();", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('variadic', function() {
+  it("variadic", function() {
     expect(
-      parser.parseEval(
-        'call(...$var);',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("call(...$var);", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('try/catch/finally', function() {
+  it("try/catch/finally", function() {
     expect(
-      parser.parseEval(
-        'try {} catch (Exception $e) {} finally {}',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("try {} catch (Exception $e) {} finally {}", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('nowdoc', function() {
+  it("nowdoc", function() {
     expect(
       parser.parseEval(
         `<<<'EOD'
@@ -974,7 +767,7 @@ EOD;`,
       )
     ).toMatchSnapshot();
   });
-  it('nowdoc assign', function() {
+  it("nowdoc assign", function() {
     expect(
       parser.parseEval(
         `$var = <<<'EOD'
@@ -989,7 +782,7 @@ EOD;`,
       )
     ).toMatchSnapshot();
   });
-  it('encapsed heredoc', function() {
+  it("encapsed heredoc", function() {
     expect(
       parser.parseEval(
         `<<<EOD
@@ -1004,7 +797,7 @@ EOD;`,
       )
     ).toMatchSnapshot();
   });
-  it('encapsed heredoc assign', function() {
+  it("encapsed heredoc assign", function() {
     expect(
       parser.parseEval(
         `$var = <<<EOD
@@ -1019,20 +812,17 @@ EOD;`,
       )
     ).toMatchSnapshot();
   });
-  it('encapsed shell', function() {
+  it("encapsed shell", function() {
     expect(
-      parser.parseEval(
-        '$var = `command`;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("$var = `command`;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('encapsed shell multiline', function() {
+  it("encapsed shell multiline", function() {
     expect(
       parser.parseEval(
         `$var = \`
@@ -1049,33 +839,27 @@ command;
       )
     ).toMatchSnapshot();
   });
-  it('encapsed string', function() {
+  it("encapsed string", function() {
     expect(
-      parser.parseEval(
-        '"string $var string";',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('"string $var string";', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('encapsed string assign', function() {
+  it("encapsed string assign", function() {
     expect(
-      parser.parseEval(
-        '$var = "string $var string";',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('$var = "string $var string";', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('encapsed string multiline', function() {
+  it("encapsed string multiline", function() {
     expect(
       parser.parseEval(
         `$var = "string
@@ -1090,10 +874,50 @@ string";`,
       )
     ).toMatchSnapshot();
   });
-  it('list', function() {
+  it("list", function() {
+    expect(
+      parser.parseEval("list($a, $b, $c) = $var;", {
+        ast: {
+          withPositions: true,
+          withSource: true
+        }
+      })
+    ).toMatchSnapshot();
+  });
+  it("list short form", function() {
+    expect(
+      parser.parseEval("[$a, $b, $c] = $var;", {
+        ast: {
+          withPositions: true,
+          withSource: true
+        }
+      })
+    ).toMatchSnapshot();
+  });
+  it("traituse", function() {
+    expect(
+      parser.parseEval("class Foo { use Hello; }", {
+        ast: {
+          withPositions: true,
+          withSource: true
+        }
+      })
+    ).toMatchSnapshot();
+  });
+  it("traituse multiple", function() {
+    expect(
+      parser.parseEval("class Foo { use Hello, World; }", {
+        ast: {
+          withPositions: true,
+          withSource: true
+        }
+      })
+    ).toMatchSnapshot();
+  });
+  it("traituse adaptations", function() {
     expect(
       parser.parseEval(
-        'list($a, $b, $c) = $var;',
+        "class Foo { use A, B { B::smallTalk insteadof A;  B::bigTalk as talk; sayHello as protected; sayHello as private myPrivateHello; } }",
         {
           ast: {
             withPositions: true,
@@ -1103,10 +927,50 @@ string";`,
       )
     ).toMatchSnapshot();
   });
-  it('list short form', function() {
+  it("method", function() {
+    expect(
+      parser.parseEval("class Foo { function method() {} }", {
+        ast: {
+          withPositions: true,
+          withSource: true
+        }
+      })
+    ).toMatchSnapshot();
+  });
+  it("method (public)", function() {
+    expect(
+      parser.parseEval("class Foo { public function method() {} }", {
+        ast: {
+          withPositions: true,
+          withSource: true
+        }
+      })
+    ).toMatchSnapshot();
+  });
+  it("cast", function() {
+    expect(
+      parser.parseEval('$var = (int) "2112"', {
+        ast: {
+          withPositions: true,
+          withSource: true
+        }
+      })
+    ).toMatchSnapshot();
+  });
+  it("retif", function() {
+    expect(
+      parser.parseEval("$var = $var ? true : false;", {
+        ast: {
+          withPositions: true,
+          withSource: true
+        }
+      })
+    ).toMatchSnapshot();
+  });
+  it("retif nested", function() {
     expect(
       parser.parseEval(
-        '[$a, $b, $c] = $var;',
+        "$var = ($one ? true : false) ? ($two ? true : false) : ($three ? true : false);",
         {
           ast: {
             withPositions: true,
@@ -1116,189 +980,67 @@ string";`,
       )
     ).toMatchSnapshot();
   });
-  it('traituse', function() {
+  it("parameter", function() {
     expect(
-      parser.parseEval(
-        'class Foo { use Hello; }',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("function fn(?int $foo = 2112) {}", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('traituse multiple', function() {
+  it("bin", function() {
     expect(
-      parser.parseEval(
-        'class Foo { use Hello, World; }',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("$var + 2112;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('traituse adaptations', function() {
+  it("bin nested", function() {
     expect(
-      parser.parseEval(
-        'class Foo { use A, B { B::smallTalk insteadof A;  B::bigTalk as talk; sayHello as protected; sayHello as private myPrivateHello; } }',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("$var + 2112 + $var;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('method', function() {
+  it("bin nested (2)", function() {
     expect(
-      parser.parseEval(
-        'class Foo { function method() {} }',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("$var + $var + 2112;", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('method (public)', function() {
+  it("silent", function() {
     expect(
-      parser.parseEval(
-        'class Foo { public function method() {} }',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval("@call();", {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('cast', function() {
+  it("conststatement", function() {
     expect(
-      parser.parseEval(
-        '$var = (int) "2112"',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
+      parser.parseEval('const CONSTANT = "Hello world!";', {
+        ast: {
+          withPositions: true,
+          withSource: true
         }
-      )
+      })
     ).toMatchSnapshot();
   });
-  it('retif', function() {
-    expect(
-      parser.parseEval(
-        '$var = $var ? true : false;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it('retif nested', function() {
-    expect(
-      parser.parseEval(
-        '$var = ($one ? true : false) ? ($two ? true : false) : ($three ? true : false);',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it('parameter', function() {
-    expect(
-      parser.parseEval(
-        'function fn(?int $foo = 2112) {}',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it('bin', function() {
-    expect(
-      parser.parseEval(
-        '$var + 2112;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it('bin nested', function() {
-    expect(
-      parser.parseEval(
-        '$var + 2112 + $var;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it('bin nested (2)', function() {
-    expect(
-      parser.parseEval(
-        '$var + $var + 2112;',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it('silent', function() {
-    expect(
-      parser.parseEval(
-        '@call();',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it('conststatement', function() {
-    expect(
-      parser.parseEval(
-        'const CONSTANT = "Hello world!";',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it('conststatement multiple', function() {
+  it("conststatement multiple", function() {
     expect(
       parser.parseEval(
         'const CONSTANT = "Hello world!", OTHER_CONSTANT = "Other hello world!";',
@@ -1316,5 +1058,74 @@ string";`,
   });
   it("declare directive (multiple)", function() {
     expect(parser.parseEval("declare (A='B', C='D') { }")).toMatchSnapshot();
+  });
+  it("propertylookup", function() {
+    expect(
+      parser.parseEval(
+        `
+        $var = $var
+          // Comment
+          ->each() // Comment
+          // Comment
+          ->map() // Comment
+          // Comment
+          ->first() // Comment
+          // Comment
+          ->dump();
+        `,
+        {
+          ast: {
+            withPositions: true,
+            withSource: true
+          }
+        }
+      )
+    ).toMatchSnapshot();
+  });
+  it("staticlookup", function() {
+    expect(
+      parser.parseEval(
+        `
+        $var = $var
+          // Comment
+          ::each() // Comment
+          // Comment
+          ::map() // Comment
+          // Comment
+          ::first() // Comment
+          // Comment
+          ::dump();
+        `,
+        {
+          ast: {
+            withPositions: true,
+            withSource: true
+          }
+        }
+      )
+    ).toMatchSnapshot();
+  });
+  it("offsetlookup", function() {
+    expect(
+      parser.parseEval(
+        `
+        $var = $var
+          // Comment
+          ['foo'] // Comment
+          // Comment
+          ['bar'] // Comment
+          // Comment
+          ['baz'] // Comment
+          // Comment
+          ['qqq'];
+        `,
+        {
+          ast: {
+            withPositions: true,
+            withSource: true
+          }
+        }
+      )
+    ).toMatchSnapshot();
   });
 });

--- a/test/snapshot/location.test.js
+++ b/test/snapshot/location.test.js
@@ -1111,7 +1111,7 @@ string";`,
         `
         $var = $var
           // Comment
-          ['foo'] // Comment
+          [ 'foo' ] // Comment
           // Comment
           ['bar'] // Comment
           // Comment

--- a/test/snapshot/namespace.test.js
+++ b/test/snapshot/namespace.test.js
@@ -1,6 +1,11 @@
 const parser = require('../main');
 
 describe("Test namespace statements", function() {
+  it("fix #246 - doesn't work properly for `FULL_QUALIFIED_NAME`", function() {
+    expect(parser.parseEval(`
+      $obj = new \\Foo();
+    `)).toMatchSnapshot();
+  });
   it("allow trailing comma for grouped namespaces #177", function() {
     expect(parser.parseEval(`
     use Foo\\Bar\\ {

--- a/test/snapshot/propertylookup.test.js
+++ b/test/snapshot/propertylookup.test.js
@@ -1,6 +1,9 @@
 const parser = require('../main');
 
 describe("propertylookup", function() {
+  it("fix 128 - Don't have curly for propertylookup", function() {
+    expect(parser.parseEval('$this->{foo};$this->bar;')).toMatchSnapshot();
+  });
   it("simple", function() {
     expect(parser.parseEval('$obj->property;')).toMatchSnapshot();
   });

--- a/test/snapshot/string.test.js
+++ b/test/snapshot/string.test.js
@@ -1,6 +1,11 @@
 const parser = require("../main");
 
 describe("Test strings", function() {
+
+  it("fix #251", function() {
+    expect(parser.parseEval('$var = "string ${juices[\'FOO\']} string";')).toMatchSnapshot();
+  });
+
   it("fix #144", function() {
     expect(parser.parseEval('"encapsed \\" {$var}";')).toMatchSnapshot();
   });

--- a/test/snapshot/variable.test.js
+++ b/test/snapshot/variable.test.js
@@ -1,6 +1,13 @@
 const parser = require('../main');
 
 describe("Test variables", function() {
+  it("fix 253 - can't be parsed `global` with multiple `$`", function() {
+    expect(parser.parseEval(`
+      global $$foo;
+    `
+    )).toMatchSnapshot();
+  });
+
   it("array destructuring", function() {
     expect(parser.parseEval("[$id1, $name1] = $data[0];")).toMatchSnapshot();
   });

--- a/test/snapshot/variable.test.js
+++ b/test/snapshot/variable.test.js
@@ -18,6 +18,15 @@ describe("Test variables", function() {
     )).toMatchSnapshot();
   });
   
+  it("fix 248 - test curly", function() {
+    expect(parser.parseEval(`
+      $bar->{$property->foo};
+      $bar->\${$property};
+      $bar->foo_{$property};
+    `
+    )).toMatchSnapshot();
+  });
+
 
   it("array destructuring", function() {
     expect(parser.parseEval("[$id1, $name1] = $data[0];")).toMatchSnapshot();

--- a/test/snapshot/variable.test.js
+++ b/test/snapshot/variable.test.js
@@ -8,6 +8,17 @@ describe("Test variables", function() {
     )).toMatchSnapshot();
   });
 
+  it("fix 248 - broken ast for `$$$$$`", function() {
+    expect(parser.parseEval(`
+      $foo::$$property;
+      $foo::\${$property};
+      $bar->$$property;
+      $bar->\${$property};
+    `
+    )).toMatchSnapshot();
+  });
+  
+
   it("array destructuring", function() {
     expect(parser.parseEval("[$id1, $name1] = $data[0];")).toMatchSnapshot();
   });


### PR DESCRIPTION
We already do same for `propertylookup`. It is allow for prettier format comment like:

```php
$var = $var
    // Comment
    ::each() // Comment
    // Comment
    ::map() // Comment
    // Comment
    ::first() // Comment
    // Comment
    ::dump();
```