### PR TITLE
feat: null coalesce equal operator

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -141,7 +141,8 @@ declare module "php-parser" {
     T_COALESCE = 230,
     T_POW = 231,
     T_POW_EQUAL = 232,
-    T_SPACESHIP = 233
+    T_SPACESHIP = 233,
+    T_COALESCE_EQUAL = 234
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -96,6 +96,7 @@ const engine = function(options) {
       }
       options.lexer.php7 = options.parser.php7;
       options.lexer.php73 = options.parser.php73;
+      options.lexer.php74 = options.parser.php74;
     }
     combine(options, this);
   }

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -31,6 +31,7 @@ const lexer = function(engine) {
   this.short_tags = false;
   this.php7 = true;
   this.php73 = true;
+  this.php74 = true;
   this.yyprevcol = 0;
   this.keywords = {
     __class__: this.tok.T_CLASS_C,

--- a/src/lexer/tokens.js
+++ b/src/lexer/tokens.js
@@ -154,8 +154,13 @@ module.exports = {
     },
     "?": function() {
       if (this.php7 && this._input[this.offset] === "?") {
-        this.input();
-        return this.tok.T_COALESCE;
+        if (this.php74 && this._input[this.offset + 1] === "=") {
+          this.consume(2);
+          return this.tok.T_COALESCE_EQUAL;
+        } else {
+          this.input();
+          return this.tok.T_COALESCE;
+        }
       }
       return "?";
     },

--- a/src/parser/expr.js
+++ b/src/parser/expr.js
@@ -433,6 +433,10 @@ module.exports = {
           if (isConst) this.error("VARIABLE");
           return result("assign", expr, this.next().read_expr(), ">>=");
 
+        case this.tok.T_COALESCE_EQUAL:
+          if (isConst) this.error("VARIABLE");
+          return result("assign", expr, this.next().read_expr(), "??=");
+
         case this.tok.T_INC:
           if (isConst) this.error("VARIABLE");
           this.next();

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -143,7 +143,8 @@ module.exports = {
     230: "T_COALESCE",
     231: "T_POW",
     232: "T_POW_EQUAL",
-    233: "T_SPACESHIP"
+    233: "T_SPACESHIP",
+    234: "T_COALESCE_EQUAL"
   },
   names: {
     T_HALT_COMPILER: 101,
@@ -278,6 +279,7 @@ module.exports = {
     T_COALESCE: 230,
     T_POW: 231,
     T_POW_EQUAL: 232,
-    T_SPACESHIP: 233
+    T_SPACESHIP: 233,
+    T_COALESCE_EQUAL: 234
   }
 };

--- a/test/snapshot/__snapshots__/assign.test.js.snap
+++ b/test/snapshot/__snapshots__/assign.test.js.snap
@@ -234,6 +234,125 @@ Program {
 }
 `;
 
+exports[`assign ??= (php < 7) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": RetIf {
+        "falseExpr": undefined,
+        "kind": "retif",
+        "test": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "trueExpr": undefined,
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Variable {
+        "curly": false,
+        "kind": "variable",
+        "name": "var",
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": "EXPR",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '?' on line 1",
+      "token": "'?'",
+    },
+    Error {
+      "expected": ":",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '=', expecting ':' on line 1",
+      "token": "'='",
+    },
+    Error {
+      "expected": "EXPR",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '=' on line 1",
+      "token": "'='",
+    },
+    Error {
+      "expected": ";",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '$var' (T_VARIABLE), expecting ';' on line 1",
+      "token": "'$var' (T_VARIABLE)",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
+exports[`assign ??= 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "??=",
+        "right": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`assign ??= with bin 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "??=",
+        "right": Bin {
+          "kind": "bin",
+          "left": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "var",
+          },
+          "right": Number {
+            "kind": "number",
+            "value": "10",
+          },
+          "type": "+",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`assign ^= 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/__snapshots__/bin.test.js.snap
+++ b/test/snapshot/__snapshots__/bin.test.js.snap
@@ -494,6 +494,47 @@ Program {
 }
 `;
 
+exports[`bin ?? (php < 7) 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": RetIf {
+        "falseExpr": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "kind": "retif",
+        "test": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "trueExpr": undefined,
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": "EXPR",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '?' on line 1",
+      "token": "'?'",
+    },
+    Error {
+      "expected": ":",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '$var' (T_VARIABLE), expecting ':' on line 1",
+      "token": "'$var' (T_VARIABLE)",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
 exports[`bin ?? 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/assign.test.js
+++ b/test/snapshot/assign.test.js
@@ -46,6 +46,21 @@ describe('assign', () => {
   it('>>=', () => {
     expect(parser.parseEval("$var >>= $var;")).toMatchSnapshot();
   });
+  it('??=', () => {
+    expect(parser.parseEval("$var ??= $var;")).toMatchSnapshot();
+  });
+  it('??= with bin', () => {
+    expect(parser.parseEval("$var ??= $var + 10;")).toMatchSnapshot();
+  });
+  it('??= (php < 7)', function() {
+    const astErr = parser.parseEval(`$var ??= $var;`, {
+      parser: {
+        php7: false,
+        suppressErrors: true
+      }
+    });
+    expect(astErr).toMatchSnapshot();
+  });
   it('with ref', () => {
     expect(parser.parseEval("$bar = &$foo;")).toMatchSnapshot();
   });

--- a/test/snapshot/bin.test.js
+++ b/test/snapshot/bin.test.js
@@ -101,6 +101,15 @@ describe('bin', () => {
   it('??', () => {
     expect(parser.parseEval('$foo ?? $bar;')).toMatchSnapshot();
   });
+  it('?? (php < 7)', function() {
+    const astErr = parser.parseEval(`$var ?? $var;`, {
+      parser: {
+        php7: false,
+        suppressErrors: true
+      }
+    });
+    expect(astErr).toMatchSnapshot();
+  });
   it('assign', () => {
     expect(parser.parseEval('$var = $var + $var;')).toMatchSnapshot();
   });


### PR DESCRIPTION
New feature from php7.4

Find bug:
```js
it.only('??= (php < 7.4)', function() {
    const astErr = parser.parseEval(`$var ??= $var;`, {
      parser: {
        php74: false, // php73 doesn't work also
        suppressErrors: true
      }
    });
    expect(astErr).toMatchSnapshot();
  });
```

Doesn't work, i think it is not related to this PR, let's fix it in other PR.

I wanted to try to find out that I did not miss anything and in the future to do it quickly and correctly (new features)