### PR TITLE
fix: curly offsetlookup

### DIFF
--- a/src/parser/utils.js
+++ b/src/parser/utils.js
@@ -116,7 +116,7 @@ module.exports = {
     const result = cb();
     if (result) {
       this.ast.swapLocations(result, byref, result, this);
-      result.byref = true;  
+      result.byref = true;
     }
     return result;
   },

--- a/test/snapshot/__snapshots__/break.test.js.snap
+++ b/test/snapshot/__snapshots__/break.test.js.snap
@@ -61,6 +61,23 @@ Program {
 }
 `;
 
+exports[`break with expression 1`] = `
+Program {
+  "children": Array [
+    Break {
+      "kind": "break",
+      "level": Variable {
+        "curly": false,
+        "kind": "variable",
+        "name": "var",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`break with parens 1`] = `
 Program {
   "children": Array [
@@ -70,23 +87,6 @@ Program {
         "kind": "number",
         "parenthesizedExpression": true,
         "value": "1",
-      },
-    },
-  ],
-  "errors": Array [],
-  "kind": "program",
-}
-`;
-
-exports[`break with var 1`] = `
-Program {
-  "children": Array [
-    Break {
-      "kind": "break",
-      "level": Variable {
-        "curly": false,
-        "kind": "variable",
-        "name": "var",
       },
     },
   ],

--- a/test/snapshot/__snapshots__/expr.test.js.snap
+++ b/test/snapshot/__snapshots__/expr.test.js.snap
@@ -114,44 +114,37 @@ Program {
             "kind": "identifier",
             "name": "foo",
           },
-          "what": PropertyLookup {
-            "kind": "propertylookup",
-            "offset": Encapsed {
-              "kind": "encapsed",
-              "type": "offset",
-              "value": Array [
-                Identifier {
-                  "kind": "identifier",
-                  "name": "bar",
-                },
-                EncapsedPart {
-                  "curly": true,
-                  "expression": Variable {
+          "what": OffsetLookup {
+            "kind": "offsetlookup",
+            "offset": Variable {
+              "curly": false,
+              "kind": "variable",
+              "name": "baz",
+            },
+            "what": PropertyLookup {
+              "kind": "propertylookup",
+              "offset": Identifier {
+                "kind": "identifier",
+                "name": "bar",
+              },
+              "what": Call {
+                "arguments": Array [
+                  Variable {
                     "curly": false,
                     "kind": "variable",
-                    "name": "baz",
+                    "name": "foo",
                   },
-                  "kind": "encapsedpart",
-                },
-              ],
-            },
-            "what": Call {
-              "arguments": Array [
-                Variable {
-                  "curly": false,
-                  "kind": "variable",
-                  "name": "foo",
-                },
-              ],
-              "kind": "call",
-              "what": Post {
-                "kind": "post",
-                "parenthesizedExpression": true,
-                "type": "+",
-                "what": Variable {
-                  "curly": false,
-                  "kind": "variable",
-                  "name": "a",
+                ],
+                "kind": "call",
+                "what": Post {
+                  "kind": "post",
+                  "parenthesizedExpression": true,
+                  "type": "+",
+                  "what": Variable {
+                    "curly": false,
+                    "kind": "variable",
+                    "name": "a",
+                  },
                 },
               },
             },

--- a/test/snapshot/__snapshots__/graceful.test.js.snap
+++ b/test/snapshot/__snapshots__/graceful.test.js.snap
@@ -145,6 +145,108 @@ Program {
 }
 `;
 
+exports[`Test graceful mode to suppress errors should fail with '[' and '}' 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": OffsetLookup {
+        "kind": "offsetlookup",
+        "offset": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "bar",
+        },
+        "what": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "obj",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": undefined,
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": "]",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '}', expecting ']' on line 1",
+      "token": "'}'",
+    },
+    Error {
+      "expected": ";",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '}', expecting ';' on line 1",
+      "token": "'}'",
+    },
+    Error {
+      "expected": "EXPR",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '}' on line 1",
+      "token": "'}'",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
+exports[`Test graceful mode to suppress errors should fail with '{' and ']' 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": OffsetLookup {
+        "kind": "offsetlookup",
+        "offset": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "foo",
+        },
+        "what": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "obj",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": undefined,
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": "}",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected ']', expecting '}' on line 1",
+      "token": "']'",
+    },
+    Error {
+      "expected": ";",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected ']', expecting ';' on line 1",
+      "token": "']'",
+    },
+    Error {
+      "expected": "EXPR",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected ']' on line 1",
+      "token": "']'",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
 exports[`Test graceful mode to suppress errors staticlookup 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/__snapshots__/offsetlookup.test.js.snap
+++ b/test/snapshot/__snapshots__/offsetlookup.test.js.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`offsetlookup call (curly) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Call {
+        "arguments": Array [],
+        "kind": "call",
+        "what": OffsetLookup {
+          "kind": "offsetlookup",
+          "offset": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "var",
+          },
+          "what": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "obj",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`offsetlookup call 1`] = `
 Program {
   "children": Array [
@@ -13,6 +42,341 @@ Program {
             "curly": false,
             "kind": "variable",
             "name": "var",
+          },
+          "what": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "obj",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`offsetlookup inside propertylookup (curly) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": OffsetLookup {
+        "kind": "offsetlookup",
+        "offset": Number {
+          "kind": "number",
+          "value": "1",
+        },
+        "what": PropertyLookup {
+          "kind": "propertylookup",
+          "offset": Identifier {
+            "kind": "identifier",
+            "name": "bzr_",
+          },
+          "what": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "foo",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": OffsetLookup {
+        "kind": "offsetlookup",
+        "offset": String {
+          "isDoubleQuote": false,
+          "kind": "string",
+          "raw": "'string'",
+          "unicode": false,
+          "value": "string",
+        },
+        "what": PropertyLookup {
+          "kind": "propertylookup",
+          "offset": Identifier {
+            "kind": "identifier",
+            "name": "bzr_",
+          },
+          "what": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "foo",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": OffsetLookup {
+        "kind": "offsetlookup",
+        "offset": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "baz",
+        },
+        "what": PropertyLookup {
+          "kind": "propertylookup",
+          "offset": Identifier {
+            "kind": "identifier",
+            "name": "bzr_",
+          },
+          "what": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "foo",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": OffsetLookup {
+        "kind": "offsetlookup",
+        "offset": PropertyLookup {
+          "kind": "propertylookup",
+          "offset": Identifier {
+            "kind": "identifier",
+            "name": "foo",
+          },
+          "what": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "baz",
+          },
+        },
+        "what": PropertyLookup {
+          "kind": "propertylookup",
+          "offset": Identifier {
+            "kind": "identifier",
+            "name": "bzr_",
+          },
+          "what": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "foo",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": OffsetLookup {
+        "kind": "offsetlookup",
+        "offset": RetIf {
+          "falseExpr": String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'two'",
+            "unicode": false,
+            "value": "two",
+          },
+          "kind": "retif",
+          "test": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "var",
+          },
+          "trueExpr": String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'one'",
+            "unicode": false,
+            "value": "one",
+          },
+        },
+        "what": PropertyLookup {
+          "kind": "propertylookup",
+          "offset": Identifier {
+            "kind": "identifier",
+            "name": "bzr_",
+          },
+          "what": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "foo",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`offsetlookup inside propertylookup 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": OffsetLookup {
+        "kind": "offsetlookup",
+        "offset": Number {
+          "kind": "number",
+          "value": "1",
+        },
+        "what": PropertyLookup {
+          "kind": "propertylookup",
+          "offset": Identifier {
+            "kind": "identifier",
+            "name": "bzr_",
+          },
+          "what": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "foo",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": OffsetLookup {
+        "kind": "offsetlookup",
+        "offset": String {
+          "isDoubleQuote": false,
+          "kind": "string",
+          "raw": "'string'",
+          "unicode": false,
+          "value": "string",
+        },
+        "what": PropertyLookup {
+          "kind": "propertylookup",
+          "offset": Identifier {
+            "kind": "identifier",
+            "name": "bzr_",
+          },
+          "what": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "foo",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": OffsetLookup {
+        "kind": "offsetlookup",
+        "offset": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "baz",
+        },
+        "what": PropertyLookup {
+          "kind": "propertylookup",
+          "offset": Identifier {
+            "kind": "identifier",
+            "name": "bzr_",
+          },
+          "what": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "foo",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": OffsetLookup {
+        "kind": "offsetlookup",
+        "offset": PropertyLookup {
+          "kind": "propertylookup",
+          "offset": Identifier {
+            "kind": "identifier",
+            "name": "foo",
+          },
+          "what": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "baz",
+          },
+        },
+        "what": PropertyLookup {
+          "kind": "propertylookup",
+          "offset": Identifier {
+            "kind": "identifier",
+            "name": "bzr_",
+          },
+          "what": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "foo",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": OffsetLookup {
+        "kind": "offsetlookup",
+        "offset": RetIf {
+          "falseExpr": String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'two'",
+            "unicode": false,
+            "value": "two",
+          },
+          "kind": "retif",
+          "test": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "var",
+          },
+          "trueExpr": String {
+            "isDoubleQuote": false,
+            "kind": "string",
+            "raw": "'one'",
+            "unicode": false,
+            "value": "one",
+          },
+        },
+        "what": PropertyLookup {
+          "kind": "propertylookup",
+          "offset": Identifier {
+            "kind": "identifier",
+            "name": "bzr_",
+          },
+          "what": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "foo",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`offsetlookup multiple (curly) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": OffsetLookup {
+        "kind": "offsetlookup",
+        "offset": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"second\\"",
+          "unicode": false,
+          "value": "second",
+        },
+        "what": OffsetLookup {
+          "kind": "offsetlookup",
+          "offset": String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "raw": "\\"first\\"",
+            "unicode": false,
+            "value": "first",
           },
           "what": Variable {
             "curly": false,
@@ -66,6 +430,33 @@ Program {
 }
 `;
 
+exports[`offsetlookup simple (curly) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": OffsetLookup {
+        "kind": "offsetlookup",
+        "offset": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"index\\"",
+          "unicode": false,
+          "value": "index",
+        },
+        "what": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "obj",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`offsetlookup simple 1`] = `
 Program {
   "children": Array [
@@ -78,6 +469,31 @@ Program {
           "raw": "\\"index\\"",
           "unicode": false,
           "value": "index",
+        },
+        "what": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "obj",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`offsetlookup variable (curly) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": OffsetLookup {
+        "kind": "offsetlookup",
+        "offset": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
         },
         "what": Variable {
           "curly": false,

--- a/test/snapshot/__snapshots__/variable.test.js.snap
+++ b/test/snapshot/__snapshots__/variable.test.js.snap
@@ -1280,31 +1280,24 @@ Program {
       "kind": "expressionstatement",
     },
     ExpressionStatement {
-      "expression": PropertyLookup {
-        "kind": "propertylookup",
-        "offset": Encapsed {
-          "kind": "encapsed",
-          "type": "offset",
-          "value": Array [
-            Identifier {
-              "kind": "identifier",
-              "name": "foo_",
-            },
-            EncapsedPart {
-              "curly": true,
-              "expression": Variable {
-                "curly": false,
-                "kind": "variable",
-                "name": "property",
-              },
-              "kind": "encapsedpart",
-            },
-          ],
-        },
-        "what": Variable {
+      "expression": OffsetLookup {
+        "kind": "offsetlookup",
+        "offset": Variable {
           "curly": false,
           "kind": "variable",
-          "name": "bar",
+          "name": "property",
+        },
+        "what": PropertyLookup {
+          "kind": "propertylookup",
+          "offset": Identifier {
+            "kind": "identifier",
+            "name": "foo_",
+          },
+          "what": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "bar",
+          },
         },
       },
       "kind": "expressionstatement",

--- a/test/snapshot/graceful.test.js
+++ b/test/snapshot/graceful.test.js
@@ -94,5 +94,13 @@ describe("Test graceful mode", function() {
     it("should fail !", function() {
       expect(test.parseEval("new Foo::{call()}();")).toMatchSnapshot();
     });
+
+    it("should fail with '{' and ']'", function() {
+      expect(test.parseEval("$obj{$foo];")).toMatchSnapshot();
+    });
+
+    it("should fail with '[' and '}'", function() {
+      expect(test.parseEval("$obj[$bar};")).toMatchSnapshot();
+    });
   });
 });

--- a/test/snapshot/offsetlookup.test.js
+++ b/test/snapshot/offsetlookup.test.js
@@ -13,4 +13,34 @@ describe("offsetlookup", function() {
   it("multiple", function() {
     expect(parser.parseEval('$obj["first"]["second"];')).toMatchSnapshot();
   });
+  it("simple (curly)", function() {
+    expect(parser.parseEval('$obj{"index"};')).toMatchSnapshot();
+  });
+  it("variable (curly)", function() {
+    expect(parser.parseEval('$obj{$var};')).toMatchSnapshot();
+  });
+  it("call (curly)", function() {
+    expect(parser.parseEval('$obj{$var}();')).toMatchSnapshot();
+  });
+  it("multiple (curly)", function() {
+    expect(parser.parseEval('$obj{"first"}{"second"};')).toMatchSnapshot();
+  });
+  it("inside propertylookup", function() {
+    expect(parser.parseEval(`
+$foo->bzr_[1];
+$foo->bzr_['string'];
+$foo->bzr_[$baz];
+$foo->bzr_[$baz->foo];
+$foo->bzr_[$var ? 'one' : 'two'];
+    `)).toMatchSnapshot();
+  });
+  it("inside propertylookup (curly)", function() {
+    expect(parser.parseEval(`
+$foo->bzr_{1};
+$foo->bzr_{'string'};
+$foo->bzr_{$baz};
+$foo->bzr_{$baz->foo};
+$foo->bzr_{$var ? 'one' : 'two'};
+    `)).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
It is basic tests

I find a lot of check on `[`, but array access can be done with `{`, need investigate

fixes #374

/cc @ichiriac 