### PR TITLE
refactor: dereferencable_scalar

### DIFF
--- a/test/snapshot/__snapshots__/scalar.test.js.snap
+++ b/test/snapshot/__snapshots__/scalar.test.js.snap
@@ -1,5 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Test scalar statements test constants #2 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "a",
+        },
+        "operator": "=",
+        "right": ClassReference {
+          "kind": "classreference",
+          "name": "Foo",
+          "resolution": "uqn",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test scalar statements test constants #2 2`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "a",
+        },
+        "operator": "=",
+        "right": StaticLookup {
+          "kind": "staticlookup",
+          "offset": Identifier {
+            "kind": "identifier",
+            "name": "foo",
+          },
+          "what": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "var",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`Test scalar statements test constants 1`] = `
 Program {
   "children": Array [
@@ -212,6 +271,96 @@ Program {
             "type": null,
             "uses": Array [],
           },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test scalar statements test dereferencable_scalar #2 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": Array {
+          "items": Array [
+            Number {
+              "kind": "number",
+              "value": "1",
+            },
+          ],
+          "kind": "array",
+          "shortForm": true,
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test scalar statements test dereferencable_scalar #3 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"test\\"",
+          "unicode": false,
+          "value": "test",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test scalar statements test dereferencable_scalar 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": Array {
+          "items": Array [
+            Number {
+              "kind": "number",
+              "value": "1",
+            },
+          ],
+          "kind": "array",
+          "shortForm": false,
         },
       },
       "kind": "expressionstatement",

--- a/test/snapshot/scalar.test.js
+++ b/test/snapshot/scalar.test.js
@@ -5,6 +5,14 @@ describe("Test scalar statements", function() {
     expect(parser.parseEval('$a = foo::ref[-5];')).toMatchSnapshot();
   });
 
+  it("test constants #2", function() {
+    expect(parser.parseEval('$a = Foo;')).toMatchSnapshot();
+  });
+
+  it("test constants #2", function() {
+    expect(parser.parseEval('$a = $var::foo;')).toMatchSnapshot();
+  });
+
   it("test dereferencable", function() {
     expect(parser.parseEval(`
       $a = foo::bar()[5]->test;
@@ -12,5 +20,15 @@ describe("Test scalar statements", function() {
       $c = (foo())[5];
       $d = (function($a) { return $a * 2; })(5);
     `)).toMatchSnapshot();
+  });
+
+  it("test dereferencable_scalar", function() {
+    expect(parser.parseEval('$var = array(1);')).toMatchSnapshot();
+  });
+  it("test dereferencable_scalar #2", function() {
+    expect(parser.parseEval('$var = [1];')).toMatchSnapshot();
+  });
+  it("test dereferencable_scalar #3", function() {
+    expect(parser.parseEval('$var = "test";')).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Refactor.
`dereferencable_scalar` can be used in multiple places
https://github.com/php/php-src/blob/php-7.4.0beta4/Zend/zend_language_parser.y#L1095

I think we have bugs in some places with `dereferencable_scalar`, so we need move this to own method and use this in other places, i will send fixes with tests in future