### PR TITLE
fix: silent precendence

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -253,26 +253,22 @@ AST.prototype.resolvePrecedence = function(result, parser) {
       }
     }
   } else if (
-    (result.kind === "cast" &&
-      result.what &&
-      !result.what.parenthesizedExpression) ||
-    (result.kind === "silent" &&
-      result.expr &&
-      !result.expr.parenthesizedExpression)
+    ["silent", "cast"].includes(result.kind) &&
+    result.expr &&
+    !result.expr.parenthesizedExpression
   ) {
     // https://github.com/glayzzle/php-parser/issues/172
-    const subject = result.kind === "cast" ? "what" : "expr";
-    if (result[subject].kind === "bin") {
-      buffer = result[subject];
-      result[subject] = result[subject].left;
-      this.swapLocations(result, result, result[subject], parser);
+    if (result.expr.kind === "bin") {
+      buffer = result.expr;
+      result.expr = result.expr.left;
+      this.swapLocations(result, result, result.expr, parser);
       buffer.left = this.resolvePrecedence(result, parser);
       this.swapLocations(buffer, buffer.left, buffer.right, parser);
       result = buffer;
-    } else if (result[subject].kind === "retif") {
-      buffer = result[subject];
-      result[subject] = result[subject].test;
-      this.swapLocations(result, result, result[subject], parser);
+    } else if (result.expr.kind === "retif") {
+      buffer = result.expr;
+      result.expr = result.expr.test;
+      this.swapLocations(result, result, result.expr, parser);
       buffer.test = this.resolvePrecedence(result, parser);
       this.swapLocations(buffer, buffer.test, buffer.falseExpr, parser);
       result = buffer;

--- a/src/ast.js
+++ b/src/ast.js
@@ -163,8 +163,7 @@ AST.precedence = {};
   ["*", "/", "%"],
   ["!"],
   ["instanceof"],
-  ["cast"]
-  // TODO: typecasts
+  ["cast", "silent"]
   // TODO: [ (array)
   // TODO: clone, new
 ].forEach(function(list, index) {
@@ -254,22 +253,26 @@ AST.prototype.resolvePrecedence = function(result, parser) {
       }
     }
   } else if (
-    result.kind === "cast" &&
-    result.what &&
-    !result.what.parenthesizedExpression
+    (result.kind === "cast" &&
+      result.what &&
+      !result.what.parenthesizedExpression) ||
+    (result.kind === "silent" &&
+      result.expr &&
+      !result.expr.parenthesizedExpression)
   ) {
     // https://github.com/glayzzle/php-parser/issues/172
-    if (result.what.kind === "bin") {
-      buffer = result.what;
-      result.what = result.what.left;
-      this.swapLocations(result, result, result.what, parser);
+    const subject = result.kind === "cast" ? "what" : "expr";
+    if (result[subject].kind === "bin") {
+      buffer = result[subject];
+      result[subject] = result[subject].left;
+      this.swapLocations(result, result, result[subject], parser);
       buffer.left = this.resolvePrecedence(result, parser);
       this.swapLocations(buffer, buffer.left, buffer.right, parser);
       result = buffer;
-    } else if (result.what.kind === "retif") {
-      buffer = result.what;
-      result.what = result.what.test;
-      this.swapLocations(result, result, result.what, parser);
+    } else if (result[subject].kind === "retif") {
+      buffer = result[subject];
+      result[subject] = result[subject].test;
+      this.swapLocations(result, result, result[subject], parser);
       buffer.test = this.resolvePrecedence(result, parser);
       this.swapLocations(buffer, buffer.test, buffer.falseExpr, parser);
       result = buffer;
@@ -325,16 +328,6 @@ AST.prototype.resolvePrecedence = function(result, parser) {
         this.swapLocations(buffer, buffer.left, result.right, parser);
         result = buffer;
       }
-    }
-  } else if (result.kind === "silent" && !result.expr.parenthesizedExpression) {
-    if (result.expr.kind === "assign") return result;
-    // overall least precedence
-    if (result.expr.right) {
-      buffer = result.expr;
-      result.expr = buffer.left;
-      buffer.left = result;
-      this.swapLocations(buffer, buffer.left, buffer.right, parser);
-      result = buffer;
     }
   } else if (result.kind === "expressionstatement") {
     this.swapLocations(result, result.expression, result, parser);

--- a/src/ast.js
+++ b/src/ast.js
@@ -253,7 +253,7 @@ AST.prototype.resolvePrecedence = function(result, parser) {
       }
     }
   } else if (
-    ["silent", "cast"].includes(result.kind) &&
+    (result.kind === "silent" || result.kind === "cast") &&
     result.expr &&
     !result.expr.parenthesizedExpression
   ) {
@@ -283,13 +283,6 @@ AST.prototype.resolvePrecedence = function(result, parser) {
         this.swapLocations(result, result, result.what, parser);
         buffer.left = this.resolvePrecedence(result, parser);
         this.swapLocations(buffer, buffer.left, buffer.right, parser);
-        result = buffer;
-      } else if (result.what.kind === "retif") {
-        buffer = result.what;
-        result.what = result.what.test;
-        this.swapLocations(result, result, result.what, parser);
-        buffer.test = this.resolvePrecedence(result, parser);
-        this.swapLocations(buffer, buffer.test, buffer.falseExpr, parser);
         result = buffer;
       }
     }

--- a/src/ast/cast.js
+++ b/src/ast/cast.js
@@ -14,17 +14,17 @@ const KIND = "cast";
  * @extends {Operation}
  * @property {String} type
  * @property {String} raw
- * @property {Expression} what
+ * @property {Expression} expr
  */
 module.exports = Operation.extends(KIND, function Cast(
   type,
   raw,
-  what,
+  expr,
   docs,
   location
 ) {
   Operation.apply(this, [KIND, docs, location]);
   this.type = type;
   this.raw = raw;
-  this.what = what;
+  this.expr = expr;
 });

--- a/test/snapshot/__snapshots__/acid.test.js.snap
+++ b/test/snapshot/__snapshots__/acid.test.js.snap
@@ -3737,23 +3737,7 @@ Program {
                 "test": Bin {
                   "kind": "bin",
                   "left": Cast {
-                    "kind": "cast",
-                    "loc": Location {
-                      "end": Position {
-                        "column": 19,
-                        "line": 90,
-                        "offset": 1817,
-                      },
-                      "source": "(int)$index",
-                      "start": Position {
-                        "column": 8,
-                        "line": 90,
-                        "offset": 1806,
-                      },
-                    },
-                    "raw": "(int)",
-                    "type": "int",
-                    "what": Variable {
+                    "expr": Variable {
                       "curly": false,
                       "kind": "variable",
                       "loc": Location {
@@ -3771,6 +3755,22 @@ Program {
                       },
                       "name": "index",
                     },
+                    "kind": "cast",
+                    "loc": Location {
+                      "end": Position {
+                        "column": 19,
+                        "line": 90,
+                        "offset": 1817,
+                      },
+                      "source": "(int)$index",
+                      "start": Position {
+                        "column": 8,
+                        "line": 90,
+                        "offset": 1806,
+                      },
+                    },
+                    "raw": "(int)",
+                    "type": "int",
                   },
                   "loc": Location {
                     "end": Position {
@@ -6177,23 +6177,7 @@ next:
                                 "test": Bin {
                                   "kind": "bin",
                                   "left": Cast {
-                                    "kind": "cast",
-                                    "loc": Location {
-                                      "end": Position {
-                                        "column": 41,
-                                        "line": 99,
-                                        "offset": 2047,
-                                      },
-                                      "source": "(int)calculateMeaningOfLife()",
-                                      "start": Position {
-                                        "column": 12,
-                                        "line": 99,
-                                        "offset": 2018,
-                                      },
-                                    },
-                                    "raw": "(int)",
-                                    "type": "int",
-                                    "what": Call {
+                                    "expr": Call {
                                       "arguments": Array [],
                                       "kind": "call",
                                       "loc": Location {
@@ -6228,6 +6212,22 @@ next:
                                         "resolution": "uqn",
                                       },
                                     },
+                                    "kind": "cast",
+                                    "loc": Location {
+                                      "end": Position {
+                                        "column": 41,
+                                        "line": 99,
+                                        "offset": 2047,
+                                      },
+                                      "source": "(int)calculateMeaningOfLife()",
+                                      "start": Position {
+                                        "column": 12,
+                                        "line": 99,
+                                        "offset": 2018,
+                                      },
+                                    },
+                                    "raw": "(int)",
+                                    "type": "int",
                                   },
                                   "loc": Location {
                                     "end": Position {

--- a/test/snapshot/__snapshots__/expr.test.js.snap
+++ b/test/snapshot/__snapshots__/expr.test.js.snap
@@ -965,157 +965,157 @@ Program {
   "children": Array [
     ExpressionStatement {
       "expression": Cast {
+        "expr": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
         "kind": "cast",
         "raw": "(int)",
         "type": "int",
-        "what": Variable {
-          "curly": false,
-          "kind": "variable",
-          "name": "var",
-        },
       },
       "kind": "expressionstatement",
     },
     ExpressionStatement {
       "expression": Cast {
+        "expr": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
         "kind": "cast",
         "raw": "(integer)",
         "type": "int",
-        "what": Variable {
-          "curly": false,
-          "kind": "variable",
-          "name": "var",
-        },
       },
       "kind": "expressionstatement",
     },
     ExpressionStatement {
       "expression": Cast {
+        "expr": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
         "kind": "cast",
         "raw": "(bool)",
         "type": "bool",
-        "what": Variable {
-          "curly": false,
-          "kind": "variable",
-          "name": "var",
-        },
       },
       "kind": "expressionstatement",
     },
     ExpressionStatement {
       "expression": Cast {
+        "expr": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
         "kind": "cast",
         "raw": "(boolean)",
         "type": "bool",
-        "what": Variable {
-          "curly": false,
-          "kind": "variable",
-          "name": "var",
-        },
       },
       "kind": "expressionstatement",
     },
     ExpressionStatement {
       "expression": Cast {
+        "expr": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
         "kind": "cast",
         "raw": "(float)",
         "type": "float",
-        "what": Variable {
-          "curly": false,
-          "kind": "variable",
-          "name": "var",
-        },
       },
       "kind": "expressionstatement",
     },
     ExpressionStatement {
       "expression": Cast {
+        "expr": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
         "kind": "cast",
         "raw": "(double)",
         "type": "float",
-        "what": Variable {
-          "curly": false,
-          "kind": "variable",
-          "name": "var",
-        },
       },
       "kind": "expressionstatement",
     },
     ExpressionStatement {
       "expression": Cast {
+        "expr": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
         "kind": "cast",
         "raw": "(real)",
         "type": "float",
-        "what": Variable {
-          "curly": false,
-          "kind": "variable",
-          "name": "var",
-        },
       },
       "kind": "expressionstatement",
     },
     ExpressionStatement {
       "expression": Cast {
+        "expr": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
         "kind": "cast",
         "raw": "(string)",
         "type": "string",
-        "what": Variable {
-          "curly": false,
-          "kind": "variable",
-          "name": "var",
-        },
       },
       "kind": "expressionstatement",
     },
     ExpressionStatement {
       "expression": Cast {
+        "expr": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
         "kind": "cast",
         "raw": "(binary)",
         "type": "binary",
-        "what": Variable {
-          "curly": false,
-          "kind": "variable",
-          "name": "var",
-        },
       },
       "kind": "expressionstatement",
     },
     ExpressionStatement {
       "expression": Cast {
+        "expr": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
         "kind": "cast",
         "raw": "(array)",
         "type": "array",
-        "what": Variable {
-          "curly": false,
-          "kind": "variable",
-          "name": "var",
-        },
       },
       "kind": "expressionstatement",
     },
     ExpressionStatement {
       "expression": Cast {
+        "expr": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
         "kind": "cast",
         "raw": "(object)",
         "type": "object",
-        "what": Variable {
-          "curly": false,
-          "kind": "variable",
-          "name": "var",
-        },
       },
       "kind": "expressionstatement",
     },
     ExpressionStatement {
       "expression": Cast {
-        "kind": "cast",
-        "raw": "(unset)",
-        "type": "unset",
-        "what": Variable {
+        "expr": Variable {
           "curly": false,
           "kind": "variable",
           "name": "var",
         },
+        "kind": "cast",
+        "raw": "(unset)",
+        "type": "unset",
       },
       "kind": "expressionstatement",
     },

--- a/test/snapshot/__snapshots__/location.test.js.snap
+++ b/test/snapshot/__snapshots__/location.test.js.snap
@@ -541,23 +541,7 @@ Program {
       "expression": Bin {
         "kind": "bin",
         "left": Cast {
-          "kind": "cast",
-          "loc": Location {
-            "end": Position {
-              "column": 13,
-              "line": 1,
-              "offset": 13,
-            },
-            "source": "(string)$var1",
-            "start": Position {
-              "column": 0,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "raw": "(string)",
-          "type": "string",
-          "what": Variable {
+          "expr": Variable {
             "curly": false,
             "kind": "variable",
             "loc": Location {
@@ -575,6 +559,22 @@ Program {
             },
             "name": "var1",
           },
+          "kind": "cast",
+          "loc": Location {
+            "end": Position {
+              "column": 13,
+              "line": 1,
+              "offset": 13,
+            },
+            "source": "(string)$var1",
+            "start": Position {
+              "column": 0,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "raw": "(string)",
+          "type": "string",
         },
         "loc": Location {
           "end": Position {
@@ -3025,23 +3025,7 @@ Program {
         },
         "operator": "=",
         "right": Cast {
-          "kind": "cast",
-          "loc": Location {
-            "end": Position {
-              "column": 19,
-              "line": 1,
-              "offset": 19,
-            },
-            "source": "(int) \\"2112\\"",
-            "start": Position {
-              "column": 7,
-              "line": 1,
-              "offset": 7,
-            },
-          },
-          "raw": "(int)",
-          "type": "int",
-          "what": String {
+          "expr": String {
             "isDoubleQuote": true,
             "kind": "string",
             "loc": Location {
@@ -3061,6 +3045,22 @@ Program {
             "unicode": false,
             "value": "2112",
           },
+          "kind": "cast",
+          "loc": Location {
+            "end": Position {
+              "column": 19,
+              "line": 1,
+              "offset": 19,
+            },
+            "source": "(int) \\"2112\\"",
+            "start": Position {
+              "column": 7,
+              "line": 1,
+              "offset": 7,
+            },
+          },
+          "raw": "(int)",
+          "type": "int",
         },
       },
       "kind": "expressionstatement",


### PR DESCRIPTION
Change `silent` to be handled exactly the same way as `cast` is handled. Also refactor `shouldBeSame` for better error reporting.

Fixes #195
Fixes #355 