### PR TITLE
fix: regression with unary / retif precedence

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -284,6 +284,13 @@ AST.prototype.resolvePrecedence = function(result, parser) {
         buffer.left = this.resolvePrecedence(result, parser);
         this.swapLocations(buffer, buffer.left, buffer.right, parser);
         result = buffer;
+      } else if (result.what.kind === "retif") {
+        buffer = result.what;
+        result.what = result.what.test;
+        this.swapLocations(result, result, result.what, parser);
+        buffer.test = this.resolvePrecedence(result, parser);
+        this.swapLocations(buffer, buffer.test, buffer.falseExpr, parser);
+        result = buffer;
       }
     }
   } else if (result.kind === "retif") {

--- a/test/precedence.test.js
+++ b/test/precedence.test.js
@@ -158,4 +158,8 @@ describe("Test precedence", function() {
     shouldBeSame("$a = (string)$b->foo . $c", "$a = ((string)$b->foo) . $c");
     shouldBeSame("(bool) $var ? 1 : 2;", "((bool)$var) ? 1 : 2;");
   });
+
+  it("test unary / retif", function() {
+    shouldBeSame("$a = +(+$var ? 1 : 2)", "$a = +((+$var) ? 1 : 2)")
+  });
 });


### PR DESCRIPTION
I noticed during the update of prettier/plugin-php that we shouldn't have removed the code block handling unary / retif in #455 :wink: 
This reverts the code block and adds a test.