### PR TITLE
fix: string value

### DIFF
--- a/test/snapshot/__snapshots__/break.test.js.snap
+++ b/test/snapshot/__snapshots__/break.test.js.snap
@@ -61,6 +61,23 @@ Program {
 }
 `;
 
+exports[`break with expression 1`] = `
+Program {
+  "children": Array [
+    Break {
+      "kind": "break",
+      "level": Variable {
+        "curly": false,
+        "kind": "variable",
+        "name": "var",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`break with parens 1`] = `
 Program {
   "children": Array [
@@ -70,23 +87,6 @@ Program {
         "kind": "number",
         "parenthesizedExpression": true,
         "value": "1",
-      },
-    },
-  ],
-  "errors": Array [],
-  "kind": "program",
-}
-`;
-
-exports[`break with var 1`] = `
-Program {
-  "children": Array [
-    Break {
-      "kind": "break",
-      "level": Variable {
-        "curly": false,
-        "kind": "variable",
-        "name": "var",
       },
     },
   ],

--- a/test/snapshot/__snapshots__/string.test.js.snap
+++ b/test/snapshot/__snapshots__/string.test.js.snap
@@ -650,6 +650,513 @@ Program {
 }
 `;
 
+exports[`Test strings double quotes 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\n\\"",
+          "unicode": false,
+          "value": "
+",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\r\\"",
+          "unicode": false,
+          "value": "
+",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\t\\"",
+          "unicode": false,
+          "value": "	",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\v\\"",
+          "unicode": false,
+          "value": "",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\e\\"",
+          "unicode": false,
+          "value": "",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\f\\"",
+          "unicode": false,
+          "value": "",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\\\\\\\"",
+          "unicode": false,
+          "value": "\\\\",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\$\\"",
+          "unicode": false,
+          "value": "$",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\\\"\\"",
+          "unicode": false,
+          "value": "\\"",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\141\\"",
+          "unicode": false,
+          "value": "a",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\7FF\\"",
+          "unicode": false,
+          "value": "FF",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\x61\\"",
+          "unicode": false,
+          "value": "a",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\x0Z\\"",
+          "unicode": false,
+          "value": " Z",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\xZZ\\"",
+          "unicode": false,
+          "value": "\\\\xZZ",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\u{0061}\\"",
+          "unicode": false,
+          "value": "a",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\u{}\\"",
+          "unicode": false,
+          "value": "\\\\u{}",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\u{0FFF}\\"",
+          "unicode": false,
+          "value": "࿿",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\u{0ZZZ}\\"",
+          "unicode": false,
+          "value": "\\\\u{0ZZZ}",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"cat\\\\u{1F639}\\"",
+          "unicode": false,
+          "value": "cat😹",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\u{D83D}\\\\u{DCA9}\\"",
+          "unicode": false,
+          "value": "💩",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"💩\\"",
+          "unicode": false,
+          "value": "💩",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\u{ZZZZ}\\\\u{ZZZZ}\\"",
+          "unicode": false,
+          "value": "\\\\u{ZZZZ}\\\\u{ZZZZ}",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"🌟\\"",
+          "unicode": false,
+          "value": "🌟",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"'\\"",
+          "unicode": false,
+          "value": "'",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\'\\"",
+          "unicode": false,
+          "value": "\\\\'",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\\\n | \\\\r | \\\\t | \\\\v | \\\\e | \\\\f | \\\\\\\\ | \\\\$ | \\\\\\" | \\\\141 | \\\\x61 | \\\\u{0061}\\"",
+          "unicode": false,
+          "value": "
+ | 
+ | 	 |  |  |  | \\\\ | $ | \\" | a | a | a",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`Test strings encapsed variable / curly constant 1`] = `
 Program {
   "children": Array [
@@ -1226,6 +1733,148 @@ Program {
         "raw": "'string'",
         "unicode": false,
         "value": "string",
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test strings single quotes 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": false,
+          "kind": "string",
+          "raw": "'foo'",
+          "unicode": false,
+          "value": "foo",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": false,
+          "kind": "string",
+          "raw": "'\\\\''",
+          "unicode": false,
+          "value": "'",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": false,
+          "kind": "string",
+          "raw": "'\\\\'\\\\'\\\\''",
+          "unicode": false,
+          "value": "'''",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": false,
+          "kind": "string",
+          "raw": "'\\\\'foo'",
+          "unicode": false,
+          "value": "'foo",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": false,
+          "kind": "string",
+          "raw": "'foo\\\\''",
+          "unicode": false,
+          "value": "foo'",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": false,
+          "kind": "string",
+          "raw": "'foo\\\\'foo'",
+          "unicode": false,
+          "value": "foo'foo",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": false,
+          "kind": "string",
+          "raw": "'\\\\\\\\\\\\''",
+          "unicode": false,
+          "value": "\\\\'",
+        },
       },
       "kind": "expressionstatement",
     },

--- a/test/snapshot/string.test.js
+++ b/test/snapshot/string.test.js
@@ -1,9 +1,10 @@
 const parser = require("../main");
 
 describe("Test strings", function() {
-
   it("fix #251", function() {
-    expect(parser.parseEval('$var = "string ${juices[\'FOO\']} string";')).toMatchSnapshot();
+    expect(
+      parser.parseEval("$var = \"string ${juices['FOO']} string\";")
+    ).toMatchSnapshot();
   });
 
   it("fix #144", function() {
@@ -389,4 +390,49 @@ describe("Test strings", function() {
   it("single (2)", function() {
     expect(parser.parseEval('"string";')).toMatchSnapshot();
   });
+  it("single quotes", function() {
+    expect(
+      parser.parseEval(`
+$var = 'foo';
+$var = '\\'';
+$var = '\\'\\'\\'';
+$var = '\\'foo';
+$var = 'foo\\'';
+$var = 'foo\\'foo';
+$var = '\\\\\\'';
+`)
+    ).toMatchSnapshot();
+  });
+    it("double quotes", function() {
+        expect(
+            parser.parseEval(`
+$var = "\\n";
+$var = "\\r";
+$var = "\\t";
+$var = "\\v";
+$var = "\\e";
+$var = "\\f";
+$var = "\\\\";
+$var = "\\$";
+$var = "\\"";
+$var = "\\141";
+$var = "\\7FF";
+$var = "\\x61";
+$var = "\\x0Z";
+$var = "\\xZZ";
+$var = "\\u{0061}";
+$var = "\\u{}";
+$var = "\\u{0FFF}";
+$var = "\\u{0ZZZ}";
+$var = "cat\\u{1F639}";
+$var = "\\u{D83D}\\u{DCA9}";
+$var = "💩";
+$var = "\\u{ZZZZ}\\u{ZZZZ}";
+$var = "🌟";
+$var = "'";
+$var = "\\'";
+$var = "\\n | \\r | \\t | \\v | \\e | \\f | \\\\ | \\$ | \\" | \\141 | \\x61 | \\u{0061}";
+`)
+        ).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
fixes #245

Here interesting place: 
```php
$var = "\u{D83D}\u{DCA9}";
```

Parser on php output: `��` (`strlen` return `6`), because:
> A string is series of characters, where a character is the same as a byte. This means that PHP only supports a 256-character set, and hence does not offer native Unicode support.

But our parser written on `nodejs` and strings will be re-encoded as a UTF-16 string.
So in test we have `value: '💩'`

I think it is expected behavior. In theory we can convert our string to the string is series of characters, but i think it is out of scope parser.

/cc @ichiriac What do you think? 