### PR TITLE
null coalesce operator should be right-associative

### DIFF
--- a/test/snapshot/__snapshots__/bin.test.js.snap
+++ b/test/snapshot/__snapshots__/bin.test.js.snap
@@ -561,6 +561,41 @@ Program {
 }
 `;
 
+exports[`bin ?? right-associative 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Bin {
+        "kind": "bin",
+        "left": Bin {
+          "kind": "bin",
+          "left": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "foo",
+          },
+          "right": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "bar",
+          },
+          "type": "??",
+        },
+        "right": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "bazz",
+        },
+        "type": "??",
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`bin ^ 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/bin.test.js
+++ b/test/snapshot/bin.test.js
@@ -103,6 +103,9 @@ describe("bin", () => {
   it("??", () => {
     expect(parser.parseEval("$foo ?? $bar;")).toMatchSnapshot();
   });
+  it("?? right-associative", () => {
+    expect(parser.parseEval("$foo ?? $bar ?? $bazz;")).toMatchSnapshot();
+  });
   it("?? (php < 7)", function() {
     const astErr = parser.parseEval(`$var ?? $var;`, {
       parser: {


### PR DESCRIPTION
This is actually just a bug report with an attached test: The null coalescing operator is currently evaluated in a left-associative style, while it should be right-associative.