### PR TITLE
Fix regression for empty offsetlookup

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -217,7 +217,7 @@ AST.prototype.resolvePrecedence = function(result, parser) {
   } else if (
     result.kind === "propertylookup" ||
     result.kind === "staticlookup" ||
-    result.kind === "offsetlookup"
+    (result.kind === "offsetlookup" && result.offset)
   ) {
     // including what argument into location
     this.resolveLocations(result, result.what, result.offset, parser);

--- a/test/snapshot/__snapshots__/location.test.js.snap
+++ b/test/snapshot/__snapshots__/location.test.js.snap
@@ -1501,6 +1501,116 @@ Program {
 }
 `;
 
+exports[`Test locations assign [] 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": OffsetLookup {
+          "kind": "offsetlookup",
+          "loc": Location {
+            "end": Position {
+              "column": 6,
+              "line": 1,
+              "offset": 6,
+            },
+            "source": "[]",
+            "start": Position {
+              "column": 4,
+              "line": 1,
+              "offset": 4,
+            },
+          },
+          "offset": false,
+          "what": Variable {
+            "byref": false,
+            "curly": false,
+            "kind": "variable",
+            "loc": Location {
+              "end": Position {
+                "column": 4,
+                "line": 1,
+                "offset": 4,
+              },
+              "source": "$var",
+              "start": Position {
+                "column": 0,
+                "line": 1,
+                "offset": 0,
+              },
+            },
+            "name": "var",
+          },
+        },
+        "loc": Location {
+          "end": Position {
+            "column": 13,
+            "line": 1,
+            "offset": 13,
+          },
+          "source": "$var[] = $var",
+          "start": Position {
+            "column": 0,
+            "line": 1,
+            "offset": 0,
+          },
+        },
+        "operator": "=",
+        "right": Variable {
+          "byref": false,
+          "curly": false,
+          "kind": "variable",
+          "loc": Location {
+            "end": Position {
+              "column": 13,
+              "line": 1,
+              "offset": 13,
+            },
+            "source": "$var",
+            "start": Position {
+              "column": 9,
+              "line": 1,
+              "offset": 9,
+            },
+          },
+          "name": "var",
+        },
+      },
+      "kind": "expressionstatement",
+      "loc": Location {
+        "end": Position {
+          "column": 13,
+          "line": 1,
+          "offset": 13,
+        },
+        "source": "$var[] = $var",
+        "start": Position {
+          "column": 0,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+  "loc": Location {
+    "end": Position {
+      "column": 13,
+      "line": 1,
+      "offset": 13,
+    },
+    "source": "$var[] = $var",
+    "start": Position {
+      "column": 0,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+}
+`;
+
 exports[`Test locations assign 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/location.test.js
+++ b/test/snapshot/location.test.js
@@ -1128,4 +1128,14 @@ string";`,
       )
     ).toMatchSnapshot();
   });
+  it("assign []", function() {
+    expect(
+      parser.parseEval(`$var[] = $var`, {
+        ast: {
+          withPositions: true,
+          withSource: true
+        }
+      })
+    ).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Hi @ichiriac,

I'm currently updating prettier for PHP to the latest version of the parser, and noticed a regression introduced in https://github.com/glayzzle/php-parser/commit/3f20511d3459a9297c99e75a1c6c86424de87512:

Input: `$var[] = "var"`

Error:
```
TypeError: Cannot read property 'end' of undefined

      at AST.Object.<anonymous>.AST.resolveLocations (node_modules/php-parser/src/ast.js:196:42)
```
This is my attempt to fix it :wink: 