### PR TITLE
test: break and continue

### DIFF
--- a/test/snapshot/__snapshots__/break.test.js.snap
+++ b/test/snapshot/__snapshots__/break.test.js.snap
@@ -60,3 +60,37 @@ Program {
   "kind": "program",
 }
 `;
+
+exports[`break with parens 1`] = `
+Program {
+  "children": Array [
+    Break {
+      "kind": "break",
+      "level": Number {
+        "kind": "number",
+        "parenthesizedExpression": true,
+        "value": "1",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`break with var 1`] = `
+Program {
+  "children": Array [
+    Break {
+      "kind": "break",
+      "level": Variable {
+        "curly": false,
+        "kind": "variable",
+        "name": "var",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;

--- a/test/snapshot/__snapshots__/continue.test.js.snap
+++ b/test/snapshot/__snapshots__/continue.test.js.snap
@@ -60,3 +60,37 @@ Program {
   "kind": "program",
 }
 `;
+
+exports[`continue with expression 1`] = `
+Program {
+  "children": Array [
+    Continue {
+      "kind": "continue",
+      "level": Variable {
+        "curly": false,
+        "kind": "variable",
+        "name": "var",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`continue with parens 1`] = `
+Program {
+  "children": Array [
+    Continue {
+      "kind": "continue",
+      "level": Number {
+        "kind": "number",
+        "parenthesizedExpression": true,
+        "value": "1",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;

--- a/test/snapshot/break.test.js
+++ b/test/snapshot/break.test.js
@@ -13,4 +13,11 @@ describe('break', () => {
   it('argument 2', () => {
     expect(parser.parseEval('break 2;')).toMatchSnapshot();
   });
+  it('with parens', () => {
+    expect(parser.parseEval('break (1);')).toMatchSnapshot();
+  });
+  // Deprecated since 5.4.0
+  it('with expression', () => {
+    expect(parser.parseEval('break $var;')).toMatchSnapshot();
+  });
 });

--- a/test/snapshot/continue.test.js
+++ b/test/snapshot/continue.test.js
@@ -13,4 +13,11 @@ describe('continue', () => {
   it('argument 2', () => {
     expect(parser.parseEval('continue 2;')).toMatchSnapshot();
   });
+  it('with parens', () => {
+    expect(parser.parseEval('continue (1);')).toMatchSnapshot();
+  });
+  // Deprecated since 5.4.0
+  it('with expression', () => {
+    expect(parser.parseEval('continue $var;')).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
before 5.4.0 it is possible to have `expr` in these nodes (https://github.com/php/php-src/blob/php-7.4.0beta4/Zend/zend_language_parser.y#L437), just test