### PR TITLE
Trigger syntax error when encountering array unpacking with reference

### DIFF
--- a/src/parser/array.js
+++ b/src/parser/array.js
@@ -84,6 +84,9 @@ module.exports = {
       value = this.read_variable(true, false);
     } else if (this.token === this.tok.T_ELLIPSIS && this.php74) {
       this.next();
+      if (this.token === '&') {
+        this.error()
+      }
       unpack = true;
       value = this.read_expr();
     } else {

--- a/test/snapshot/__snapshots__/array.test.js.snap
+++ b/test/snapshot/__snapshots__/array.test.js.snap
@@ -1804,3 +1804,50 @@ Program {
   "kind": "program",
 }
 `;
+
+exports[`Array without keys spread operator with reference 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": Array {
+          "items": Array [
+            Entry {
+              "byRef": false,
+              "key": null,
+              "kind": "entry",
+              "unpack": true,
+              "value": Variable {
+                "byref": true,
+                "curly": false,
+                "kind": "variable",
+                "name": "arr",
+              },
+            },
+          ],
+          "kind": "array",
+          "shortForm": true,
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": undefined,
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '&' on line 1",
+      "token": "'&'",
+    },
+  ],
+  "kind": "program",
+}
+`;

--- a/test/snapshot/array.test.js
+++ b/test/snapshot/array.test.js
@@ -125,6 +125,15 @@ $var = [...new ArrayIterator(['a', 'b', 'c'])];
     ).toMatchSnapshot();
   });
 
+  it('spread operator with reference', function() {
+    const astErr = parser.parseEval(`$var = [...&$arr];`, {
+      parser: {
+        suppressErrors: true
+      }
+    });
+    expect(astErr).toMatchSnapshot();
+  });
+
   it("byRef", () => {
     expect(
         parser.parseEval(`


### PR DESCRIPTION
Currently, this is allowed by the parser:

```php
[...&$arr]
```

However, this is incorrect and should trigger a syntax error ([RFC](https://wiki.php.net/rfc/spread_operator_for_array#by-reference_passing), [example](http://sandbox.onlinephpfunctions.com/code/e37a072d7be243df0e60140f6f35850645abf3e9)).