### PR TITLE
chore: refactor testing infrastructure

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     sourceType: "module"
   },
   plugins: ["prettier"],
-  extends: ["eslint:recommended"],
+  extends: ["eslint:recommended", "plugin:jest/recommended"],
   env: {
     browser: true,
     node: true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ notifications:
     on_success: change
     on_failure: always
     on_start: never
-script: npm run lint && npm run cover
+script: npm test
 after_success: cat /home/travis/build/glayzzle/php-parser/coverage/lcov.info | /home/travis/build/glayzzle/php-parser/node_modules/coveralls/bin/coveralls.js
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,20 @@
+"use strict";
+
+const ENABLE_COVERAGE = !!process.env.CI || !!process.env.COVERAGE;
+
+module.exports = {
+  collectCoverage: ENABLE_COVERAGE,
+  coverageDirectory: "coverage/",
+  projects: [
+    {
+      displayName: "test",
+      testEnvironment: "node"
+    },
+    {
+      runner: "jest-runner-eslint",
+      displayName: "lint",
+      testMatch: ["<rootDir>/**/*.js"],
+      testPathIgnorePatterns: ["<rootDir>/node_modules/", "<rootDir>/coverage/"]
+    }
+  ]
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -172,24 +172,15 @@
       }
     },
     "@babel/generator": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
-      "integrity": "sha1-mqSMGYkleHep2XEpbltzv+cuRG4=",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+      "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.3.4",
+        "@babel/types": "^7.7.4",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.11",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-          "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
-          "dev": true
-        }
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0"
       }
     },
     "@babel/helper-annotate-as-pure": {
@@ -554,23 +545,23 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-      "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+      "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-get-function-arity": "^7.7.4",
+        "@babel/template": "^7.7.4",
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-      "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+      "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helper-hoist-variables": {
@@ -1021,12 +1012,12 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
-      "integrity": "sha1-Oq4oXAMRwqsJXZl7jJqUytVH2BM=",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+      "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helper-wrap-function": {
@@ -1335,9 +1326,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz",
-      "integrity": "sha1-pDNX5Lv0uSpDf7nkZcGShIKH8nw=",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+      "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -1440,9 +1431,9 @@
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
-      "integrity": "sha1-O3o+czUQxX6CC5FCpleayLDfrS4=",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
+      "integrity": "sha512-mObR+r+KZq0XhRVS2BrBKBpr5jqrqzlPvS9C9vuOf5ilSwzloAl7RPWLrgKdWS6IreaVrjHxTjtyqFiOisaCwg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -1985,73 +1976,68 @@
       }
     },
     "@babel/template": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
-      "integrity": "sha1-AFs/3w7ZbogEEzA3ng2ppwjrKQc=",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+      "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.2.2",
-        "@babel/types": "^7.2.2"
+        "@babel/parser": "^7.7.4",
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/traverse": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz",
-      "integrity": "sha1-EzCqtyI0+N6gkbCMT4udBccRngY=",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+      "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.3.4",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/parser": "^7.3.4",
-        "@babel/types": "^7.3.4",
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.7.4",
+        "@babel/helper-function-name": "^7.7.4",
+        "@babel/helper-split-export-declaration": "^7.7.4",
+        "@babel/parser": "^7.7.4",
+        "@babel/types": "^7.7.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+          "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.0.0"
+          }
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
         },
-        "globals": {
-          "version": "11.11.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
-          "integrity": "sha1-3Pk3V/ot5Uhvvu1xGFOK33ienC4=",
-          "dev": true
-        },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
     },
     "@babel/types": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
-      "integrity": "sha1-v0gurq/7Nnooq7+TV6lJYyNdkO0=",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+      "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
-      },
-      "dependencies": {
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-          "dev": true
-        }
       }
     },
     "@cnakazawa/watch": {
@@ -2274,9 +2260,9 @@
       }
     },
     "@types/babel__core": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
-      "integrity": "sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
+      "integrity": "sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -2287,9 +2273,9 @@
       }
     },
     "@types/babel__generator": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
-      "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
+      "integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
@@ -2306,9 +2292,9 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
-      "integrity": "sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.8.tgz",
+      "integrity": "sha512-yGeB2dHEdvxjP0y4UbRtQaSkXJ9649fYCmIdRoul5kfAoGCwxuCbMhag0k3RPfnuh9kPGm8x89btcfDEXdVWGw==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -2339,6 +2325,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/json-schema": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
+      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
+      "dev": true
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -2352,19 +2344,100 @@
       "dev": true
     },
     "@types/yargs": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.2.tgz",
-      "integrity": "sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==",
+      "version": "13.0.4",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.4.tgz",
+      "integrity": "sha512-Ke1WmBbIkVM8bpvsNEcGgQM70XcEh/nbpxQhW7FhrsbCsXSY9BmLB1+LHtD7r9zrsOcFlLiF+a/UeJsdfw3C5A==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
     },
     "@types/yargs-parser": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.0.0.tgz",
-      "integrity": "sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
+      "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
       "dev": true
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.14.0.tgz",
+      "integrity": "sha512-KcyKS7G6IWnIgl3ZpyxyBCxhkBPV+0a5Jjy2g5HxlrbG2ZLQNFeneIBVXdaBCYOVjvGmGGFKom1kgiAY75SDeQ==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/typescript-estree": "2.14.0",
+        "eslint-scope": "^5.0.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.14.0.tgz",
+      "integrity": "sha512-pnLpUcMNG7GfFFfNQbEX6f1aPa5fMnH2G9By+A1yovYI4VIOK2DzkaRuUlIkbagpAcrxQHLqovI1YWqEcXyRnA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "eslint-visitor-keys": "^1.1.0",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "lodash.unescape": "4.0.1",
+        "semver": "^6.3.0",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
@@ -2555,9 +2628,9 @@
       "dev": true
     },
     "abab": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
-      "integrity": "sha1-q6CrTF7uLUx500h9hUUPsjduuw8=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
+      "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
       "dev": true
     },
     "acorn": {
@@ -2567,9 +2640,9 @@
       "dev": true
     },
     "acorn-globals": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.3.tgz",
-      "integrity": "sha512-vkR40VwS2SYO98AIeFvzWWh+xyc2qi9s7OoXSFEGIP/rOJKzjnhykaZJNnHdoq4BL2gGxI5EZOU16z896EYnOQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+      "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
       "dev": true,
       "requires": {
         "acorn": "^6.0.1",
@@ -3051,13 +3124,13 @@
     "browser-process-hrtime": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
-      "integrity": "sha1-YW8A+u8d9+wbW/nP4r3DFw8mx7Q=",
+      "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
       "dev": true
     },
     "browser-resolve": {
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
-      "integrity": "sha1-m3y7PQ9RDky4a9vXlhJNKLWJCvY=",
+      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
       "dev": true,
       "requires": {
         "resolve": "1.1.7"
@@ -3154,9 +3227,9 @@
       }
     },
     "bser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
-      "integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
@@ -3581,9 +3654,9 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-      "integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
@@ -3713,6 +3786,17 @@
         "sha.js": "^2.4.8"
       }
     },
+    "create-jest-runner": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/create-jest-runner/-/create-jest-runner-0.5.3.tgz",
+      "integrity": "sha512-a9VY2doMBmzRollJB3Ft3/Y5fBceSWJ4gdyVsg4/d7nP1S4715VG939s2VnITDj79YBmRgKhjGjNRv1c+Kre1g==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "jest-worker": "^24.0.0",
+        "throat": "^4.1.0"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -3778,7 +3862,7 @@
     "data-urls": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
-      "integrity": "sha1-Fe4Fgrql4iu1nHcUDaj5x2lju/4=",
+      "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
       "dev": true,
       "requires": {
         "abab": "^2.0.0",
@@ -3787,9 +3871,9 @@
       },
       "dependencies": {
         "whatwg-url": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
-          "integrity": "sha1-/ekm+lSlmfOt+C3/Jan3vgLcbt0=",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
           "dev": true,
           "requires": {
             "lodash.sortby": "^4.7.0",
@@ -3945,7 +4029,7 @@
     "domexception": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
-      "integrity": "sha1-k3RCZEymoxJh7zbj7Gd/6AVYLJA=",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
       "dev": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
@@ -4086,23 +4170,42 @@
       }
     },
     "es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha1-rIYUX91QmdjdSVWMy6Lq+biOJOk=",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
+      "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.2.0",
+        "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        }
       }
     },
     "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha1-7fckeAM0VujdqO8J4ArZZQcH83c=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
@@ -4117,9 +4220,9 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
-      "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.1.tgz",
+      "integrity": "sha512-Q8t2YZ+0e0pc7NRVj3B4tSQ9rim1oi4Fh46k2xhJ2qOiEwhQfdjyEQddWdj7ZFaKmU+5104vn1qrcjEPWq+bgQ==",
       "dev": true,
       "requires": {
         "esprima": "^3.1.3",
@@ -4138,7 +4241,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true,
           "optional": true
         }
@@ -4240,6 +4343,15 @@
         }
       }
     },
+    "eslint-plugin-jest": {
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.2.0.tgz",
+      "integrity": "sha512-/jbCUW+g0jejXAvsytgcNhii6uEgolt0RO2e4+mhmXybfkcram5V3XIyrHCnUsb0vCmDKgHhJ1lYSm7F3VCEDA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^2.5.0"
+      }
+    },
     "eslint-plugin-prettier": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
@@ -4338,9 +4450,9 @@
       }
     },
     "exec-sh": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
-      "integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
+      "integrity": "sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==",
       "dev": true
     },
     "execa": {
@@ -4568,12 +4680,12 @@
       "dev": true
     },
     "fb-watchman": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
-      "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
+      "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
       "dev": true,
       "requires": {
-        "bser": "^2.0.0"
+        "bser": "2.1.1"
       }
     },
     "figgy-pudding": {
@@ -5584,7 +5696,7 @@
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
@@ -5701,7 +5813,7 @@
     "html-encoding-sniffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-      "integrity": "sha1-5w2EuU2lOqN14R/jo1G+ZkLKRvg=",
+      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "dev": true,
       "requires": {
         "whatwg-encoding": "^1.0.1"
@@ -6063,9 +6175,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU=",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
       "dev": true
     },
     "is-ci": {
@@ -6098,9 +6210,9 @@
       }
     },
     "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
       "dev": true
     },
     "is-descriptor": {
@@ -6197,12 +6309,12 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "^1.0.3"
       }
     },
     "is-stream": {
@@ -6212,12 +6324,20 @@
       "dev": true
     },
     "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha1-oFX2rlcZLK7jKeeoYBGLSXqVDzg=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "^1.0.1"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
+        }
       }
     },
     "is-typedarray": {
@@ -6283,105 +6403,6 @@
         "semver": "^6.0.0"
       },
       "dependencies": {
-        "@babel/generator": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
-          "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.5.5",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.4.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.4.4"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-          "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.4.4",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-          "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.4.4",
-            "@babel/types": "^7.4.4"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
-          "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.5.5",
-            "@babel/generator": "^7.5.5",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/parser": "^7.5.5",
-            "@babel/types": "^7.5.5",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.13"
-          },
-          "dependencies": {
-            "@babel/code-frame": {
-              "version": "7.5.5",
-              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-              "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-              "dev": true,
-              "requires": {
-                "@babel/highlight": "^7.0.0"
-              }
-            }
-          }
-        },
-        "@babel/types": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-          "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.13",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "jsesc": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -6779,6 +6800,18 @@
         "throat": "^4.0.0"
       }
     },
+    "jest-runner-eslint": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/jest-runner-eslint/-/jest-runner-eslint-0.7.5.tgz",
+      "integrity": "sha512-R4EqQnX0gtUv2SA1vwerI6rd5hLm0tVBTq2j3j4BZBHEfh7oKGF/hlkkNVDRfd73TAOcCaM3uhgzny7R4mnWVQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "cosmiconfig": "^5.0.0",
+        "create-jest-runner": "^0.5.3",
+        "eslint": "^4.0.0 || ^5.0.0 || ^6.0.0"
+      }
+    },
     "jest-runtime": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.9.0.tgz",
@@ -6868,7 +6901,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }
@@ -7028,7 +7061,7 @@
     "jsdom": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
-      "integrity": "sha1-GoDUDd03ih3lllbp5txaO6hle8g=",
+      "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
       "dev": true,
       "requires": {
         "abab": "^2.0.0",
@@ -7163,7 +7196,7 @@
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-      "integrity": "sha1-W4o6d2Xf4AEmHd6RVYnngvjJTR4=",
+      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
       "dev": true
     },
     "leven": {
@@ -7366,6 +7399,12 @@
         "lodash._reinterpolate": "^3.0.0",
         "lodash.escape": "^3.0.0"
       }
+    },
+    "lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
+      "dev": true
     },
     "log-driver": {
       "version": "1.2.7",
@@ -7788,30 +7827,16 @@
       "dev": true
     },
     "node-notifier": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.2.tgz",
-      "integrity": "sha512-85nkTziazE2dR4pyoLxMwz0b9MmxFQPVXYs/WlWI7CPtBkARJOV+89khdNjpbclXIJDECQYnTvh1xuZV3WHkCA==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
+      "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
       "dev": true,
       "requires": {
         "growly": "^1.3.0",
-        "is-wsl": "^2.1.0",
-        "semver": "^6.3.0",
+        "is-wsl": "^1.1.0",
+        "semver": "^5.5.0",
         "shellwords": "^0.1.1",
-        "which": "^1.3.1"
-      },
-      "dependencies": {
-        "is-wsl": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.0.tgz",
-          "integrity": "sha512-pFTjpv/x5HRj8kbZ/Msxi9VrvtOMRBqaDi3OIcbwPI3OuH+r3lLxVWukLITBaOGJIbA/w2+M1eVmVa4XNQlAmQ==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
+        "which": "^1.3.0"
       }
     },
     "node-releases": {
@@ -7862,9 +7887,9 @@
       }
     },
     "nwsapi": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
-      "integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
     },
     "oauth-sign": {
@@ -7910,6 +7935,12 @@
         }
       }
     },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
+    },
     "object-keys": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
@@ -7938,13 +7969,13 @@
       }
     },
     "object.getownpropertydescriptors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "object.pick": {
@@ -8163,7 +8194,7 @@
     "parse5": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-      "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg=",
+      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
       "dev": true
     },
     "pascalcase": {
@@ -8278,7 +8309,7 @@
     "pn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-      "integrity": "sha1-4vTO8OIZ9GPBeas3Rj5OHs3Muvs=",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
     "posix-character-classes": {
@@ -8359,9 +8390,9 @@
       "dev": true
     },
     "prompts": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.2.1.tgz",
-      "integrity": "sha512-VObPvJiWPhpZI6C5m60XOzTfnYg/xc/an+r9VYymj9WJW3B/DIH+REzjpAACPf8brwPeP+7vz3bIim3S+AaMjw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.0.tgz",
+      "integrity": "sha512-NfbbPPg/74fT7wk2XYQ7hAIp9zJyZp5Fu19iRbORqqy1BhtrkZ0fPafBU+7bmn8ie69DpT0R6QpJIN2oisYjJg==",
       "dev": true,
       "requires": {
         "kleur": "^3.0.3",
@@ -8471,9 +8502,9 @@
       }
     },
     "react-is": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-      "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
+      "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
       "dev": true
     },
     "read-pkg": {
@@ -8662,21 +8693,29 @@
       }
     },
     "request-promise-core": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
-      "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
+      "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "request-promise-native": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
-      "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
+      "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
       "dev": true,
       "requires": {
-        "request-promise-core": "1.1.2",
+        "request-promise-core": "1.1.3",
         "stealthy-require": "^1.1.1",
         "tough-cookie": "^2.3.3"
       }
@@ -8878,7 +8917,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
     "schema-utils": {
@@ -8973,7 +9012,7 @@
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha1-1rkYHBpI05cyTISHHvvPxz/AZUs=",
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
     "signal-exit": {
@@ -8983,9 +9022,9 @@
       "dev": true
     },
     "sisteransi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.3.tgz",
-      "integrity": "sha512-SbEG75TzH8G7eVXFSN5f9EExILKfly7SUvVY5DhhYLvfhKqhDFY0OzevWa/zwak0RLRfWS5AvfMWpd9gJvr5Yg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.4.tgz",
+      "integrity": "sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig==",
       "dev": true
     },
     "slash": {
@@ -9366,6 +9405,26 @@
         }
       }
     },
+    "string.prototype.trimleft": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -9697,17 +9756,20 @@
         "punycode": "^2.1.0"
       }
     },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
-    },
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
       "integrity": "sha1-1+TdeSRdhUKMTX5IIqeZF5VMooY=",
       "dev": true
+    },
+    "tsutils": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -9758,20 +9820,27 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.3.tgz",
+      "integrity": "sha512-7tINm46/3puUA4hCkKYo4Xdts+JDaVC9ZPRcG8Xw9R4nhO/gZgUM3TENq8IF4Vatk8qCig4MzP/c8G4u2BkVQg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true,
           "optional": true
         }
@@ -10065,7 +10134,7 @@
     "util.promisify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-      "integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
@@ -10154,7 +10223,7 @@
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha1-qFWYCx8LazWbodXZ+zmulB+qY60=",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true
     },
     "webpack": {
@@ -10322,7 +10391,7 @@
     "whatwg-encoding": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
-      "integrity": "sha1-WrrPd3wyFmpR0IXWtPPn0nET3bA=",
+      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
       "dev": true,
       "requires": {
         "iconv-lite": "0.4.24"
@@ -10337,7 +10406,7 @@
     "whatwg-url": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
-      "integrity": "sha1-8t8Cv/F2/WUHDfdK1cy7WhmZZag=",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
       "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
@@ -10443,7 +10512,7 @@
     "ws": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha1-3/7xSGa46NyRM1glFNG++vlumA8=",
+      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
       "dev": true,
       "requires": {
         "async-limiter": "~1.0.0"
@@ -10452,7 +10521,7 @@
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-      "integrity": "sha1-auc+Bt5NjG5H+fsYH3jWSK1FfGo=",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
     },
     "xmlcreate": {

--- a/package.json
+++ b/package.json
@@ -11,21 +11,18 @@
     "LICENSE"
   ],
   "scripts": {
-    "lint": "eslint . --fix",
+    "fix": "eslint . --fix",
     "test": "jest",
-    "prehusky": "npm run lint",
     "husky": "npm run test",
     "prebuild": "npm run test",
     "build": "webpack --config webpack.config.js",
     "postbuild": "npm run build-docs",
     "build-docs": "jsdoc -c .jsdoc.json",
-    "publish-docs": "git subtree push --prefix docs origin gh-pages",
-    "cover": "jest --coverage --coverageDirectory=coverage/"
+    "publish-docs": "git subtree push --prefix docs origin gh-pages"
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run husky",
-      "pre-push": "npm run husky"
+      "pre-commit": "npm run husky"
     }
   },
   "repository": {
@@ -59,19 +56,17 @@
     }
   ],
   "license": "BSD-3-Clause",
-  "jest": {
-    "testEnvironment": "node",
-    "testURL": "http://localhost/"
-  },
   "devDependencies": {
     "@babel/core": "^7.3.4",
     "@babel/preset-env": "^7.3.4",
     "babel-loader": "^8.0.5",
     "coveralls": "^3.0.3",
     "eslint": "^5.15.0",
+    "eslint-plugin-jest": "^23.2.0",
     "eslint-plugin-prettier": "^3.0.1",
     "husky": "^3.0.4",
-    "jest": "^24.1.0",
+    "jest": "^24.9.0",
+    "jest-runner-eslint": "^0.7.5",
     "jsdoc": "^3.5.5",
     "jsdoc-template": "^1.2.0",
     "prettier": "^1.16.4",

--- a/test/snapshot/__snapshots__/array.test.js.snap
+++ b/test/snapshot/__snapshots__/array.test.js.snap
@@ -340,50 +340,6 @@ Program {
 }
 `;
 
-exports[`Array without keys array with trailing commas #2 1`] = `
-Program {
-  "children": Array [
-    ExpressionStatement {
-      "expression": Array {
-        "items": Array [
-          Entry {
-            "byRef": false,
-            "key": null,
-            "kind": "entry",
-            "unpack": false,
-            "value": String {
-              "isDoubleQuote": false,
-              "kind": "string",
-              "raw": "'foo'",
-              "unicode": false,
-              "value": "foo",
-            },
-          },
-          Entry {
-            "byRef": false,
-            "key": null,
-            "kind": "entry",
-            "unpack": false,
-            "value": String {
-              "isDoubleQuote": false,
-              "kind": "string",
-              "raw": "'bar'",
-              "unicode": false,
-              "value": "bar",
-            },
-          },
-        ],
-        "kind": "array",
-        "shortForm": true,
-      },
-      "kind": "expressionstatement",
-    },
-  ],
-  "errors": Array [],
-  "kind": "program",
-}
-`;
-
 exports[`Array without keys array with trailing commas #3 1`] = `
 Program {
   "children": Array [
@@ -428,7 +384,95 @@ Program {
 }
 `;
 
-exports[`Array without keys array with trailing commas 1`] = `
+exports[`Array without keys array with trailing commas #4 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Array {
+        "items": Array [
+          Entry {
+            "byRef": false,
+            "key": null,
+            "kind": "entry",
+            "unpack": false,
+            "value": String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'foo'",
+              "unicode": false,
+              "value": "foo",
+            },
+          },
+          Entry {
+            "byRef": false,
+            "key": null,
+            "kind": "entry",
+            "unpack": false,
+            "value": String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'bar'",
+              "unicode": false,
+              "value": "bar",
+            },
+          },
+        ],
+        "kind": "array",
+        "shortForm": true,
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Array without keys array with trailing commas #5 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Array {
+        "items": Array [
+          Entry {
+            "byRef": false,
+            "key": null,
+            "kind": "entry",
+            "unpack": false,
+            "value": String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'foo'",
+              "unicode": false,
+              "value": "foo",
+            },
+          },
+          Entry {
+            "byRef": false,
+            "key": null,
+            "kind": "entry",
+            "unpack": false,
+            "value": String {
+              "isDoubleQuote": false,
+              "kind": "string",
+              "raw": "'bar'",
+              "unicode": false,
+              "value": "bar",
+            },
+          },
+        ],
+        "kind": "array",
+        "shortForm": true,
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Array without keys array without trailing commas #2 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -473,50 +517,6 @@ Program {
 `;
 
 exports[`Array without keys array without trailing commas 1`] = `
-Program {
-  "children": Array [
-    ExpressionStatement {
-      "expression": Array {
-        "items": Array [
-          Entry {
-            "byRef": false,
-            "key": null,
-            "kind": "entry",
-            "unpack": false,
-            "value": String {
-              "isDoubleQuote": false,
-              "kind": "string",
-              "raw": "'foo'",
-              "unicode": false,
-              "value": "foo",
-            },
-          },
-          Entry {
-            "byRef": false,
-            "key": null,
-            "kind": "entry",
-            "unpack": false,
-            "value": String {
-              "isDoubleQuote": false,
-              "kind": "string",
-              "raw": "'bar'",
-              "unicode": false,
-              "value": "bar",
-            },
-          },
-        ],
-        "kind": "array",
-        "shortForm": true,
-      },
-      "kind": "expressionstatement",
-    },
-  ],
-  "errors": Array [],
-  "kind": "program",
-}
-`;
-
-exports[`Array without keys array without trailing commas 2`] = `
 Program {
   "children": Array [
     ExpressionStatement {

--- a/test/snapshot/__snapshots__/byref.test.js.snap
+++ b/test/snapshot/__snapshots__/byref.test.js.snap
@@ -336,47 +336,6 @@ Program {
 }
 `;
 
-exports[`byref closure 2`] = `
-Program {
-  "children": Array [
-    ExpressionStatement {
-      "expression": Assign {
-        "kind": "assign",
-        "left": Variable {
-          "curly": false,
-          "kind": "variable",
-          "name": "var",
-        },
-        "operator": "=",
-        "right": Closure {
-          "arguments": Array [],
-          "body": Block {
-            "children": Array [],
-            "kind": "block",
-          },
-          "byref": false,
-          "isStatic": false,
-          "kind": "closure",
-          "nullable": false,
-          "type": null,
-          "uses": Array [
-            Variable {
-              "byref": true,
-              "curly": false,
-              "kind": "variable",
-              "name": "message",
-            },
-          ],
-        },
-      },
-      "kind": "expressionstatement",
-    },
-  ],
-  "errors": Array [],
-  "kind": "program",
-}
-`;
-
 exports[`byref foreach (key/value) 1`] = `
 Program {
   "children": Array [
@@ -921,31 +880,6 @@ Program {
           "curly": false,
           "kind": "variable",
           "name": "foo",
-        },
-      },
-      "kind": "expressionstatement",
-    },
-  ],
-  "errors": Array [],
-  "kind": "program",
-}
-`;
-
-exports[`byref variable 2`] = `
-Program {
-  "children": Array [
-    ExpressionStatement {
-      "expression": AssignRef {
-        "kind": "assignref",
-        "left": Variable {
-          "curly": false,
-          "kind": "variable",
-          "name": "a",
-        },
-        "right": Variable {
-          "curly": false,
-          "kind": "variable",
-          "name": "var",
         },
       },
       "kind": "expressionstatement",

--- a/test/snapshot/__snapshots__/location.test.js.snap
+++ b/test/snapshot/__snapshots__/location.test.js.snap
@@ -1,130 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Test locations #164 : expr must include ; 1`] = `
-Program {
-  "children": Array [
-    ExpressionStatement {
-      "expression": Assign {
-        "kind": "assign",
-        "left": Variable {
-          "curly": false,
-          "kind": "variable",
-          "loc": Location {
-            "end": Position {
-              "column": 2,
-              "line": 1,
-              "offset": 2,
-            },
-            "source": "$a",
-            "start": Position {
-              "column": 0,
-              "line": 1,
-              "offset": 0,
-            },
-          },
-          "name": "a",
-        },
-        "loc": Location {
-          "end": Position {
-            "column": 12,
-            "line": 1,
-            "offset": 12,
-          },
-          "source": "$a = $b + 1;",
-          "start": Position {
-            "column": 0,
-            "line": 1,
-            "offset": 0,
-          },
-        },
-        "operator": "=",
-        "right": Bin {
-          "kind": "bin",
-          "left": Variable {
-            "curly": false,
-            "kind": "variable",
-            "loc": Location {
-              "end": Position {
-                "column": 7,
-                "line": 1,
-                "offset": 7,
-              },
-              "source": "$b",
-              "start": Position {
-                "column": 5,
-                "line": 1,
-                "offset": 5,
-              },
-            },
-            "name": "b",
-          },
-          "loc": Location {
-            "end": Position {
-              "column": 11,
-              "line": 1,
-              "offset": 11,
-            },
-            "source": "$b + 1",
-            "start": Position {
-              "column": 5,
-              "line": 1,
-              "offset": 5,
-            },
-          },
-          "right": Number {
-            "kind": "number",
-            "loc": Location {
-              "end": Position {
-                "column": 11,
-                "line": 1,
-                "offset": 11,
-              },
-              "source": "1",
-              "start": Position {
-                "column": 10,
-                "line": 1,
-                "offset": 10,
-              },
-            },
-            "value": "1",
-          },
-          "type": "+",
-        },
-      },
-      "kind": "expressionstatement",
-      "loc": Location {
-        "end": Position {
-          "column": 12,
-          "line": 1,
-          "offset": 12,
-        },
-        "source": "$a = $b + 1;",
-        "start": Position {
-          "column": 0,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-    },
-  ],
-  "errors": Array [],
-  "kind": "program",
-  "loc": Location {
-    "end": Position {
-      "column": 12,
-      "line": 1,
-      "offset": 12,
-    },
-    "source": "$a = $b + 1;",
-    "start": Position {
-      "column": 0,
-      "line": 1,
-      "offset": 0,
-    },
-  },
-}
-`;
-
 exports[`Test locations #164 : expr should avoid ?> 1`] = `
 Program {
   "children": Array [
@@ -250,7 +125,132 @@ Program {
 }
 `;
 
-exports[`Test locations #202 : include calling argument 1`] = `
+exports[`Test locations test #164 : expr must include ; 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "loc": Location {
+            "end": Position {
+              "column": 2,
+              "line": 1,
+              "offset": 2,
+            },
+            "source": "$a",
+            "start": Position {
+              "column": 0,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "name": "a",
+        },
+        "loc": Location {
+          "end": Position {
+            "column": 12,
+            "line": 1,
+            "offset": 12,
+          },
+          "source": "$a = $b + 1;",
+          "start": Position {
+            "column": 0,
+            "line": 1,
+            "offset": 0,
+          },
+        },
+        "operator": "=",
+        "right": Bin {
+          "kind": "bin",
+          "left": Variable {
+            "curly": false,
+            "kind": "variable",
+            "loc": Location {
+              "end": Position {
+                "column": 7,
+                "line": 1,
+                "offset": 7,
+              },
+              "source": "$b",
+              "start": Position {
+                "column": 5,
+                "line": 1,
+                "offset": 5,
+              },
+            },
+            "name": "b",
+          },
+          "loc": Location {
+            "end": Position {
+              "column": 11,
+              "line": 1,
+              "offset": 11,
+            },
+            "source": "$b + 1",
+            "start": Position {
+              "column": 5,
+              "line": 1,
+              "offset": 5,
+            },
+          },
+          "right": Number {
+            "kind": "number",
+            "loc": Location {
+              "end": Position {
+                "column": 11,
+                "line": 1,
+                "offset": 11,
+              },
+              "source": "1",
+              "start": Position {
+                "column": 10,
+                "line": 1,
+                "offset": 10,
+              },
+            },
+            "value": "1",
+          },
+          "type": "+",
+        },
+      },
+      "kind": "expressionstatement",
+      "loc": Location {
+        "end": Position {
+          "column": 12,
+          "line": 1,
+          "offset": 12,
+        },
+        "source": "$a = $b + 1;",
+        "start": Position {
+          "column": 0,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+  "loc": Location {
+    "end": Position {
+      "column": 12,
+      "line": 1,
+      "offset": 12,
+    },
+    "source": "$a = $b + 1;",
+    "start": Position {
+      "column": 0,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+}
+`;
+
+exports[`Test locations test #202 : include calling argument 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -408,7 +408,7 @@ Program {
 }
 `;
 
-exports[`Test locations #230 : check location 1`] = `
+exports[`Test locations test #230 : check location 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -534,7 +534,7 @@ Program {
 }
 `;
 
-exports[`Test locations #230 : check location on cast 1`] = `
+exports[`Test locations test #230 : check location on cast 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -643,7 +643,7 @@ Program {
 }
 `;
 
-exports[`Test locations #230 : check location on retif 1`] = `
+exports[`Test locations test #230 : check location on retif 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -838,7 +838,7 @@ Program {
 }
 `;
 
-exports[`Test locations abstract class (inner statement) 1`] = `
+exports[`Test locations test abstract class (inner statement) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -954,7 +954,7 @@ Program {
 }
 `;
 
-exports[`Test locations abstract class 1`] = `
+exports[`Test locations test abstract class 1`] = `
 Program {
   "children": Array [
     Class {
@@ -1015,7 +1015,7 @@ Program {
 }
 `;
 
-exports[`Test locations array 1`] = `
+exports[`Test locations test array 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -1180,7 +1180,7 @@ Program {
 }
 `;
 
-exports[`Test locations array nested 1`] = `
+exports[`Test locations test array nested 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -1383,7 +1383,7 @@ Program {
 }
 `;
 
-exports[`Test locations array short form 1`] = `
+exports[`Test locations test array short form 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -1548,7 +1548,7 @@ Program {
 }
 `;
 
-exports[`Test locations array short form nested 1`] = `
+exports[`Test locations test array short form nested 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -1751,7 +1751,7 @@ Program {
 }
 `;
 
-exports[`Test locations array with keys, byRef and unpack 1`] = `
+exports[`Test locations test array with keys, byRef and unpack 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -2067,7 +2067,7 @@ Program {
 }
 `;
 
-exports[`Test locations assign [] 1`] = `
+exports[`Test locations test assign [] 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -2175,7 +2175,7 @@ Program {
 }
 `;
 
-exports[`Test locations assign 1`] = `
+exports[`Test locations test assign 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -2266,7 +2266,7 @@ Program {
 }
 `;
 
-exports[`Test locations assign by ref 1`] = `
+exports[`Test locations test assign by ref 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -2356,7 +2356,7 @@ Program {
 }
 `;
 
-exports[`Test locations assign mutliple 1`] = `
+exports[`Test locations test assign mutliple 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -2482,7 +2482,7 @@ Program {
 }
 `;
 
-exports[`Test locations bin 1`] = `
+exports[`Test locations test bin 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -2607,7 +2607,7 @@ Program {
 }
 `;
 
-exports[`Test locations bin 2`] = `
+exports[`Test locations test bin 2`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -2697,7 +2697,7 @@ Program {
 }
 `;
 
-exports[`Test locations bin nested (2) 1`] = `
+exports[`Test locations test bin nested (2) 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -2822,7 +2822,7 @@ Program {
 }
 `;
 
-exports[`Test locations bin nested 1`] = `
+exports[`Test locations test bin nested 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -2947,7 +2947,7 @@ Program {
 }
 `;
 
-exports[`Test locations break 1`] = `
+exports[`Test locations test break 1`] = `
 Program {
   "children": Array [
     Break {
@@ -2986,7 +2986,7 @@ Program {
 }
 `;
 
-exports[`Test locations cast 1`] = `
+exports[`Test locations test cast 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -3097,7 +3097,7 @@ Program {
 }
 `;
 
-exports[`Test locations class (inner statement) 1`] = `
+exports[`Test locations test class (inner statement) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -3213,7 +3213,7 @@ Program {
 }
 `;
 
-exports[`Test locations class 1`] = `
+exports[`Test locations test class 1`] = `
 Program {
   "children": Array [
     Class {
@@ -3274,7 +3274,7 @@ Program {
 }
 `;
 
-exports[`Test locations clone 1`] = `
+exports[`Test locations test clone 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -3346,7 +3346,7 @@ Program {
 }
 `;
 
-exports[`Test locations conststatement 1`] = `
+exports[`Test locations test conststatement 1`] = `
 Program {
   "children": Array [
     ConstantStatement {
@@ -3439,7 +3439,7 @@ Program {
 }
 `;
 
-exports[`Test locations conststatement multiple 1`] = `
+exports[`Test locations test conststatement multiple 1`] = `
 Program {
   "children": Array [
     ConstantStatement {
@@ -3585,7 +3585,7 @@ Program {
 }
 `;
 
-exports[`Test locations continue 1`] = `
+exports[`Test locations test continue 1`] = `
 Program {
   "children": Array [
     Continue {
@@ -3624,7 +3624,7 @@ Program {
 }
 `;
 
-exports[`Test locations declare 1`] = `
+exports[`Test locations test declare 1`] = `
 Program {
   "children": Array [
     Declare {
@@ -3716,7 +3716,7 @@ Program {
 }
 `;
 
-exports[`Test locations declare block 1`] = `
+exports[`Test locations test declare block 1`] = `
 Program {
   "children": Array [
     Declare {
@@ -3848,7 +3848,7 @@ Program {
 }
 `;
 
-exports[`Test locations declare directive (multiple) 1`] = `
+exports[`Test locations test declare directive (multiple) 1`] = `
 Program {
   "children": Array [
     Declare {
@@ -3857,12 +3857,51 @@ Program {
         DeclareDirective {
           "key": Identifier {
             "kind": "identifier",
+            "loc": Location {
+              "end": Position {
+                "column": 10,
+                "line": 1,
+                "offset": 10,
+              },
+              "source": "A",
+              "start": Position {
+                "column": 9,
+                "line": 1,
+                "offset": 9,
+              },
+            },
             "name": "A",
           },
           "kind": "declaredirective",
+          "loc": Location {
+            "end": Position {
+              "column": 14,
+              "line": 1,
+              "offset": 14,
+            },
+            "source": "A='B'",
+            "start": Position {
+              "column": 9,
+              "line": 1,
+              "offset": 9,
+            },
+          },
           "value": String {
             "isDoubleQuote": false,
             "kind": "string",
+            "loc": Location {
+              "end": Position {
+                "column": 14,
+                "line": 1,
+                "offset": 14,
+              },
+              "source": "'B'",
+              "start": Position {
+                "column": 11,
+                "line": 1,
+                "offset": 11,
+              },
+            },
             "raw": "'B'",
             "unicode": false,
             "value": "B",
@@ -3871,12 +3910,51 @@ Program {
         DeclareDirective {
           "key": Identifier {
             "kind": "identifier",
+            "loc": Location {
+              "end": Position {
+                "column": 17,
+                "line": 1,
+                "offset": 17,
+              },
+              "source": "C",
+              "start": Position {
+                "column": 16,
+                "line": 1,
+                "offset": 16,
+              },
+            },
             "name": "C",
           },
           "kind": "declaredirective",
+          "loc": Location {
+            "end": Position {
+              "column": 21,
+              "line": 1,
+              "offset": 21,
+            },
+            "source": "C='D'",
+            "start": Position {
+              "column": 16,
+              "line": 1,
+              "offset": 16,
+            },
+          },
           "value": String {
             "isDoubleQuote": false,
             "kind": "string",
+            "loc": Location {
+              "end": Position {
+                "column": 21,
+                "line": 1,
+                "offset": 21,
+              },
+              "source": "'D'",
+              "start": Position {
+                "column": 18,
+                "line": 1,
+                "offset": 18,
+              },
+            },
             "raw": "'D'",
             "unicode": false,
             "value": "D",
@@ -3884,15 +3962,41 @@ Program {
         },
       ],
       "kind": "declare",
+      "loc": Location {
+        "end": Position {
+          "column": 26,
+          "line": 1,
+          "offset": 26,
+        },
+        "source": "declare (A='B', C='D') { }",
+        "start": Position {
+          "column": 0,
+          "line": 1,
+          "offset": 0,
+        },
+      },
       "mode": "block",
     },
   ],
   "errors": Array [],
   "kind": "program",
+  "loc": Location {
+    "end": Position {
+      "column": 26,
+      "line": 1,
+      "offset": 26,
+    },
+    "source": "declare (A='B', C='D') { }",
+    "start": Position {
+      "column": 0,
+      "line": 1,
+      "offset": 0,
+    },
+  },
 }
 `;
 
-exports[`Test locations declare directive 1`] = `
+exports[`Test locations test declare directive 1`] = `
 Program {
   "children": Array [
     Declare {
@@ -3901,25 +4005,90 @@ Program {
         DeclareDirective {
           "key": Identifier {
             "kind": "identifier",
+            "loc": Location {
+              "end": Position {
+                "column": 21,
+                "line": 1,
+                "offset": 21,
+              },
+              "source": "strict_types",
+              "start": Position {
+                "column": 9,
+                "line": 1,
+                "offset": 9,
+              },
+            },
             "name": "strict_types",
           },
           "kind": "declaredirective",
+          "loc": Location {
+            "end": Position {
+              "column": 23,
+              "line": 1,
+              "offset": 23,
+            },
+            "source": "strict_types=1",
+            "start": Position {
+              "column": 9,
+              "line": 1,
+              "offset": 9,
+            },
+          },
           "value": Number {
             "kind": "number",
+            "loc": Location {
+              "end": Position {
+                "column": 23,
+                "line": 1,
+                "offset": 23,
+              },
+              "source": "1",
+              "start": Position {
+                "column": 22,
+                "line": 1,
+                "offset": 22,
+              },
+            },
             "value": "1",
           },
         },
       ],
       "kind": "declare",
+      "loc": Location {
+        "end": Position {
+          "column": 25,
+          "line": 1,
+          "offset": 25,
+        },
+        "source": "declare (strict_types=1);",
+        "start": Position {
+          "column": 0,
+          "line": 1,
+          "offset": 0,
+        },
+      },
       "mode": "none",
     },
   ],
   "errors": Array [],
   "kind": "program",
+  "loc": Location {
+    "end": Position {
+      "column": 25,
+      "line": 1,
+      "offset": 25,
+    },
+    "source": "declare (strict_types=1);",
+    "start": Position {
+      "column": 0,
+      "line": 1,
+      "offset": 0,
+    },
+  },
 }
 `;
 
-exports[`Test locations do 1`] = `
+exports[`Test locations test do 1`] = `
 Program {
   "children": Array [
     Do {
@@ -4030,7 +4199,7 @@ Program {
 }
 `;
 
-exports[`Test locations echo 1`] = `
+exports[`Test locations test echo 1`] = `
 Program {
   "children": Array [
     Echo {
@@ -4091,7 +4260,7 @@ Program {
 }
 `;
 
-exports[`Test locations empty 1`] = `
+exports[`Test locations test empty 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -4198,7 +4367,7 @@ Program {
 }
 `;
 
-exports[`Test locations encapsed heredoc 1`] = `
+exports[`Test locations test encapsed heredoc 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -4307,7 +4476,7 @@ EOD;",
 }
 `;
 
-exports[`Test locations encapsed heredoc assign 1`] = `
+exports[`Test locations test encapsed heredoc assign 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -4453,7 +4622,7 @@ EOD;",
 }
 `;
 
-exports[`Test locations encapsed shell 1`] = `
+exports[`Test locations test encapsed shell 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -4584,7 +4753,7 @@ Program {
 }
 `;
 
-exports[`Test locations encapsed shell multiline 1`] = `
+exports[`Test locations test encapsed shell multiline 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -4751,7 +4920,7 @@ command;
 }
 `;
 
-exports[`Test locations encapsed string 1`] = `
+exports[`Test locations test encapsed string 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -4921,7 +5090,7 @@ Program {
 }
 `;
 
-exports[`Test locations encapsed string assign 1`] = `
+exports[`Test locations test encapsed string assign 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -5126,7 +5295,7 @@ Program {
 }
 `;
 
-exports[`Test locations encapsed string multiline 1`] = `
+exports[`Test locations test encapsed string multiline 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -5349,7 +5518,7 @@ string\\";",
 }
 `;
 
-exports[`Test locations eval 1`] = `
+exports[`Test locations test eval 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -5423,7 +5592,7 @@ Program {
 }
 `;
 
-exports[`Test locations exit 1`] = `
+exports[`Test locations test exit 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -5495,7 +5664,7 @@ Program {
 }
 `;
 
-exports[`Test locations final class (inner statement) 1`] = `
+exports[`Test locations test final class (inner statement) 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -5611,7 +5780,7 @@ Program {
 }
 `;
 
-exports[`Test locations final class 1`] = `
+exports[`Test locations test final class 1`] = `
 Program {
   "children": Array [
     Class {
@@ -5672,7 +5841,7 @@ Program {
 }
 `;
 
-exports[`Test locations for 1`] = `
+exports[`Test locations test for 1`] = `
 Program {
   "children": Array [
     For {
@@ -5895,7 +6064,7 @@ Program {
 }
 `;
 
-exports[`Test locations for block 1`] = `
+exports[`Test locations test for block 1`] = `
 Program {
   "children": Array [
     For {
@@ -6136,7 +6305,7 @@ Program {
 }
 `;
 
-exports[`Test locations foreach 1`] = `
+exports[`Test locations test foreach 1`] = `
 Program {
   "children": Array [
     Foreach {
@@ -6251,7 +6420,7 @@ Program {
 }
 `;
 
-exports[`Test locations foreach block 1`] = `
+exports[`Test locations test foreach block 1`] = `
 Program {
   "children": Array [
     Foreach {
@@ -6384,7 +6553,7 @@ Program {
 }
 `;
 
-exports[`Test locations function 1`] = `
+exports[`Test locations test function 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -6500,7 +6669,7 @@ Program {
 }
 `;
 
-exports[`Test locations global 1`] = `
+exports[`Test locations test global 1`] = `
 Program {
   "children": Array [
     Global {
@@ -6558,7 +6727,7 @@ Program {
 }
 `;
 
-exports[`Test locations goto #2 1`] = `
+exports[`Test locations test goto #2 1`] = `
 Program {
   "children": Array [
     Goto {
@@ -6613,7 +6782,7 @@ Program {
 }
 `;
 
-exports[`Test locations goto 1`] = `
+exports[`Test locations test goto 1`] = `
 Program {
   "children": Array [
     Goto {
@@ -6668,7 +6837,7 @@ Program {
 }
 `;
 
-exports[`Test locations if/elseif/else 1`] = `
+exports[`Test locations test if/elseif/else 1`] = `
 Program {
   "children": Array [
     If {
@@ -6947,7 +7116,7 @@ Program {
 }
 `;
 
-exports[`Test locations if/elseif/else block 1`] = `
+exports[`Test locations test if/elseif/else block 1`] = `
 Program {
   "children": Array [
     If {
@@ -7280,7 +7449,7 @@ Program {
 }
 `;
 
-exports[`Test locations include 1`] = `
+exports[`Test locations test include 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -7356,7 +7525,7 @@ Program {
 }
 `;
 
-exports[`Test locations interface 1`] = `
+exports[`Test locations test interface 1`] = `
 Program {
   "children": Array [
     Interface {
@@ -7413,7 +7582,7 @@ Program {
 }
 `;
 
-exports[`Test locations isset 1`] = `
+exports[`Test locations test isset 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -7522,7 +7691,7 @@ Program {
 }
 `;
 
-exports[`Test locations label #2 1`] = `
+exports[`Test locations test label #2 1`] = `
 Program {
   "children": Array [
     Label {
@@ -7616,7 +7785,7 @@ Program {
 }
 `;
 
-exports[`Test locations label 1`] = `
+exports[`Test locations test label 1`] = `
 Program {
   "children": Array [
     Label {
@@ -7710,7 +7879,7 @@ Program {
 }
 `;
 
-exports[`Test locations list 1`] = `
+exports[`Test locations test list 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -7913,7 +8082,7 @@ Program {
 }
 `;
 
-exports[`Test locations list short form 1`] = `
+exports[`Test locations test list short form 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -8116,7 +8285,7 @@ Program {
 }
 `;
 
-exports[`Test locations magic 1`] = `
+exports[`Test locations test magic 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -8172,7 +8341,7 @@ Program {
 }
 `;
 
-exports[`Test locations method (public) 1`] = `
+exports[`Test locations test method (public) 1`] = `
 Program {
   "children": Array [
     Class {
@@ -8292,7 +8461,7 @@ Program {
 }
 `;
 
-exports[`Test locations method 1`] = `
+exports[`Test locations test method 1`] = `
 Program {
   "children": Array [
     Class {
@@ -8412,7 +8581,7 @@ Program {
 }
 `;
 
-exports[`Test locations namespace 1`] = `
+exports[`Test locations test namespace 1`] = `
 Program {
   "children": Array [
     Namespace {
@@ -8453,7 +8622,7 @@ Program {
 }
 `;
 
-exports[`Test locations namespace backets 1`] = `
+exports[`Test locations test namespace backets 1`] = `
 Program {
   "children": Array [
     Namespace {
@@ -8534,7 +8703,7 @@ Program {
 }
 `;
 
-exports[`Test locations negative number 1`] = `
+exports[`Test locations test negative number 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -8606,7 +8775,7 @@ Program {
 }
 `;
 
-exports[`Test locations new 1`] = `
+exports[`Test locations test new 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -8679,7 +8848,7 @@ Program {
 }
 `;
 
-exports[`Test locations new anonymous class 1`] = `
+exports[`Test locations test new anonymous class 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -8792,7 +8961,7 @@ Program {
 }
 `;
 
-exports[`Test locations nowdoc 1`] = `
+exports[`Test locations test nowdoc 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -8857,7 +9026,7 @@ EOD;",
 }
 `;
 
-exports[`Test locations nowdoc assign 1`] = `
+exports[`Test locations test nowdoc assign 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -8959,7 +9128,7 @@ EOD;",
 }
 `;
 
-exports[`Test locations number 1`] = `
+exports[`Test locations test number 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -9014,7 +9183,7 @@ Program {
 }
 `;
 
-exports[`Test locations offsetlookup 1`] = `
+exports[`Test locations test offsetlookup 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -9295,7 +9464,7 @@ Program {
 }
 `;
 
-exports[`Test locations parameter 1`] = `
+exports[`Test locations test parameter 1`] = `
 Program {
   "children": Array [
     _Function {
@@ -9443,7 +9612,7 @@ Program {
 }
 `;
 
-exports[`Test locations post 1`] = `
+exports[`Test locations test post 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -9516,7 +9685,7 @@ Program {
 }
 `;
 
-exports[`Test locations pre 1`] = `
+exports[`Test locations test pre 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -9589,7 +9758,7 @@ Program {
 }
 `;
 
-exports[`Test locations print 1`] = `
+exports[`Test locations test print 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -9663,7 +9832,7 @@ Program {
 }
 `;
 
-exports[`Test locations propertylookup 1`] = `
+exports[`Test locations test propertylookup 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -10020,7 +10189,7 @@ Program {
 }
 `;
 
-exports[`Test locations retif 1`] = `
+exports[`Test locations test retif 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -10163,7 +10332,7 @@ Program {
 }
 `;
 
-exports[`Test locations retif nested 1`] = `
+exports[`Test locations test retif nested 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -10465,7 +10634,7 @@ Program {
 }
 `;
 
-exports[`Test locations return 1`] = `
+exports[`Test locations test return 1`] = `
 Program {
   "children": Array [
     Return {
@@ -10520,7 +10689,7 @@ Program {
 }
 `;
 
-exports[`Test locations silent 1`] = `
+exports[`Test locations test silent 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -10644,7 +10813,7 @@ Program {
 }
 `;
 
-exports[`Test locations silent 2`] = `
+exports[`Test locations test silent 2`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -10733,7 +10902,7 @@ Program {
 }
 `;
 
-exports[`Test locations single call 1`] = `
+exports[`Test locations test single call 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -10806,7 +10975,7 @@ Program {
 }
 `;
 
-exports[`Test locations static 1`] = `
+exports[`Test locations test static 1`] = `
 Program {
   "children": Array [
     Static {
@@ -10897,7 +11066,7 @@ Program {
 }
 `;
 
-exports[`Test locations static multiple 1`] = `
+exports[`Test locations test static multiple 1`] = `
 Program {
   "children": Array [
     Static {
@@ -11090,7 +11259,7 @@ Program {
 }
 `;
 
-exports[`Test locations staticlookup 1`] = `
+exports[`Test locations test staticlookup 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -11447,7 +11616,7 @@ Program {
 }
 `;
 
-exports[`Test locations string double quotes 1`] = `
+exports[`Test locations test string double quotes 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -11505,7 +11674,7 @@ Program {
 }
 `;
 
-exports[`Test locations string single quotes 1`] = `
+exports[`Test locations test string single quotes 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -11563,7 +11732,7 @@ Program {
 }
 `;
 
-exports[`Test locations switch 1`] = `
+exports[`Test locations test switch 1`] = `
 Program {
   "children": Array [
     Switch {
@@ -11637,7 +11806,7 @@ Program {
 }
 `;
 
-exports[`Test locations switch case 1`] = `
+exports[`Test locations test switch case 1`] = `
 Program {
   "children": Array [
     Switch {
@@ -11819,7 +11988,7 @@ Program {
 }
 `;
 
-exports[`Test locations switch default 1`] = `
+exports[`Test locations test switch default 1`] = `
 Program {
   "children": Array [
     Switch {
@@ -11968,7 +12137,7 @@ Program {
 }
 `;
 
-exports[`Test locations ternary 1`] = `
+exports[`Test locations test ternary 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -12080,7 +12249,7 @@ Program {
 }
 `;
 
-exports[`Test locations ternary no true expression 1`] = `
+exports[`Test locations test ternary no true expression 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -12173,7 +12342,7 @@ Program {
 }
 `;
 
-exports[`Test locations trait 1`] = `
+exports[`Test locations test trait 1`] = `
 Program {
   "children": Array [
     Trait {
@@ -12229,7 +12398,7 @@ Program {
 }
 `;
 
-exports[`Test locations traituse 1`] = `
+exports[`Test locations test traituse 1`] = `
 Program {
   "children": Array [
     Class {
@@ -12328,7 +12497,7 @@ Program {
 }
 `;
 
-exports[`Test locations traituse adaptations 1`] = `
+exports[`Test locations test traituse adaptations 1`] = `
 Program {
   "children": Array [
     Class {
@@ -12642,7 +12811,7 @@ Program {
 }
 `;
 
-exports[`Test locations traituse multiple 1`] = `
+exports[`Test locations test traituse multiple 1`] = `
 Program {
   "children": Array [
     Class {
@@ -12759,7 +12928,7 @@ Program {
 }
 `;
 
-exports[`Test locations try 1`] = `
+exports[`Test locations test try 1`] = `
 Program {
   "children": Array [
     Try {
@@ -12850,7 +13019,7 @@ Program {
 }
 `;
 
-exports[`Test locations try/catch/finally 1`] = `
+exports[`Test locations test try/catch/finally 1`] = `
 Program {
   "children": Array [
     Try {
@@ -12995,7 +13164,7 @@ Program {
 }
 `;
 
-exports[`Test locations unary 1`] = `
+exports[`Test locations test unary 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -13068,7 +13237,7 @@ Program {
 }
 `;
 
-exports[`Test locations unset 1`] = `
+exports[`Test locations test unset 1`] = `
 Program {
   "children": Array [
     Unset {
@@ -13126,7 +13295,7 @@ Program {
 }
 `;
 
-exports[`Test locations variable 1`] = `
+exports[`Test locations test variable 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -13182,7 +13351,7 @@ Program {
 }
 `;
 
-exports[`Test locations variadic 1`] = `
+exports[`Test locations test variadic 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -13290,7 +13459,7 @@ Program {
 }
 `;
 
-exports[`Test locations while 1`] = `
+exports[`Test locations test while 1`] = `
 Program {
   "children": Array [
     While {
@@ -13386,7 +13555,7 @@ Program {
 }
 `;
 
-exports[`Test locations while block 1`] = `
+exports[`Test locations test while block 1`] = `
 Program {
   "children": Array [
     While {
@@ -13500,7 +13669,7 @@ Program {
 }
 `;
 
-exports[`Test locations yield 1`] = `
+exports[`Test locations test yield 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
@@ -13573,7 +13742,7 @@ Program {
 }
 `;
 
-exports[`Test locations yield from 1`] = `
+exports[`Test locations test yield from 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {

--- a/test/snapshot/__snapshots__/number.test.js.snap
+++ b/test/snapshot/__snapshots__/number.test.js.snap
@@ -4,6 +4,13 @@ exports[`Test numbers test common cases 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {
+      "expression": Number {
+        "kind": "number",
+        "value": "1234",
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
       "expression": Assign {
         "kind": "assign",
         "left": Variable {
@@ -164,22 +171,6 @@ Program {
           "kind": "number",
           "value": "7E-10",
         },
-      },
-      "kind": "expressionstatement",
-    },
-  ],
-  "errors": Array [],
-  "kind": "program",
-}
-`;
-
-exports[`Test numbers test common cases 2`] = `
-Program {
-  "children": Array [
-    ExpressionStatement {
-      "expression": Number {
-        "kind": "number",
-        "value": "1234",
       },
       "kind": "expressionstatement",
     },

--- a/test/snapshot/__snapshots__/scalar.test.js.snap
+++ b/test/snapshot/__snapshots__/scalar.test.js.snap
@@ -26,7 +26,7 @@ Program {
 }
 `;
 
-exports[`Test scalar statements test constants #2 2`] = `
+exports[`Test scalar statements test constants #3 1`] = `
 Program {
   "children": Array [
     ExpressionStatement {

--- a/test/snapshot/array.test.js
+++ b/test/snapshot/array.test.js
@@ -67,19 +67,19 @@ describe("Array without keys", () => {
     expect(parser.parseEval("['foo', 'bar']")).toMatchSnapshot();
   });
 
-  it("array without trailing commas", () => {
+  it("array without trailing commas #2", () => {
     expect(parser.parseEval("['foo', 'bar']")).toMatchSnapshot();
   });
 
-  it("array with trailing commas", () => {
+  it("array with trailing commas #3", () => {
     expect(parser.parseEval("['foo', 'bar',]")).toMatchSnapshot();
   });
 
-  it("array with trailing commas #2", () => {
+  it("array with trailing commas #4", () => {
     expect(parser.parseEval("['foo', 'bar'   ,]")).toMatchSnapshot();
   });
 
-  it("array with trailing commas #3", () => {
+  it("array with trailing commas #5", () => {
     expect(parser.parseEval("['foo', 'bar'   ,   ]")).toMatchSnapshot();
   });
 

--- a/test/snapshot/arrowfunc.test.js
+++ b/test/snapshot/arrowfunc.test.js
@@ -1,32 +1,17 @@
 const parser = require("../main");
 
 describe("arrow function", () => {
-  it("simple", () => {
-    expect(parser.parseEval('$var = fn() => "something";')).toMatchSnapshot();
+  it.each([
+    ["simple", '$var = fn() => "something";'],
+    ["argument", '$var = fn($arg) =>  "something";'],
+    ["argument by ref", '$var = fn(&$arg) => "something";'],
+    ["arguments", '$var = fn($arg, $arg, $arg) => "something";'],
+    ["return type", '$var = fn(): ?string => "something";'],
+    ["inside call", `call(fn($arg) => $arg);`]
+  ])("%s", function(_, code) {
+    expect(parser.parseEval(code)).toMatchSnapshot();
   });
-  it("argument", () => {
-    expect(
-      parser.parseEval('$var = fn($arg) =>  "something";')
-    ).toMatchSnapshot();
-  });
-  it("argument by ref", () => {
-    expect(
-      parser.parseEval('$var = fn(&$arg) => "something";')
-    ).toMatchSnapshot();
-  });
-  it("arguments", () => {
-    expect(
-      parser.parseEval('$var = fn($arg, $arg, $arg) => "something";')
-    ).toMatchSnapshot();
-  });
-  it("return type", () => {
-    expect(
-      parser.parseEval('$var = fn(): ?string => "something";')
-    ).toMatchSnapshot();
-  });
-  it("inside call", () => {
-    expect(parser.parseEval(`call(fn($arg) => $arg);`)).toMatchSnapshot();
-  });
+
   it("error / fn passes on php7.3", () => {
     expect(
       parser.parseEval(`function fn($arg) { return $arg; }`, {

--- a/test/snapshot/byref.test.js
+++ b/test/snapshot/byref.test.js
@@ -33,9 +33,6 @@ describe("byref", () => {
   it("function definition", () => {
     expect(parser.parseEval("function &foo( &$bar ) { }")).toMatchSnapshot();
   });
-  it("variable", () => {
-    expect(parser.parseEval("$a = &$var;")).toMatchSnapshot();
-  });
   it("variadic", () => {
     expect(parser.parseEval("function test(&...$var) { }")).toMatchSnapshot();
   });
@@ -112,11 +109,6 @@ describe("byref", () => {
   });
   it.skip("propertylookup #2", () => {
     expect(parser.parseEval("$var = &($var)->test;")).toMatchSnapshot();
-  });
-  it("closure", () => {
-    expect(
-      parser.parseEval("$var = function () use (&$message) { };")
-    ).toMatchSnapshot();
   });
   it("with bin", () => {
     expect(parser.parseEval("$foo = &$bar || $bar;")).toMatchSnapshot();

--- a/test/snapshot/encapsed.test.js
+++ b/test/snapshot/encapsed.test.js
@@ -1,198 +1,103 @@
 const parser = require("../main");
 
 describe("encapsed", function() {
-  it("variable (simple syntax)", function() {
-    expect(parser.parseEval('"string $var string";')).toMatchSnapshot();
-  });
-  it("two variable (simple syntax)", function() {
-    expect(parser.parseEval('"string $var->$var string";')).toMatchSnapshot();
-  });
-  it("variable curly (simple syntax)", function() {
-    expect(parser.parseEval('"string ${var} string";')).toMatchSnapshot();
-  });
-  it("offsetlookup (simple syntax)", function() {
-    expect(parser.parseEval('"string $array[0] string";')).toMatchSnapshot();
-  });
-  it("offsetlookup (2) (simple syntax)", function() {
-    expect(
-      parser.parseEval('"string $array[koolaid1] string";')
-    ).toMatchSnapshot();
-  });
-  it("offsetlookup (3) (simple syntax)", function() {
-    expect(parser.parseEval('"string $array[0][0] string";')).toMatchSnapshot();
-  });
-  it("propertylookup (simple syntax)", function() {
-    expect(
-      parser.parseEval('"string $obj->property string";')
-    ).toMatchSnapshot();
-  });
-  it("variable with space opening before curly", function() {
-    expect(parser.parseEval('"string { $var} string";')).toMatchSnapshot();
-  });
-  it("variable with before closing curly", function() {
-    expect(parser.parseEval('"string {$var } string";')).toMatchSnapshot();
-  });
-  it("variable (complex syntax)", function() {
-    expect(parser.parseEval('"string {$var} string";')).toMatchSnapshot();
-  });
-  it("propertylookup (complex syntax)", function() {
-    expect(
-      parser.parseEval('"string {$obj->property} string";')
-    ).toMatchSnapshot();
-  });
-  it("offsetlookup (complex syntax)", function() {
-    expect(
-      parser.parseEval('"string {$array["key"]} string";')
-    ).toMatchSnapshot();
-  });
-  it("offsetlookup 2 (complex syntax)", function() {
-    expect(
-      parser.parseEval('"string {$array[4][3]} string";')
-    ).toMatchSnapshot();
-  });
-  it("offsetlookup 3 (complex syntax)", function() {
-    expect(
-      parser.parseEval('"string {$arr[foo][3]} string";')
-    ).toMatchSnapshot();
-  });
-  it("offsetlookup 4 (complex syntax)", function() {
-    expect(
-      parser.parseEval('"string {$arr["foo"][3]} string";')
-    ).toMatchSnapshot();
-  });
-  it("propertylookup and offsetlookup (complex syntax)", function() {
-    expect(
-      parser.parseEval('"string {$obj->values[3]->name} string";')
-    ).toMatchSnapshot();
-  });
-  it("value of the var (complex syntax)", function() {
-    expect(parser.parseEval('"string {${$name}} string";')).toMatchSnapshot();
-  });
-  it("value of the var named by the return value (complex syntax)", function() {
-    expect(parser.parseEval('"string {${call()}} string";')).toMatchSnapshot();
-  });
-  it("value of the var named by the return value (2) (complex syntax)", function() {
-    expect(parser.parseEval('"string {${call()}} string";')).toMatchSnapshot();
-  });
-  it("value of the var named by the return value (3) (complex syntax)", function() {
-    expect(
-      parser.parseEval('"string {${$obj->property}} string";')
-    ).toMatchSnapshot();
-  });
-  it("value of the var named by the return value (4) (complex syntax)", function() {
-    expect(
-      parser.parseEval('"string {${$obj->call()}} string";')
-    ).toMatchSnapshot();
-  });
-  it("value of the var named by the return value (5) (complex syntax)", function() {
-    expect(
-      parser.parseEval('"string {${$obj::$var}} string";')
-    ).toMatchSnapshot();
-  });
-  it("value of the var named by the return value (6) (complex syntax)", function() {
-    expect(
-      parser.parseEval('"string {${$obj::call()}} string";')
-    ).toMatchSnapshot();
-  });
-  it("propertylookup by variable (complex syntax)", function() {
-    expect(parser.parseEval('"string {$obj->$var} string";')).toMatchSnapshot();
-  });
-  it("propertylookup by variable (2) (complex syntax)", function() {
-    expect(
-      parser.parseEval('"string {$obj->{$array[1]}} string";')
-    ).toMatchSnapshot();
-  });
-  it("propertylookup with multiple call (complex syntax)", function() {
-    expect(
-      parser.parseEval('"string {$obj->call()->call()} string";')
-    ).toMatchSnapshot();
-  });
-  it("multiple propertylookup (complex syntax)", function() {
-    expect(
-      parser.parseEval('"string {$obj->property->property} string";')
-    ).toMatchSnapshot();
-  });
-  it("propertylookup with comments (complex syntax)", function() {
-    expect(
-      parser.parseEval('"string {$var->foo->bar /* Comment */ } string";')
-    ).toMatchSnapshot();
-  });
-  it("newline before closing curly (complex syntax)", function() {
-    expect(parser.parseEval('"string {$var\n} string";')).toMatchSnapshot();
-  });
-  it("staticlookup (complex syntax)", function() {
-    expect(parser.parseEval('"string {$obj::$var} string";')).toMatchSnapshot();
-  });
-  it("staticlookup (2) (complex syntax)", function() {
-    expect(
-      parser.parseEval('"string {$obj::call()} string";')
-    ).toMatchSnapshot();
-  });
-  it("staticlookup (3) (complex syntax)", function() {
-    expect(
-      parser.parseEval('"string {$obj::$var::$var} string";')
-    ).toMatchSnapshot();
-  });
-  it("staticlookup (4) (complex syntax)", function() {
-    expect(
-      parser.parseEval(
-        '"string {$var::$target::$resource::$binary::$foo::$bar::$foobar::$bar::$foo::$foobar::$bar::$foo} string";'
-      )
-    ).toMatchSnapshot();
-  });
-  it("string offset in encapsed var offset", () => {
-    expect(parser.parseEval(`"$var[var]";`)).toMatchSnapshot();
-  });
-  it("positive offset in encapsed var offset", () => {
-    expect(parser.parseEval(`"$var[1]";`)).toMatchSnapshot();
-  });
-  it("negative offset in encapsed var offset", () => {
-    expect(parser.parseEval(`"$var[-1]";`)).toMatchSnapshot();
-  });
-  it("string offset in encapsed var offset", () => {
-    expect(parser.parseEval(`"$var[$var]";`)).toMatchSnapshot();
-  });
-  it("dollar open curly braces", () => {
-    expect(parser.parseEval('"string ${juice} string";')).toMatchSnapshot();
-  });
-  it("dollar open curly braces #2", () => {
-    expect(parser.parseEval('"string ${$juice} string";')).toMatchSnapshot();
-  });
-  it("dollar open curly braces #3", () => {
-    expect(parser.parseEval('"string ${${$juice}} string";')).toMatchSnapshot();
-  });
-  it("dollar open curly braces #4", () => {
-    expect(parser.parseEval('"string ${call()} string";')).toMatchSnapshot();
-  });
-  it("dollar open curly braces #5", () => {
-    expect(
-      parser.parseEval('"string ${test[test]} string";')
-    ).toMatchSnapshot();
-  });
-  it("dollar open curly braces #6", () => {
-    expect(parser.parseEval('"string ${test[1]} string";')).toMatchSnapshot();
-  });
-  it("dollar open curly braces #7", () => {
-    expect(parser.parseEval('"string ${test[-1]} string";')).toMatchSnapshot();
-  });
-  it("dollar open curly braces #8", () => {
-    expect(
-      parser.parseEval('"string ${test[$var]} string";')
-    ).toMatchSnapshot();
-  });
-  it("curly", () => {
-    expect(parser.parseEval('"string {$juice} string";')).toMatchSnapshot();
-  });
-  it("curly #2", () => {
-    expect(parser.parseEval('"string {$$juice} string";')).toMatchSnapshot();
-  });
-  it("curly #3", () => {
-    expect(parser.parseEval('"string {$call()} string";')).toMatchSnapshot();
-  });
-  it("no curly", () => {
-    expect(parser.parseEval('"string $$juice string";')).toMatchSnapshot();
-  });
-  it("propertylookup", () => {
-    expect(parser.parseEval('$this->{"set{$type}"};')).toMatchSnapshot();
+  it.each([
+    ["variable (simple syntax)", '"string $var string";'],
+    ["two variable (simple syntax)", '"string $var->$var string";'],
+    ["variable curly (simple syntax)", '"string ${var} string";'],
+    ["offsetlookup (simple syntax)", '"string $array[0] string";'],
+    ["offsetlookup (2) (simple syntax)", '"string $array[koolaid1] string";'],
+    ["offsetlookup (3) (simple syntax)", '"string $array[0][0] string";'],
+    ["propertylookup (simple syntax)", '"string $obj->property string";'],
+    ["variable with space opening before curly", '"string { $var} string";'],
+    ["variable with before closing curly", '"string {$var } string";'],
+    ["variable (complex syntax)", '"string {$var} string";'],
+    ["propertylookup (complex syntax)", '"string {$obj->property} string";'],
+    ["offsetlookup (complex syntax)", '"string {$array["key"]} string";'],
+    ["offsetlookup 2 (complex syntax)", '"string {$array[4][3]} string";'],
+    ["offsetlookup 3 (complex syntax)", '"string {$arr[foo][3]} string";'],
+    ["offsetlookup 4 (complex syntax)", '"string {$arr["foo"][3]} string";'],
+    [
+      "propertylookup and offsetlookup (complex syntax)",
+      '"string {$obj->values[3]->name} string";'
+    ],
+    ["value of the var (complex syntax)", '"string {${$name}} string";'],
+    [
+      "value of the var named by the return value (complex syntax)",
+      '"string {${call()}} string";'
+    ],
+    [
+      "value of the var named by the return value (2) (complex syntax)",
+      '"string {${call()}} string";'
+    ],
+    [
+      "value of the var named by the return value (3) (complex syntax)",
+      '"string {${$obj->property}} string";'
+    ],
+    [
+      "value of the var named by the return value (4) (complex syntax)",
+      '"string {${$obj->call()}} string";'
+    ],
+    [
+      "value of the var named by the return value (5) (complex syntax)",
+      '"string {${$obj::$var}} string";'
+    ],
+    [
+      "value of the var named by the return value (6) (complex syntax)",
+      '"string {${$obj::call()}} string";'
+    ],
+    [
+      "propertylookup by variable (complex syntax)",
+      '"string {$obj->$var} string";'
+    ],
+    [
+      "propertylookup by variable (2) (complex syntax)",
+      '"string {$obj->{$array[1]}} string";'
+    ],
+    [
+      "propertylookup with multiple call (complex syntax)",
+      '"string {$obj->call()->call()} string";'
+    ],
+    [
+      "multiple propertylookup (complex syntax)",
+      '"string {$obj->property->property} string";'
+    ],
+    [
+      "propertylookup with comments (complex syntax)",
+      '"string {$var->foo->bar /* Comment */ } string";'
+    ],
+    [
+      "newline before closing curly (complex syntax)",
+      '"string {$var\n} string";'
+    ],
+    ["staticlookup (complex syntax)", '"string {$obj::$var} string";'],
+    ["staticlookup (2) (complex syntax)", '"string {$obj::call()} string";'],
+    [
+      "staticlookup (3) (complex syntax)",
+      '"string {$obj::$var::$var} string";'
+    ],
+    [
+      "staticlookup (4) (complex syntax)",
+      '"string {$var::$target::$resource::$binary::$foo::$bar::$foobar::$bar::$foo::$foobar::$bar::$foo} string";'
+    ],
+    ["string offset in encapsed var offset", `"$var[var]";`],
+    ["positive offset in encapsed var offset", `"$var[1]";`],
+    ["negative offset in encapsed var offset", `"$var[-1]";`],
+    ["string offset in encapsed var offset", `"$var[$var]";`],
+    ["dollar open curly braces", '"string ${juice} string";'],
+    ["dollar open curly braces #2", '"string ${$juice} string";'],
+    ["dollar open curly braces #3", '"string ${${$juice}} string";'],
+    ["dollar open curly braces #4", '"string ${call()} string";'],
+    ["dollar open curly braces #5", '"string ${test[test]} string";'],
+    ["dollar open curly braces #6", '"string ${test[1]} string";'],
+    ["dollar open curly braces #7", '"string ${test[-1]} string";'],
+    ["dollar open curly braces #8", '"string ${test[$var]} string";'],
+    ["curly", '"string {$juice} string";'],
+    ["curly #2", '"string {$$juice} string";'],
+    ["curly #3", '"string {$call()} string";'],
+    ["no curly", '"string $$juice string";'],
+    ["propertylookup", '$this->{"set{$type}"};']
+  ])("%s", function(_, code) {
+    expect(parser.parseEval(code)).toMatchSnapshot();
   });
 });

--- a/test/snapshot/location.test.js
+++ b/test/snapshot/location.test.js
@@ -1,1111 +1,172 @@
 const parser = require("../main");
 
 describe("Test locations", function() {
-  it("#230 : check location", function() {
-    expect(
-      parser.parseEval("$var1 + $var2 + $var3;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("#230 : check location on retif", function() {
-    expect(
-      parser.parseEval(
-        "$var1 + $var2 ? true : $false ? $innerTrue : $innerFalse;",
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it("#230 : check location on cast", function() {
-    expect(
-      parser.parseEval("(string)$var1 + $var2;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("#202 : include calling argument", function() {
-    expect(
-      parser.parseEval("$foo->bar->baz($arg);", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("#164 : expr must include ;", function() {
-    expect(
-      parser.parseEval("$a = $b + 1;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("#164 : expr should avoid ?>", function() {
-    expect(
-      parser.parseCode("<?php $a = $b + 1 ?>", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("if/elseif/else", function() {
-    expect(
-      parser.parseEval(
-        'if ($a > $b) echo "something"; elseif ($a < $b) echo "something"; else echo "something";',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it("if/elseif/else block", function() {
-    expect(
-      parser.parseEval(
-        'if ($a > $b) { echo "something"; } elseif ($a < $b) { echo "something"; } else { echo "something"; }',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it("switch", function() {
-    expect(
-      parser.parseEval("switch ($i) {}", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("switch case", function() {
-    expect(
-      parser.parseEval('switch ($i) { case 0: echo "something"; break; }', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("switch default", function() {
-    expect(
-      parser.parseEval('switch ($i) { default: echo "something"; }', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("for", function() {
-    expect(
-      parser.parseEval('for ($i = 1; $i <= 10; $i++) echo "something";', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("for block", function() {
-    expect(
-      parser.parseEval('for ($i = 1; $i <= 10; $i++) { echo "something"; }', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("foreach", function() {
-    expect(
-      parser.parseEval('foreach ($arr as $value) echo "something";', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("foreach block", function() {
-    expect(
-      parser.parseEval('foreach ($arr as $value) { echo "something"; }', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("while", function() {
-    expect(
-      parser.parseEval('while(true) echo "something";', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("while block", function() {
-    expect(
-      parser.parseEval('while(true) { echo "something"; }', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("do", function() {
-    expect(
-      parser.parseEval("do { echo $i; } while(true);", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("return", function() {
-    expect(
-      parser.parseEval("return 1;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
+  it.each([
+    ["#230 : check location", "$var1 + $var2 + $var3;"],
+    [
+      "#230 : check location on retif",
+      "$var1 + $var2 ? true : $false ? $innerTrue : $innerFalse;"
+    ],
+    ["#230 : check location on cast", "(string)$var1 + $var2;"],
+    ["#202 : include calling argument", "$foo->bar->baz($arg);"],
+    ["#164 : expr must include ;", "$a = $b + 1;"],
+    [
+      "if/elseif/else",
+      'if ($a > $b) echo "something"; elseif ($a < $b) echo "something"; else echo "something";'
+    ],
+    [
+      "if/elseif/else block",
+      'if ($a > $b) { echo "something"; } elseif ($a < $b) { echo "something"; } else { echo "something"; }'
+    ],
+    ["switch", "switch ($i) {}"],
+    ["switch case", 'switch ($i) { case 0: echo "something"; break; }'],
+    ["switch default", 'switch ($i) { default: echo "something"; }'],
+    ["for", 'for ($i = 1; $i <= 10; $i++) echo "something";'],
+    ["for block", 'for ($i = 1; $i <= 10; $i++) { echo "something"; }'],
+    ["foreach", 'foreach ($arr as $value) echo "something";'],
+    ["foreach block", 'foreach ($arr as $value) { echo "something"; }'],
+    ["while", 'while(true) echo "something";'],
+    ["while block", 'while(true) { echo "something"; }'],
+    ["do", "do { echo $i; } while(true);"],
+    ["return", "return 1;"],
+    ["break", "break;"],
 
-  it("break", function() {
-    expect(
-      parser.parseEval("break;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-
-  it("continue", function() {
-    expect(
-      parser.parseEval("continue;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("global", function() {
-    expect(
-      parser.parseEval("global $a;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("static", function() {
-    expect(
-      parser.parseEval("static $a = 1;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("static multiple", function() {
-    expect(
-      parser.parseEval("static $a = 1, $b = 2, $c = 3;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("echo", function() {
-    expect(
-      parser.parseEval('echo "something";', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("unset", function() {
-    expect(
-      parser.parseEval("unset($foo);", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("declare", function() {
-    expect(
-      parser.parseEval("declare(ticks=1);", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("declare block", function() {
-    expect(
-      parser.parseEval('declare(ticks=1) { echo "something"; }', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("try", function() {
-    expect(
-      parser.parseEval("try new Exception();", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("goto", function() {
-    expect(
-      parser.parseEval("goto a;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("goto #2", function() {
-    expect(
-      parser.parseEval("goto longName;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("label", function() {
-    expect(
-      parser.parseEval('a: echo "something";', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("label #2", function() {
-    expect(
-      parser.parseEval('longName: echo "something";', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("function", function() {
-    expect(
-      parser.parseEval('function foo() { echo "something"; }', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("class", function() {
-    expect(
-      parser.parseEval("class Foo {}", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("abstract class", function() {
-    expect(
-      parser.parseEval("abstract class Foo {}", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("final class", function() {
-    expect(
-      parser.parseEval("final class Foo {}", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("class (inner statement)", function() {
-    expect(
-      parser.parseEval("function foo() { class Foo {} }", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("abstract class (inner statement)", function() {
-    expect(
-      parser.parseEval("function foo() { abstract class Foo {} }", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("final class (inner statement)", function() {
-    expect(
-      parser.parseEval("function foo() { final class Foo {} }", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("interface", function() {
-    expect(
-      parser.parseEval("interface Foo {}", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("trait", function() {
-    expect(
-      parser.parseEval("trait Foo {}", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("namespace", function() {
-    expect(
-      parser.parseEval("namespace my\\name;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("namespace backets", function() {
-    expect(
-      parser.parseEval('namespace my\\name { echo "something"; }', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("string double quotes", function() {
-    expect(
-      parser.parseEval('"string";', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("string single quotes", function() {
-    expect(
-      parser.parseEval("'string';", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("number", function() {
-    expect(
-      parser.parseEval("2112;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("negative number", function() {
-    expect(
-      parser.parseEval("-2112;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("magic", function() {
-    expect(
-      parser.parseEval("__DIR__;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("ternary", function() {
-    expect(
-      parser.parseEval('$valid ? "yes" : "no";', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("ternary no true expression", function() {
-    expect(
-      parser.parseEval('$valid ?: "no";', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("variable", function() {
-    expect(
-      parser.parseEval("$var;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("assign", function() {
-    expect(
-      parser.parseEval("$var = true;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("assign by ref", function() {
-    expect(
-      parser.parseEval("$var = &$var;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("assign mutliple", function() {
-    expect(
-      parser.parseEval("$var = $other = true;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("unary", function() {
-    expect(
-      parser.parseEval("!$var;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("pre", function() {
-    expect(
-      parser.parseEval("++$var;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("post", function() {
-    expect(
-      parser.parseEval("$var++;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("yield", function() {
-    expect(
-      parser.parseEval("yield $var;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("yield from", function() {
-    expect(
-      parser.parseEval("yield from from();", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("bin", function() {
-    expect(
-      parser.parseEval("$var = $var + 100;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("array", function() {
-    expect(
-      parser.parseEval("array(1, 2, 3);", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("array nested", function() {
-    expect(
-      parser.parseEval("array(array(1, 2, 3));", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("array short form", function() {
-    expect(
-      parser.parseEval("[1, 2, 3];", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("array short form nested", function() {
-    expect(
-      parser.parseEval("[[1, 2, 3]];", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("array with keys, byRef and unpack", function() {
-    expect(
-      parser.parseEval(
-        `$var = [1, 'foo', 'test' => $foo, 'test' => &$foo, ...$var];`,
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it("clone", function() {
-    expect(
-      parser.parseEval("clone $var;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("new", function() {
-    expect(
-      parser.parseEval("new Foo();", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("new anonymous class", function() {
-    expect(
-      parser.parseEval("$var = new class {};", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("eval", function() {
-    expect(
-      parser.parseEval('eval("code");', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("exit", function() {
-    expect(
-      parser.parseEval("exit(1);", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("print", function() {
-    expect(
-      parser.parseEval('print "something";', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("include", function() {
-    expect(
-      parser.parseEval('include "something";', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("isset", function() {
-    expect(
-      parser.parseEval("$var = isset($var);", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("empty", function() {
-    expect(
-      parser.parseEval("$var = empty($var);", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("silent", function() {
-    expect(
-      parser.parseEval("$var = @call();", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("variadic", function() {
-    expect(
-      parser.parseEval("call(...$var);", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("try/catch/finally", function() {
-    expect(
-      parser.parseEval("try {} catch (Exception $e) {} finally {}", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("nowdoc", function() {
-    expect(
-      parser.parseEval(
-        `<<<'EOD'
+    ["continue", "continue;"],
+    ["global", "global $a;"],
+    ["static", "static $a = 1;"],
+    ["static multiple", "static $a = 1, $b = 2, $c = 3;"],
+    ["echo", 'echo "something";'],
+    ["unset", "unset($foo);"],
+    ["declare", "declare(ticks=1);"],
+    ["declare block", 'declare(ticks=1) { echo "something"; }'],
+    ["try", "try new Exception();"],
+    ["goto", "goto a;"],
+    ["goto #2", "goto longName;"],
+    ["label", 'a: echo "something";'],
+    ["label #2", 'longName: echo "something";'],
+    ["function", 'function foo() { echo "something"; }'],
+    ["class", "class Foo {}"],
+    ["abstract class", "abstract class Foo {}"],
+    ["final class", "final class Foo {}"],
+    ["class (inner statement)", "function foo() { class Foo {} }"],
+    [
+      "abstract class (inner statement)",
+      "function foo() { abstract class Foo {} }"
+    ],
+    ["final class (inner statement)", "function foo() { final class Foo {} }"],
+    ["interface", "interface Foo {}"],
+    ["trait", "trait Foo {}"],
+    ["namespace", "namespace my\\name;"],
+    ["namespace backets", 'namespace my\\name { echo "something"; }'],
+    ["string double quotes", '"string";'],
+    ["string single quotes", "'string';"],
+    ["number", "2112;"],
+    ["negative number", "-2112;"],
+    ["magic", "__DIR__;"],
+    ["ternary", '$valid ? "yes" : "no";'],
+    ["ternary no true expression", '$valid ?: "no";'],
+    ["variable", "$var;"],
+    ["assign", "$var = true;"],
+    ["assign by ref", "$var = &$var;"],
+    ["assign mutliple", "$var = $other = true;"],
+    ["unary", "!$var;"],
+    ["pre", "++$var;"],
+    ["post", "$var++;"],
+    ["yield", "yield $var;"],
+    ["yield from", "yield from from();"],
+    ["bin", "$var = $var + 100;"],
+    ["array", "array(1, 2, 3);"],
+    ["array nested", "array(array(1, 2, 3));"],
+    ["array short form", "[1, 2, 3];"],
+    ["array short form nested", "[[1, 2, 3]];"],
+    [
+      "array with keys, byRef and unpack",
+      `$var = [1, 'foo', 'test' => $foo, 'test' => &$foo, ...$var];`
+    ],
+    ["clone", "clone $var;"],
+    ["new", "new Foo();"],
+    ["new anonymous class", "$var = new class {};"],
+    ["eval", 'eval("code");'],
+    ["exit", "exit(1);"],
+    ["print", 'print "something";'],
+    ["include", 'include "something";'],
+    ["isset", "$var = isset($var);"],
+    ["empty", "$var = empty($var);"],
+    ["silent", "$var = @call();"],
+    ["variadic", "call(...$var);"],
+    ["try/catch/finally", "try {} catch (Exception $e) {} finally {}"],
+    [
+      "nowdoc",
+      `<<<'EOD'
 Text
-EOD;`,
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it("nowdoc assign", function() {
-    expect(
-      parser.parseEval(
-        `$var = <<<'EOD'
+EOD;`
+    ],
+    [
+      "nowdoc assign",
+      `$var = <<<'EOD'
 Text
-EOD;`,
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it("encapsed heredoc", function() {
-    expect(
-      parser.parseEval(
-        `<<<EOD
+EOD;`
+    ],
+    [
+      "encapsed heredoc",
+      `<<<EOD
 Text
-EOD;`,
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it("encapsed heredoc assign", function() {
-    expect(
-      parser.parseEval(
-        `$var = <<<EOD
+EOD;`
+    ],
+    [
+      "encapsed heredoc assign",
+      `$var = <<<EOD
 Text
-EOD;`,
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it("encapsed shell", function() {
-    expect(
-      parser.parseEval("$var = `command`;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("encapsed shell multiline", function() {
-    expect(
-      parser.parseEval(
-        `$var = \`
+EOD;`
+    ],
+    ["encapsed shell", "$var = `command`;"],
+    [
+      "encapsed shell multiline",
+      `$var = \`
 command;
 command;
 command;
-\`;`,
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it("encapsed string", function() {
-    expect(
-      parser.parseEval('"string $var string";', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("encapsed string assign", function() {
-    expect(
-      parser.parseEval('$var = "string $var string";', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("encapsed string multiline", function() {
-    expect(
-      parser.parseEval(
-        `$var = "string
+\`;`
+    ],
+    ["encapsed string", '"string $var string";'],
+    ["encapsed string assign", '$var = "string $var string";'],
+    [
+      "encapsed string multiline",
+      `$var = "string
 $var
-string";`,
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it("list", function() {
-    expect(
-      parser.parseEval("list($a, $b, $c) = $var;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("list short form", function() {
-    expect(
-      parser.parseEval("[$a, $b, $c] = $var;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("traituse", function() {
-    expect(
-      parser.parseEval("class Foo { use Hello; }", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("traituse multiple", function() {
-    expect(
-      parser.parseEval("class Foo { use Hello, World; }", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("traituse adaptations", function() {
-    expect(
-      parser.parseEval(
-        "class Foo { use A, B { B::smallTalk insteadof A;  B::bigTalk as talk; sayHello as protected; sayHello as private myPrivateHello; } }",
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it("method", function() {
-    expect(
-      parser.parseEval("class Foo { function method() {} }", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("method (public)", function() {
-    expect(
-      parser.parseEval("class Foo { public function method() {} }", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("cast", function() {
-    expect(
-      parser.parseEval('$var = (int) "2112"', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("retif", function() {
-    expect(
-      parser.parseEval("$var = $var ? true : false;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("retif nested", function() {
-    expect(
-      parser.parseEval(
-        "$var = ($one ? true : false) ? ($two ? true : false) : ($three ? true : false);",
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it("parameter", function() {
-    expect(
-      parser.parseEval("function foo(?int $foo = 2112) {}", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("bin", function() {
-    expect(
-      parser.parseEval("$var + 2112;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("bin nested", function() {
-    expect(
-      parser.parseEval("$var + 2112 + $var;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("bin nested (2)", function() {
-    expect(
-      parser.parseEval("$var + $var + 2112;", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("silent", function() {
-    expect(
-      parser.parseEval("@call();", {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("conststatement", function() {
-    expect(
-      parser.parseEval('const CONSTANT = "Hello world!";', {
-        ast: {
-          withPositions: true,
-          withSource: true
-        }
-      })
-    ).toMatchSnapshot();
-  });
-  it("conststatement multiple", function() {
-    expect(
-      parser.parseEval(
-        'const CONSTANT = "Hello world!", OTHER_CONSTANT = "Other hello world!";',
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it("declare directive", function() {
-    expect(parser.parseEval("declare (strict_types=1);")).toMatchSnapshot();
-  });
-  it("declare directive (multiple)", function() {
-    expect(parser.parseEval("declare (A='B', C='D') { }")).toMatchSnapshot();
-  });
-  it("propertylookup", function() {
-    expect(
-      parser.parseEval(
-        `
+string";`
+    ],
+    ["list", "list($a, $b, $c) = $var;"],
+    ["list short form", "[$a, $b, $c] = $var;"],
+    ["traituse", "class Foo { use Hello; }"],
+    ["traituse multiple", "class Foo { use Hello, World; }"],
+    [
+      "traituse adaptations",
+      "class Foo { use A, B { B::smallTalk insteadof A;  B::bigTalk as talk; sayHello as protected; sayHello as private myPrivateHello; } }"
+    ],
+    ["method", "class Foo { function method() {} }"],
+    ["method (public)", "class Foo { public function method() {} }"],
+    ["cast", '$var = (int) "2112"'],
+    ["retif", "$var = $var ? true : false;"],
+    [
+      "retif nested",
+      "$var = ($one ? true : false) ? ($two ? true : false) : ($three ? true : false);"
+    ],
+    ["parameter", "function foo(?int $foo = 2112) {}"],
+    ["bin", "$var + 2112;"],
+    ["bin nested", "$var + 2112 + $var;"],
+    ["bin nested (2)", "$var + $var + 2112;"],
+    ["silent", "@call();"],
+    ["conststatement", 'const CONSTANT = "Hello world!";'],
+    [
+      "conststatement multiple",
+      'const CONSTANT = "Hello world!", OTHER_CONSTANT = "Other hello world!";'
+    ],
+    ["declare directive", "declare (strict_types=1);"],
+    ["declare directive (multiple)", "declare (A='B', C='D') { }"],
+    [
+      "propertylookup",
+      `
         $var = $var
           // Comment
           ->each() // Comment
@@ -1115,20 +176,11 @@ string";`,
           ->first() // Comment
           // Comment
           ->dump();
-        `,
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it("staticlookup", function() {
-    expect(
-      parser.parseEval(
         `
+    ],
+    [
+      "staticlookup",
+      `
         $var = $var
           // Comment
           ::each() // Comment
@@ -1138,20 +190,11 @@ string";`,
           ::first() // Comment
           // Comment
           ::dump();
-        `,
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it("offsetlookup", function() {
-    expect(
-      parser.parseEval(
         `
+    ],
+    [
+      "offsetlookup",
+      `
         $var = $var
           // Comment
           [ 'foo' ] // Comment
@@ -1161,19 +204,13 @@ string";`,
           ['baz'] // Comment
           // Comment
           ['qqq'];
-        `,
-        {
-          ast: {
-            withPositions: true,
-            withSource: true
-          }
-        }
-      )
-    ).toMatchSnapshot();
-  });
-  it("assign []", function() {
+        `
+    ],
+    ["assign []", `$var[] = $var`],
+    ["single call", `call();`]
+  ])("test %s", (_, code) => {
     expect(
-      parser.parseEval(`$var[] = $var`, {
+      parser.parseEval(code, {
         ast: {
           withPositions: true,
           withSource: true
@@ -1181,9 +218,10 @@ string";`,
       })
     ).toMatchSnapshot();
   });
-  it("single call", function() {
+
+  it("#164 : expr should avoid ?>", function() {
     expect(
-      parser.parseEval(`call();`, {
+      parser.parseCode("<?php $a = $b + 1 ?>", {
         ast: {
           withPositions: true,
           withSource: true

--- a/test/snapshot/number.test.js
+++ b/test/snapshot/number.test.js
@@ -4,6 +4,7 @@ describe("Test numbers", function() {
   it("test common cases", function() {
     expect(
       parser.parseEval(`
+      1234;
       $a = -1.5;
       $b = 1234;
       $c = 9223372036854775807;
@@ -35,9 +36,5 @@ describe("Test numbers", function() {
         }
       )
     ).toMatchSnapshot();
-  });
-
-  it("test common cases", function() {
-    expect(parser.parseEval("1234;")).toMatchSnapshot();
   });
 });

--- a/test/snapshot/scalar.test.js
+++ b/test/snapshot/scalar.test.js
@@ -1,36 +1,23 @@
 const parser = require("../main");
 
 describe("Test scalar statements", function() {
-  it("test constants", function() {
-    expect(parser.parseEval("$a = foo::ref[-5];")).toMatchSnapshot();
-  });
-
-  it("test constants #2", function() {
-    expect(parser.parseEval("$a = Foo;")).toMatchSnapshot();
-  });
-
-  it("test constants #2", function() {
-    expect(parser.parseEval("$a = $var::foo;")).toMatchSnapshot();
-  });
-
-  it("test dereferencable", function() {
-    expect(
-      parser.parseEval(`
+  it.each([
+    ["test constants", "$a = foo::ref[-5];"],
+    ["test constants #2", "$a = Foo;"],
+    ["test constants #3", "$a = $var::foo;"],
+    [
+      "test dereferencable",
+      `
       $a = foo::bar()[5]->test;
       $b = (new test())->foo();
       $c = (foo())[5];
       $d = (function($a) { return $a * 2; })(5);
-    `)
-    ).toMatchSnapshot();
-  });
-
-  it("test dereferencable_scalar", function() {
-    expect(parser.parseEval("$var = array(1);")).toMatchSnapshot();
-  });
-  it("test dereferencable_scalar #2", function() {
-    expect(parser.parseEval("$var = [1];")).toMatchSnapshot();
-  });
-  it("test dereferencable_scalar #3", function() {
-    expect(parser.parseEval('$var = "test";')).toMatchSnapshot();
+    `
+    ],
+    ["test dereferencable_scalar", "$var = array(1);"],
+    ["test dereferencable_scalar #2", "$var = [1];"],
+    ["test dereferencable_scalar #3", '$var = "test";']
+  ])("%s", function(_, code) {
+    expect(parser.parseEval(code)).toMatchSnapshot();
   });
 });

--- a/test/snapshot/string.test.js
+++ b/test/snapshot/string.test.js
@@ -226,56 +226,22 @@ describe("Test strings", function() {
     ).toMatchSnapshot();
   });
 
-  it("...", function() {
-    parser.parseEval('echo B"\\colors[1] contains >$colors[1]<\\n";');
-  });
-
-  it("...", function() {
-    parser.parseEval('echo "\\colors[1] contains >$colors [1]<\\n";');
-  });
-
-  it("...", function() {
-    parser.parseEval("echo \"~'.{{$expectedLength}}'\\$~s\";");
-  });
-
-  it("...", function() {
-    parser.parseEval("$a = b'\\t\\ra';");
-  });
-
-  it("...", function() {
-    parser.parseEval('$foo = array("v1.09azAZ-._~!$", true);');
-  });
-
-  it("...", function() {
-    parser.parseEval('$v = strtolower("$i.$j.$k-$rel");');
-  });
-
-  it("...", function() {
-    parser.parseEval('$text = "$text at line $line";');
-  });
-
-  it("...", function() {
-    parser.parseEval("return \"Class.create('$package$className',{\";");
-  });
-
-  it("...", function() {
-    parser.parseEval("echo \"yo : {$feeds[0]['title[0][value]']}\";");
-  });
-
-  it("...", function() {
-    parser.parseEval('return "\\x1B[{$color}m{$str}\\x1B[0m";');
-  });
-
-  it("...", function() {
-    parser.parseEval('echo "\\"$parts[0]\\"\\n";');
-  });
-
-  it("...", function() {
-    parser.parseEval('echo "Hello {".$obj->name."} !";');
-  });
-
-  it("...", function() {
-    parser.parseEval('echo "Hello {$obj->name} !";');
+  it.each([
+    'echo B"\\colors[1] contains >$colors[1]<\\n";',
+    'echo "\\colors[1] contains >$colors [1]<\\n";',
+    "echo \"~'.{{$expectedLength}}'\\$~s\";",
+    "$a = b'\\t\\ra';",
+    '$foo = array("v1.09azAZ-._~!$", true);',
+    '$v = strtolower("$i.$j.$k-$rel");',
+    '$text = "$text at line $line";',
+    "return \"Class.create('$package$className',{\";",
+    "echo \"yo : {$feeds[0]['title[0][value]']}\";",
+    'return "\\x1B[{$color}m{$str}\\x1B[0m";',
+    'echo "\\"$parts[0]\\"\\n";',
+    'echo "Hello {".$obj->name."} !";',
+    'echo "Hello {$obj->name} !";'
+  ])("string test: %s", function(code) {
+    parser.parseEval(code);
   });
 
   it("test encapsed elements", function() {

--- a/test/snapshot/unary.test.js
+++ b/test/snapshot/unary.test.js
@@ -1,82 +1,34 @@
 const parser = require("../main");
 
 describe("Test unary", function() {
-  it("simple", function() {
-    expect(parser.parseEval("!$var;")).toMatchSnapshot();
-  });
-  it("number", function() {
-    expect(parser.parseEval("-100;")).toMatchSnapshot();
-  });
-  it("number (2)", function() {
-    expect(parser.parseEval("+100;")).toMatchSnapshot();
-  });
-  it("number (3)", function() {
-    expect(parser.parseEval("~100;")).toMatchSnapshot();
-  });
-  it("number (4)", function() {
-    expect(parser.parseEval("!100;")).toMatchSnapshot();
-  });
-  it("string", function() {
-    expect(parser.parseEval('+"string";')).toMatchSnapshot();
-  });
-  it("string (2)", function() {
-    expect(parser.parseEval('-"string";')).toMatchSnapshot();
-  });
-  it("string (3)", function() {
-    expect(parser.parseEval('~"string";')).toMatchSnapshot();
-  });
-  it("string (4)", function() {
-    expect(parser.parseEval('!"string";')).toMatchSnapshot();
-  });
-  it("boolean", function() {
-    expect(parser.parseEval("!true;")).toMatchSnapshot();
-  });
-  it("multiple", function() {
-    expect(parser.parseEval("!!$var;")).toMatchSnapshot();
-  });
-  it("multiple", function() {
-    expect(parser.parseEval("~~$var;")).toMatchSnapshot();
-  });
-  it("multiple (2)", function() {
-    expect(parser.parseEval("--$var;")).toMatchSnapshot();
-  });
-  it("multiple (3)", function() {
-    expect(parser.parseEval("+(+$var);")).toMatchSnapshot();
-  });
-  it("multiple (4)", function() {
-    expect(parser.parseEval("-(-$var);")).toMatchSnapshot();
-  });
-  it("multiple (5)", function() {
-    expect(parser.parseEval("!!!!!$var;")).toMatchSnapshot();
-  });
-  it("parens", function() {
-    expect(parser.parseEval("(!$var);")).toMatchSnapshot();
-  });
-  it("parens (2)", function() {
-    expect(parser.parseEval("!($var);")).toMatchSnapshot();
-  });
-  it("parens (3)", function() {
-    expect(parser.parseEval("(-$var);")).toMatchSnapshot();
-  });
-  it("parens (4)", function() {
-    expect(parser.parseEval("-($var);")).toMatchSnapshot();
-  });
-  it("parens (5)", function() {
-    expect(parser.parseEval("(+$var);")).toMatchSnapshot();
-  });
-  it("parens (6)", function() {
-    expect(parser.parseEval("+($var);")).toMatchSnapshot();
-  });
-  it("parens (7)", function() {
-    expect(parser.parseEval("~($var);")).toMatchSnapshot();
-  });
-  it("parens (8)", function() {
-    expect(parser.parseEval("(~$var);")).toMatchSnapshot();
-  });
-  it("parens (9)", function() {
-    expect(parser.parseEval("(-100);")).toMatchSnapshot();
-  });
-  it("parens (10)", function() {
-    expect(parser.parseEval("-(100);")).toMatchSnapshot();
+  it.each([
+    ["simple", "!$var;"],
+    ["number", "-100;"],
+    ["number (2)", "+100;"],
+    ["number (3)", "~100;"],
+    ["number (4)", "!100;"],
+    ["string", '+"string";'],
+    ["string (2)", '-"string";'],
+    ["string (3)", '~"string";'],
+    ["string (4)", '!"string";'],
+    ["boolean", "!true;"],
+    ["multiple", "!!$var;"],
+    ["multiple", "~~$var;"],
+    ["multiple (2)", "--$var;"],
+    ["multiple (3)", "+(+$var);"],
+    ["multiple (4)", "-(-$var);"],
+    ["multiple (5)", "!!!!!$var;"],
+    ["parens", "(!$var);"],
+    ["parens (2)", "!($var);"],
+    ["parens (3)", "(-$var);"],
+    ["parens (4)", "-($var);"],
+    ["parens (5)", "(+$var);"],
+    ["parens (6)", "+($var);"],
+    ["parens (7)", "~($var);"],
+    ["parens (8)", "(~$var);"],
+    ["parens (9)", "(-100);"],
+    ["parens (10)", "-(100);"]
+  ])("%s", function(_, code) {
+    expect(parser.parseEval(code)).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
* extract jest config into jest.config.js
* run eslint using jest-runner-eslint
* rename "lint" script to "fix" because it includes --fix
* remove "cover" script, coverage can still be tested locally with
`COVERAGE=1 npm test`
* add eslint-plugin-jest
* remove some redundant tests
* refactor some tests using it.each