### PR TITLE
fix: don't add unnecessary `noop`

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -323,18 +323,15 @@ AST.prototype.resolvePrecedence = function(result, parser) {
         result = buffer;
       }
     }
-  } else if (
-    result.kind === "silent" &&
-    !result.expr.parenthesizedExpression
-  ) {
-    if (result.expr.kind === 'assign') return result;
+  } else if (result.kind === "silent" && !result.expr.parenthesizedExpression) {
+    if (result.expr.kind === "assign") return result;
     // overall least precedence
     if (result.expr.right) {
       buffer = result.expr;
       result.expr = buffer.left;
       buffer.left = result;
       this.swapLocations(buffer, buffer.left, buffer.right, parser);
-      result = buffer;  
+      result = buffer;
     }
   }
   return result;

--- a/src/parser/array.js
+++ b/src/parser/array.js
@@ -64,10 +64,12 @@ module.exports = {
    */
   read_array_pair: function(shortForm) {
     if (
-      this.token === "," ||
       (!shortForm && this.token === ")") ||
       (shortForm && this.token === "]")
     ) {
+      return;
+    }
+    if (this.token === ",") {
       return this.node("noop")();
     }
     if (this.token === "&") {

--- a/src/parser/utils.js
+++ b/src/parser/utils.js
@@ -40,7 +40,6 @@ module.exports = {
         break;
       }
       if (this.next().token == ")" && this.php73) {
-        result.push(this.node("noop")());
         break;
       }
     } while (this.token != this.EOF);
@@ -65,7 +64,10 @@ module.exports = {
 
     if (typeof item === "function") {
       do {
-        result.push(item.apply(this, []));
+        const itemResult = item.apply(this, []);
+        if (itemResult) {
+          result.push(itemResult);
+        }
         if (this.token != separator) {
           break;
         }

--- a/test/snapshot/__snapshots__/array.test.js.snap
+++ b/test/snapshot/__snapshots__/array.test.js.snap
@@ -1,5 +1,427 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Array without keys array with empty values #2 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Array {
+        "items": Array [
+          Noop {
+            "kind": "noop",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'foo'",
+            "unicode": false,
+            "value": "foo",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'bar'",
+            "unicode": false,
+            "value": "bar",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'baz'",
+            "unicode": false,
+            "value": "baz",
+          },
+        ],
+        "kind": "array",
+        "shortForm": true,
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Array without keys array with empty values #3 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Array {
+        "items": Array [
+          Noop {
+            "kind": "noop",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'foo'",
+            "unicode": false,
+            "value": "foo",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'bar'",
+            "unicode": false,
+            "value": "bar",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'baz'",
+            "unicode": false,
+            "value": "baz",
+          },
+          Noop {
+            "kind": "noop",
+          },
+        ],
+        "kind": "array",
+        "shortForm": true,
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Array without keys array with empty values 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Array {
+        "items": Array [
+          Noop {
+            "kind": "noop",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'foo'",
+            "unicode": false,
+            "value": "foo",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'bar'",
+            "unicode": false,
+            "value": "bar",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'baz'",
+            "unicode": false,
+            "value": "baz",
+          },
+        ],
+        "kind": "array",
+        "shortForm": true,
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Array without keys array with multiple trailing commas #2 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Array {
+        "items": Array [
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'foo'",
+            "unicode": false,
+            "value": "foo",
+          },
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'bar'",
+            "unicode": false,
+            "value": "bar",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          Noop {
+            "kind": "noop",
+          },
+          Noop {
+            "kind": "noop",
+          },
+        ],
+        "kind": "array",
+        "shortForm": true,
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Array without keys array with multiple trailing commas 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Array {
+        "items": Array [
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'foo'",
+            "unicode": false,
+            "value": "foo",
+          },
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'bar'",
+            "unicode": false,
+            "value": "bar",
+          },
+          Noop {
+            "kind": "noop",
+          },
+        ],
+        "kind": "array",
+        "shortForm": true,
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Array without keys array with trailing commas #2 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Array {
+        "items": Array [
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'foo'",
+            "unicode": false,
+            "value": "foo",
+          },
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'bar'",
+            "unicode": false,
+            "value": "bar",
+          },
+        ],
+        "kind": "array",
+        "shortForm": true,
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Array without keys array with trailing commas #3 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Array {
+        "items": Array [
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'foo'",
+            "unicode": false,
+            "value": "foo",
+          },
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'bar'",
+            "unicode": false,
+            "value": "bar",
+          },
+        ],
+        "kind": "array",
+        "shortForm": true,
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Array without keys array with trailing commas 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Array {
+        "items": Array [
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'foo'",
+            "unicode": false,
+            "value": "foo",
+          },
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'bar'",
+            "unicode": false,
+            "value": "bar",
+          },
+        ],
+        "kind": "array",
+        "shortForm": true,
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Array without keys array without trailing commas 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Array {
+        "items": Array [
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'foo'",
+            "unicode": false,
+            "value": "foo",
+          },
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'bar'",
+            "unicode": false,
+            "value": "bar",
+          },
+        ],
+        "kind": "array",
+        "shortForm": true,
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Array without keys array without trailing commas 2`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Array {
+        "items": Array [
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'foo'",
+            "unicode": false,
+            "value": "foo",
+          },
+          String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'bar'",
+            "unicode": false,
+            "value": "bar",
+          },
+        ],
+        "kind": "array",
+        "shortForm": true,
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`Array without keys deference array 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/__snapshots__/call.test.js.snap
+++ b/test/snapshot/__snapshots__/call.test.js.snap
@@ -1174,6 +1174,121 @@ Program {
 }
 `;
 
+exports[`Test call trailing comma #2 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Call {
+        "arguments": Array [
+          String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "raw": "\\"method\\"",
+            "unicode": false,
+            "value": "method",
+          },
+          String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "raw": "\\"bar\\"",
+            "unicode": false,
+            "value": "bar",
+          },
+        ],
+        "kind": "call",
+        "what": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "foo",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test call trailing comma #3 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Call {
+        "arguments": Array [
+          String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "raw": "\\"method\\"",
+            "unicode": false,
+            "value": "method",
+          },
+          String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "raw": "\\"bar\\"",
+            "unicode": false,
+            "value": "bar",
+          },
+        ],
+        "kind": "call",
+        "what": PropertyLookup {
+          "kind": "propertylookup",
+          "offset": Identifier {
+            "kind": "identifier",
+            "name": "bar",
+          },
+          "what": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "foo",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test call trailing comma 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Call {
+        "arguments": Array [
+          String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "raw": "\\"method\\"",
+            "unicode": false,
+            "value": "method",
+          },
+          String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "raw": "\\"bar\\"",
+            "unicode": false,
+            "value": "bar",
+          },
+        ],
+        "kind": "call",
+        "what": ClassReference {
+          "kind": "classreference",
+          "name": "foo",
+          "resolution": "uqn",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`Test call variable function (2) 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/__snapshots__/graceful.test.js.snap
+++ b/test/snapshot/__snapshots__/graceful.test.js.snap
@@ -506,9 +506,6 @@ Program {
             "kind": "variable",
             "name": "arg",
           },
-          Noop {
-            "kind": "noop",
-          },
         ],
         "kind": "call",
         "what": PropertyLookup {

--- a/test/snapshot/__snapshots__/isset.test.js.snap
+++ b/test/snapshot/__snapshots__/isset.test.js.snap
@@ -84,3 +84,52 @@ Program {
   "kind": "program",
 }
 `;
+
+exports[`isset trailing comma #2 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Isset {
+        "kind": "isset",
+        "variables": Array [
+          Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "foo",
+          },
+          Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "bar",
+          },
+        ],
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`isset trailing comma 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Isset {
+        "kind": "isset",
+        "variables": Array [
+          Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "foo",
+          },
+        ],
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;

--- a/test/snapshot/__snapshots__/list.test.js.snap
+++ b/test/snapshot/__snapshots__/list.test.js.snap
@@ -1,5 +1,476 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Test list expressions array with empty values #2 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": List {
+          "items": Array [
+            Noop {
+              "kind": "noop",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'foo'",
+              "unicode": false,
+              "value": "foo",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'bar'",
+              "unicode": false,
+              "value": "bar",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'baz'",
+              "unicode": false,
+              "value": "baz",
+            },
+          ],
+          "kind": "list",
+          "shortForm": true,
+        },
+        "operator": "=",
+        "right": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "a",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test list expressions array with empty values #3 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": List {
+          "items": Array [
+            Noop {
+              "kind": "noop",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'foo'",
+              "unicode": false,
+              "value": "foo",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'bar'",
+              "unicode": false,
+              "value": "bar",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'baz'",
+              "unicode": false,
+              "value": "baz",
+            },
+            Noop {
+              "kind": "noop",
+            },
+          ],
+          "kind": "list",
+          "shortForm": true,
+        },
+        "operator": "=",
+        "right": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "a",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test list expressions array with empty values 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": List {
+          "items": Array [
+            Noop {
+              "kind": "noop",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'foo'",
+              "unicode": false,
+              "value": "foo",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'bar'",
+              "unicode": false,
+              "value": "bar",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'baz'",
+              "unicode": false,
+              "value": "baz",
+            },
+          ],
+          "kind": "list",
+          "shortForm": true,
+        },
+        "operator": "=",
+        "right": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "a",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test list expressions array with multiple trailing commas #2 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": List {
+          "items": Array [
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'foo'",
+              "unicode": false,
+              "value": "foo",
+            },
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'bar'",
+              "unicode": false,
+              "value": "bar",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            Noop {
+              "kind": "noop",
+            },
+            Noop {
+              "kind": "noop",
+            },
+          ],
+          "kind": "list",
+          "shortForm": true,
+        },
+        "operator": "=",
+        "right": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "a",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test list expressions array with multiple trailing commas 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": List {
+          "items": Array [
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'foo'",
+              "unicode": false,
+              "value": "foo",
+            },
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'bar'",
+              "unicode": false,
+              "value": "bar",
+            },
+            Noop {
+              "kind": "noop",
+            },
+          ],
+          "kind": "list",
+          "shortForm": true,
+        },
+        "operator": "=",
+        "right": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "a",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test list expressions array with trailing commas #2 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": List {
+          "items": Array [
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'foo'",
+              "unicode": false,
+              "value": "foo",
+            },
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'bar'",
+              "unicode": false,
+              "value": "bar",
+            },
+          ],
+          "kind": "list",
+          "shortForm": true,
+        },
+        "operator": "=",
+        "right": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "a",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test list expressions array with trailing commas #3 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": List {
+          "items": Array [
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'foo'",
+              "unicode": false,
+              "value": "foo",
+            },
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'bar'",
+              "unicode": false,
+              "value": "bar",
+            },
+          ],
+          "kind": "list",
+          "shortForm": true,
+        },
+        "operator": "=",
+        "right": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "a",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test list expressions array with trailing commas 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": List {
+          "items": Array [
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'foo'",
+              "unicode": false,
+              "value": "foo",
+            },
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'bar'",
+              "unicode": false,
+              "value": "bar",
+            },
+          ],
+          "kind": "list",
+          "shortForm": true,
+        },
+        "operator": "=",
+        "right": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "a",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test list expressions array without trailing commas 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": List {
+          "items": Array [
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'foo'",
+              "unicode": false,
+              "value": "foo",
+            },
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'bar'",
+              "unicode": false,
+              "value": "bar",
+            },
+          ],
+          "kind": "list",
+          "shortForm": true,
+        },
+        "operator": "=",
+        "right": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "a",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`Test list expressions fix #137 1`] = `
 Program {
   "children": Array [
@@ -339,6 +810,47 @@ Program {
 }
 `;
 
+exports[`Test list expressions list without trailing commas 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": List {
+          "items": Array [
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'foo'",
+              "unicode": false,
+              "value": "foo",
+            },
+            String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'bar'",
+              "unicode": false,
+              "value": "bar",
+            },
+          ],
+          "kind": "list",
+          "shortForm": true,
+        },
+        "operator": "=",
+        "right": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "a",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`Test list expressions test list statements 1`] = `
 Program {
   "children": Array [
@@ -451,22 +963,6 @@ Program {
                       },
                     },
                     "name": "e",
-                  },
-                  Noop {
-                    "kind": "noop",
-                    "loc": Location {
-                      "end": Position {
-                        "column": 26,
-                        "line": 1,
-                        "offset": 26,
-                      },
-                      "source": null,
-                      "start": Position {
-                        "column": 26,
-                        "line": 1,
-                        "offset": 26,
-                      },
-                    },
                   },
                 ],
                 "kind": "list",
@@ -736,22 +1232,6 @@ Program {
                     },
                     "name": "e",
                   },
-                  Noop {
-                    "kind": "noop",
-                    "loc": Location {
-                      "end": Position {
-                        "column": 18,
-                        "line": 1,
-                        "offset": 18,
-                      },
-                      "source": null,
-                      "start": Position {
-                        "column": 18,
-                        "line": 1,
-                        "offset": 18,
-                      },
-                    },
-                  },
                 ],
                 "kind": "array",
                 "loc": Location {
@@ -939,22 +1419,6 @@ Program {
                       },
                     },
                     "value": "9",
-                  },
-                  Noop {
-                    "kind": "noop",
-                    "loc": Location {
-                      "end": Position {
-                        "column": 48,
-                        "line": 1,
-                        "offset": 48,
-                      },
-                      "source": null,
-                      "start": Position {
-                        "column": 48,
-                        "line": 1,
-                        "offset": 48,
-                      },
-                    },
                   },
                 ],
                 "kind": "array",

--- a/test/snapshot/__snapshots__/new.test.js.snap
+++ b/test/snapshot/__snapshots__/new.test.js.snap
@@ -332,6 +332,42 @@ Program {
 }
 `;
 
+exports[`new trailing comma 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": New {
+        "arguments": Array [
+          String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "raw": "\\"constructor\\"",
+            "unicode": false,
+            "value": "constructor",
+          },
+          String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "raw": "\\"bar\\"",
+            "unicode": false,
+            "value": "bar",
+          },
+        ],
+        "kind": "new",
+        "what": ClassReference {
+          "kind": "classreference",
+          "name": "Foo",
+          "resolution": "uqn",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`new variable 1`] = `
 Program {
   "children": Array [
@@ -343,6 +379,42 @@ Program {
           "curly": false,
           "kind": "variable",
           "name": "var",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`new with arguments 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": New {
+        "arguments": Array [
+          String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "raw": "\\"constructor\\"",
+            "unicode": false,
+            "value": "constructor",
+          },
+          String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "raw": "\\"bar\\"",
+            "unicode": false,
+            "value": "bar",
+          },
+        ],
+        "kind": "new",
+        "what": ClassReference {
+          "kind": "classreference",
+          "name": "Foo",
+          "resolution": "uqn",
         },
       },
       "kind": "expressionstatement",

--- a/test/snapshot/__snapshots__/php73.test.js.snap
+++ b/test/snapshot/__snapshots__/php73.test.js.snap
@@ -115,9 +115,6 @@ Program {
               "kind": "array",
               "shortForm": true,
             },
-            Noop {
-              "kind": "noop",
-            },
           ],
           "kind": "call",
           "what": ClassReference {
@@ -154,9 +151,6 @@ Program {
               "unicode": false,
               "value": "bar",
             },
-            Noop {
-              "kind": "noop",
-            },
           ],
           "kind": "new",
           "what": ClassReference {
@@ -184,9 +178,6 @@ Program {
             "raw": "'bar'",
             "unicode": false,
             "value": "bar",
-          },
-          Noop {
-            "kind": "noop",
           },
         ],
         "kind": "call",
@@ -222,9 +213,6 @@ Program {
             "unicode": false,
             "value": "bar",
           },
-          Noop {
-            "kind": "noop",
-          },
         ],
         "kind": "call",
         "what": Variable {
@@ -248,9 +236,6 @@ Program {
           "kind": "variable",
           "name": "bar",
         },
-        Noop {
-          "kind": "noop",
-        },
       ],
     },
     ExpressionStatement {
@@ -268,9 +253,6 @@ Program {
                 "curly": false,
                 "kind": "variable",
                 "name": "bar",
-              },
-              Noop {
-                "kind": "noop",
               },
             ],
           },

--- a/test/snapshot/__snapshots__/unset.test.js.snap
+++ b/test/snapshot/__snapshots__/unset.test.js.snap
@@ -47,3 +47,46 @@ Program {
   "kind": "program",
 }
 `;
+
+exports[`unset trailing comma #2 1`] = `
+Program {
+  "children": Array [
+    Unset {
+      "kind": "unset",
+      "variables": Array [
+        Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "foo",
+        },
+        Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "bar",
+        },
+      ],
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`unset trailing comma 1`] = `
+Program {
+  "children": Array [
+    Unset {
+      "kind": "unset",
+      "variables": Array [
+        Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "foo",
+        },
+      ],
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;

--- a/test/snapshot/array.test.js
+++ b/test/snapshot/array.test.js
@@ -62,4 +62,44 @@ describe('Array without keys', () => {
   it("single and empty (short form)", () => {
     expect(parser.parseEval("[]")).toMatchSnapshot();
   });
+
+  it("array without trailing commas", () => {
+    expect(parser.parseEval("['foo', 'bar']")).toMatchSnapshot();
+  });
+
+  it("array without trailing commas", () => {
+    expect(parser.parseEval("['foo', 'bar']")).toMatchSnapshot();
+  });
+
+  it("array with trailing commas", () => {
+    expect(parser.parseEval("['foo', 'bar',]")).toMatchSnapshot();
+  });
+
+  it("array with trailing commas #2", () => {
+    expect(parser.parseEval("['foo', 'bar'   ,]")).toMatchSnapshot();
+  });
+
+  it("array with trailing commas #3", () => {
+    expect(parser.parseEval("['foo', 'bar'   ,   ]")).toMatchSnapshot();
+  });
+
+  it("array with multiple trailing commas", () => {
+    expect(parser.parseEval("['foo', 'bar',,]")).toMatchSnapshot();
+  });
+
+  it("array with multiple trailing commas #2", () => {
+    expect(parser.parseEval("['foo', 'bar',,,,,]")).toMatchSnapshot();
+  });
+
+  it("array with empty values", () => {
+    expect(parser.parseEval("[,,,'foo',,, 'bar',,,'baz']")).toMatchSnapshot();
+  });
+
+  it("array with empty values #2", () => {
+    expect(parser.parseEval("[,,,'foo',,, 'bar',,,'baz',]")).toMatchSnapshot();
+  });
+
+  it("array with empty values #3", () => {
+    expect(parser.parseEval("[,,,'foo',,, 'bar',,,'baz',,]")).toMatchSnapshot();
+  });
 });

--- a/test/snapshot/call.test.js
+++ b/test/snapshot/call.test.js
@@ -298,4 +298,31 @@ describe("Test call", function() {
     );
     expect(ast).toMatchSnapshot();
   });
+  it("trailing comma", function() {
+    const ast = parser.parseEval(
+        'foo("method", "bar",);',
+        {
+          parser: { debug: false }
+        }
+    );
+    expect(ast).toMatchSnapshot();
+  });
+  it("trailing comma #2", function() {
+    const ast = parser.parseEval(
+        '$foo("method", "bar",);',
+        {
+          parser: { debug: false }
+        }
+    );
+    expect(ast).toMatchSnapshot();
+  });
+  it("trailing comma #3", function() {
+    const ast = parser.parseEval(
+        '$foo->bar("method", "bar",);',
+        {
+          parser: { debug: false }
+        }
+    );
+    expect(ast).toMatchSnapshot();
+  });
 });

--- a/test/snapshot/isset.test.js
+++ b/test/snapshot/isset.test.js
@@ -10,4 +10,10 @@ describe("isset", function() {
   it("assign", function() {
     expect(parser.parseEval('$var = isset($var);')).toMatchSnapshot();
   });
+  it("trailing comma", function() {
+    expect(parser.parseEval('isset($foo,);')).toMatchSnapshot();
+  });
+  it("trailing comma #2", function() {
+    expect(parser.parseEval('isset($foo, $bar,);')).toMatchSnapshot();
+  });
 });

--- a/test/snapshot/list.test.js
+++ b/test/snapshot/list.test.js
@@ -31,4 +31,44 @@ describe("Test list expressions", function() {
     });
     expect(ast).toMatchSnapshot();
   });
+
+  it("list without trailing commas", () => {
+    expect(parser.parseEval("['foo', 'bar'] = $a")).toMatchSnapshot();
+  });
+
+  it("array without trailing commas", () => {
+    expect(parser.parseEval("['foo', 'bar'] = $a")).toMatchSnapshot();
+  });
+
+  it("array with trailing commas", () => {
+    expect(parser.parseEval("['foo', 'bar',] = $a")).toMatchSnapshot();
+  });
+
+  it("array with trailing commas #2", () => {
+    expect(parser.parseEval("['foo', 'bar'   ,] = $a")).toMatchSnapshot();
+  });
+
+  it("array with trailing commas #3", () => {
+    expect(parser.parseEval("['foo', 'bar'   ,   ] = $a")).toMatchSnapshot();
+  });
+
+  it("array with multiple trailing commas", () => {
+    expect(parser.parseEval("['foo', 'bar',,] = $a")).toMatchSnapshot();
+  });
+
+  it("array with multiple trailing commas #2", () => {
+    expect(parser.parseEval("['foo', 'bar',,,,,] = $a")).toMatchSnapshot();
+  });
+
+  it("array with empty values", () => {
+    expect(parser.parseEval("[,,,'foo',,, 'bar',,,'baz'] = $a")).toMatchSnapshot();
+  });
+
+  it("array with empty values #2", () => {
+    expect(parser.parseEval("[,,,'foo',,, 'bar',,,'baz',] = $a")).toMatchSnapshot();
+  });
+
+  it("array with empty values #3", () => {
+    expect(parser.parseEval("[,,,'foo',,, 'bar',,,'baz',,] = $a")).toMatchSnapshot();
+  });
 });

--- a/test/snapshot/new.test.js
+++ b/test/snapshot/new.test.js
@@ -47,4 +47,10 @@ describe("new", function() {
   it("static", function() {
     expect(parser.parseEval('new static();')).toMatchSnapshot();
   });
+  it("with arguments", function() {
+    expect(parser.parseEval('new Foo("constructor", "bar");')).toMatchSnapshot();
+  });
+  it("trailing comma", function() {
+    expect(parser.parseEval('new Foo("constructor", "bar",);')).toMatchSnapshot();
+  });
 });

--- a/test/snapshot/unset.test.js
+++ b/test/snapshot/unset.test.js
@@ -7,4 +7,10 @@ describe("unset", function() {
   it("multiple", function() {
     expect(parser.parseEval('unset($var, $var, $var);')).toMatchSnapshot();
   });
+  it("trailing comma", function() {
+    expect(parser.parseEval('unset($foo,);')).toMatchSnapshot();
+  });
+  it("trailing comma #2", function() {
+    expect(parser.parseEval('unset($foo, $bar,);')).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
fixes #358

No one parsers do it, it is unnecessary node, of somebody can check `trailing comma` exists or not can use `loc` and source code for this