### PR TITLE
fix: better ast for constants

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -296,8 +296,12 @@ AST.prototype.resolvePrecedence = function(result, parser) {
         result = buffer;
       }
     }
-  } else if (result.kind === "silent" && result.expr.right && !result.expr.parenthesizedExpression) {
-    // overall least precedence 
+  } else if (
+    result.kind === "silent" &&
+    result.expr.right &&
+    !result.expr.parenthesizedExpression
+  ) {
+    // overall least precedence
     buffer = result.expr;
     result.expr = buffer.left;
     buffer.left = result;

--- a/src/ast/classconstant.js
+++ b/src/ast/classconstant.js
@@ -21,12 +21,12 @@ const IS_PRIVATE = "private";
  */
 const ClassConstant = ConstantStatement.extends(KIND, function ClassConstant(
   kind,
-  items,
+  constants,
   flags,
   docs,
   location
 ) {
-  ConstantStatement.apply(this, [kind || KIND, items, docs, location]);
+  ConstantStatement.apply(this, [kind || KIND, constants, docs, location]);
   this.parseFlags(flags);
 });
 

--- a/src/ast/constantstatement.js
+++ b/src/ast/constantstatement.js
@@ -12,14 +12,14 @@ const KIND = "constantstatement";
  * Declares a constants into the current scope
  * @constructor ConstantStatement
  * @extends {Statement}
- * @property {Constant[]} items
+ * @property {Constant[]} constants
  */
 module.exports = Statement.extends(KIND, function ConstantStatement(
   kind,
-  items,
+  constants,
   docs,
   location
 ) {
   Statement.apply(this, [kind || KIND, docs, location]);
-  this.items = items;
+  this.constants = constants;
 });

--- a/src/parser/class.js
+++ b/src/parser/class.js
@@ -180,21 +180,23 @@ module.exports = {
        */
       function read_constant_declaration() {
         const result = this.node("constant");
-        let name = null;
+        let constName = null;
         let value = null;
         if (
           this.token === this.tok.T_STRING ||
           (this.php7 && this.is("IDENTIFIER"))
         ) {
-          name = this.text();
+          constName = this.node("identifier");
+          const name = this.text();
           this.next();
+          constName = constName(name);
         } else {
           this.expect("IDENTIFIER");
         }
         if (this.expect("=")) {
           value = this.next().read_expr();
         }
-        return result(name, value);
+        return result(constName, value);
       },
       ","
     );

--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -98,22 +98,24 @@ module.exports = {
    * ```
    */
   read_const_list: function() {
-    const result = this.read_list(
+    return this.read_list(
       function() {
         this.expect(this.tok.T_STRING);
         const result = this.node("constant");
+        let constName = this.node("identifier");
         const name = this.text();
-        if (this.next().expect("=")) {
-          return result(name, this.next().read_expr());
+        this.next();
+        constName = constName(name);
+        if (this.expect("=")) {
+          return result(constName, this.next().read_expr());
         } else {
           // fallback
-          return result(name, null);
+          return result(constName, null);
         }
       },
       ",",
       false
     );
-    return result;
   },
   /**
    * Reads a list of constants declaration

--- a/test/snapshot/__snapshots__/acid.test.js.snap
+++ b/test/snapshot/__snapshots__/acid.test.js.snap
@@ -391,7 +391,7 @@ Program {
           "type": null,
         },
         ConstantStatement {
-          "items": Array [
+          "constants": Array [
             Constant {
               "kind": "constant",
               "loc": Location {
@@ -407,7 +407,23 @@ Program {
                   "offset": 340,
                 },
               },
-              "name": "FOOBAR",
+              "name": Identifier {
+                "kind": "identifier",
+                "loc": Location {
+                  "end": Position {
+                    "column": 14,
+                    "line": 20,
+                    "offset": 346,
+                  },
+                  "source": "FOOBAR",
+                  "start": Position {
+                    "column": 8,
+                    "line": 20,
+                    "offset": 340,
+                  },
+                },
+                "name": "FOOBAR",
+              },
               "value": String {
                 "isDoubleQuote": false,
                 "kind": "string",
@@ -658,7 +674,7 @@ Program {
               ],
             },
             ClassConstant {
-              "items": Array [
+              "constants": Array [
                 Constant {
                   "kind": "constant",
                   "loc": Location {
@@ -674,7 +690,23 @@ Program {
                       "offset": 544,
                     },
                   },
-                  "name": "FOOBAR",
+                  "name": Identifier {
+                    "kind": "identifier",
+                    "loc": Location {
+                      "end": Position {
+                        "column": 16,
+                        "line": 31,
+                        "offset": 550,
+                      },
+                      "source": "FOOBAR",
+                      "start": Position {
+                        "column": 10,
+                        "line": 31,
+                        "offset": 544,
+                      },
+                    },
+                    "name": "FOOBAR",
+                  },
                   "value": String {
                     "isDoubleQuote": false,
                     "kind": "string",

--- a/test/snapshot/__snapshots__/ast.test.js.snap
+++ b/test/snapshot/__snapshots__/ast.test.js.snap
@@ -199,10 +199,13 @@ exports[`Test AST structure test constants 1`] = `
 Program {
   "children": Array [
     ConstantStatement {
-      "items": Array [
+      "constants": Array [
         Constant {
           "kind": "constant",
-          "name": "FOO",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "FOO",
+          },
           "value": Number {
             "kind": "number",
             "value": "3.14",

--- a/test/snapshot/__snapshots__/class.test.js.snap
+++ b/test/snapshot/__snapshots__/class.test.js.snap
@@ -128,10 +128,13 @@ Program {
     Interface {
       "body": Array [
         ClassConstant {
-          "items": Array [
+          "constants": Array [
             Constant {
               "kind": "constant",
-              "name": "A",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "A",
+              },
               "value": Number {
                 "kind": "number",
                 "value": "1.5",
@@ -189,10 +192,13 @@ Program {
     Trait {
       "body": Array [
         ClassConstant {
-          "items": Array [
+          "constants": Array [
             Constant {
               "kind": "constant",
-              "name": "A",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "A",
+              },
               "value": Number {
                 "kind": "number",
                 "value": "1.5",
@@ -655,10 +661,13 @@ Program {
     Class {
       "body": Array [
         ClassConstant {
-          "items": Array [
+          "constants": Array [
             Constant {
               "kind": "constant",
-              "name": "FOO",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "FOO",
+              },
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -748,10 +757,13 @@ Program {
           "visibility": "public",
         },
         ClassConstant {
-          "items": Array [
+          "constants": Array [
             Constant {
               "kind": "constant",
-              "name": "list",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "list",
+              },
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",

--- a/test/snapshot/__snapshots__/classconstant.test.js.snap
+++ b/test/snapshot/__snapshots__/classconstant.test.js.snap
@@ -6,10 +6,13 @@ Program {
     Class {
       "body": Array [
         ClassConstant {
-          "items": Array [
+          "constants": Array [
             Constant {
               "kind": "constant",
-              "name": "CONSTANT",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "CONSTANT",
+              },
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -20,7 +23,10 @@ Program {
             },
             Constant {
               "kind": "constant",
-              "name": "OTHER_CONSTANT",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "OTHER_CONSTANT",
+              },
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -57,10 +63,13 @@ Program {
     Class {
       "body": Array [
         ClassConstant {
-          "items": Array [
+          "constants": Array [
             Constant {
               "kind": "constant",
-              "name": "CONSTANT",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "CONSTANT",
+              },
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -97,10 +106,13 @@ Program {
     Class {
       "body": Array [
         ClassConstant {
-          "items": Array [
+          "constants": Array [
             Constant {
               "kind": "constant",
-              "name": "CONSTANT",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "CONSTANT",
+              },
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -137,10 +149,13 @@ Program {
     Class {
       "body": Array [
         ClassConstant {
-          "items": Array [
+          "constants": Array [
             Constant {
               "kind": "constant",
-              "name": "CONSTANT",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "CONSTANT",
+              },
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -177,10 +192,13 @@ Program {
     Class {
       "body": Array [
         ClassConstant {
-          "items": Array [
+          "constants": Array [
             Constant {
               "kind": "constant",
-              "name": "CONSTANT",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "CONSTANT",
+              },
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",

--- a/test/snapshot/__snapshots__/constantstatement.test.js.snap
+++ b/test/snapshot/__snapshots__/constantstatement.test.js.snap
@@ -4,10 +4,13 @@ exports[`constantstatement multiple 1`] = `
 Program {
   "children": Array [
     ConstantStatement {
-      "items": Array [
+      "constants": Array [
         Constant {
           "kind": "constant",
-          "name": "CONSTANT",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "CONSTANT",
+          },
           "value": String {
             "isDoubleQuote": true,
             "kind": "string",
@@ -18,7 +21,10 @@ Program {
         },
         Constant {
           "kind": "constant",
-          "name": "OTHER_CONSTANT",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "OTHER_CONSTANT",
+          },
           "value": String {
             "isDoubleQuote": true,
             "kind": "string",
@@ -40,10 +46,13 @@ exports[`constantstatement simple 1`] = `
 Program {
   "children": Array [
     ConstantStatement {
-      "items": Array [
+      "constants": Array [
         Constant {
           "kind": "constant",
-          "name": "CONSTANT",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "CONSTANT",
+          },
           "value": String {
             "isDoubleQuote": true,
             "kind": "string",

--- a/test/snapshot/__snapshots__/graceful.test.js.snap
+++ b/test/snapshot/__snapshots__/graceful.test.js.snap
@@ -193,10 +193,13 @@ Program {
     Class {
       "body": Array [
         ClassConstant {
-          "items": Array [
+          "constants": Array [
             Constant {
               "kind": "constant",
-              "name": "A",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "A",
+              },
               "value": Number {
                 "kind": "number",
                 "value": "1",

--- a/test/snapshot/__snapshots__/location.test.js.snap
+++ b/test/snapshot/__snapshots__/location.test.js.snap
@@ -2598,7 +2598,7 @@ exports[`Test locations conststatement 1`] = `
 Program {
   "children": Array [
     ConstantStatement {
-      "items": Array [
+      "constants": Array [
         Constant {
           "kind": "constant",
           "loc": Location {
@@ -2614,7 +2614,23 @@ Program {
               "offset": 6,
             },
           },
-          "name": "CONSTANT",
+          "name": Identifier {
+            "kind": "identifier",
+            "loc": Location {
+              "end": Position {
+                "column": 14,
+                "line": 1,
+                "offset": 14,
+              },
+              "source": "CONSTANT",
+              "start": Position {
+                "column": 6,
+                "line": 1,
+                "offset": 6,
+              },
+            },
+            "name": "CONSTANT",
+          },
           "value": String {
             "isDoubleQuote": true,
             "kind": "string",
@@ -2675,7 +2691,7 @@ exports[`Test locations conststatement multiple 1`] = `
 Program {
   "children": Array [
     ConstantStatement {
-      "items": Array [
+      "constants": Array [
         Constant {
           "kind": "constant",
           "loc": Location {
@@ -2691,7 +2707,23 @@ Program {
               "offset": 6,
             },
           },
-          "name": "CONSTANT",
+          "name": Identifier {
+            "kind": "identifier",
+            "loc": Location {
+              "end": Position {
+                "column": 14,
+                "line": 1,
+                "offset": 14,
+              },
+              "source": "CONSTANT",
+              "start": Position {
+                "column": 6,
+                "line": 1,
+                "offset": 6,
+              },
+            },
+            "name": "CONSTANT",
+          },
           "value": String {
             "isDoubleQuote": true,
             "kind": "string",
@@ -2728,7 +2760,23 @@ Program {
               "offset": 33,
             },
           },
-          "name": "OTHER_CONSTANT",
+          "name": Identifier {
+            "kind": "identifier",
+            "loc": Location {
+              "end": Position {
+                "column": 47,
+                "line": 1,
+                "offset": 47,
+              },
+              "source": "OTHER_CONSTANT",
+              "start": Position {
+                "column": 33,
+                "line": 1,
+                "offset": 33,
+              },
+            },
+            "name": "OTHER_CONSTANT",
+          },
           "value": String {
             "isDoubleQuote": true,
             "kind": "string",


### PR DESCRIPTION
fixes #255

- Rename `items` to `constants` (`items` some misleading)
- Use `identifier` for constant name