### PR TITLE
Impl - add noop nodes on empty blocks

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -276,17 +276,18 @@ parser.prototype.parse = function(code, filename) {
   this.innerList = false;
   this.innerListForm = false;
   const program = this.node("program");
-  let childs = [];
+  const childs = [];
   this.next();
   while (this.token != this.EOF) {
-    const node = this.read_start();
-    if (node !== null && node !== undefined) {
-      if (Array.isArray(node)) {
-        childs = childs.concat(node);
-      } else {
-        childs.push(node);
-      }
-    }
+    childs.push(this.read_start());
+  }
+  // append last comment
+  if (
+    childs.length === 0 &&
+    this.extractDoc &&
+    this._docs.length > this._docIndex
+  ) {
+    childs.push(this.node("noop")());
   }
   // #176 : register latest position
   this.prev = [

--- a/src/parser/if.js
+++ b/src/parser/if.js
@@ -36,6 +36,13 @@ module.exports = {
         }
         items.push(this.read_inner_statement());
       }
+      if (
+        items.length === 0 &&
+        this.extractDoc &&
+        this._docs.length > this._docIndex
+      ) {
+        items.push(this.node("noop")());
+      }
       body = body(null, items);
       this.expect(this.tok.T_ENDIF) && this.next();
       this.expectEndOfStatement();
@@ -80,6 +87,13 @@ module.exports = {
       }
       items.push(this.read_inner_statement());
     }
+    if (
+      items.length === 0 &&
+      this.extractDoc &&
+      this._docs.length > this._docIndex
+    ) {
+      items.push(this.node("noop")());
+    }
     body = body(null, items);
     return result(test, body, alternate, true);
   },
@@ -92,6 +106,13 @@ module.exports = {
     const items = [];
     while (this.token != this.EOF && this.token !== this.tok.T_ENDIF) {
       items.push(this.read_inner_statement());
+    }
+    if (
+      items.length === 0 &&
+      this.extractDoc &&
+      this._docs.length > this._docIndex
+    ) {
+      items.push(this.node("noop")());
     }
     return body(null, items);
   }

--- a/src/parser/if.js
+++ b/src/parser/if.js
@@ -89,13 +89,6 @@ module.exports = {
     while (this.token != this.EOF && this.token !== this.tok.T_ENDIF) {
       items.push(this.read_inner_statement());
     }
-    if (
-      items.length === 0 &&
-      this.extractDoc &&
-      this._docs.length > this._docIndex
-    ) {
-      items.push(this.node("noop")());
-    }
     return body(null, items);
   }
 };

--- a/src/parser/if.js
+++ b/src/parser/if.js
@@ -15,11 +15,10 @@ module.exports = {
    */
   read_if: function() {
     const result = this.node("if");
+    const test = this.next().read_if_expr();
     let body = null;
     let alternate = null;
     let shortForm = false;
-    let test = null;
-    test = this.next().read_if_expr();
 
     if (this.token === ":") {
       shortForm = true;
@@ -35,13 +34,6 @@ module.exports = {
           break;
         }
         items.push(this.read_inner_statement());
-      }
-      if (
-        items.length === 0 &&
-        this.extractDoc &&
-        this._docs.length > this._docIndex
-      ) {
-        items.push(this.node("noop")());
       }
       body = body(null, items);
       this.expect(this.tok.T_ENDIF) && this.next();
@@ -69,14 +61,12 @@ module.exports = {
    * reads an elseif (expr): statements
    */
   read_elseif_short: function() {
-    const result = this.node("if");
     let alternate = null;
-    let test = null;
-    let body = null;
-    const items = [];
-    test = this.next().read_if_expr();
+    const result = this.node("if");
+    const test = this.next().read_if_expr();
     if (this.expect(":")) this.next();
-    body = this.node("block");
+    const body = this.node("block");
+    const items = [];
     while (this.token != this.EOF && this.token !== this.tok.T_ENDIF) {
       if (this.token === this.tok.T_ELSEIF) {
         alternate = this.read_elseif_short();
@@ -87,22 +77,14 @@ module.exports = {
       }
       items.push(this.read_inner_statement());
     }
-    if (
-      items.length === 0 &&
-      this.extractDoc &&
-      this._docs.length > this._docIndex
-    ) {
-      items.push(this.node("noop")());
-    }
-    body = body(null, items);
-    return result(test, body, alternate, true);
+    return result(test, body(null, items), alternate, true);
   },
   /**
    *
    */
   read_else_short: function() {
-    const body = this.node("block");
     if (this.next().expect(":")) this.next();
+    const body = this.node("block");
     const items = [];
     while (this.token != this.EOF && this.token !== this.tok.T_ENDIF) {
       items.push(this.read_inner_statement());

--- a/src/parser/namespace.js
+++ b/src/parser/namespace.js
@@ -21,37 +21,47 @@ module.exports = {
     const result = this.node("namespace");
     let body;
     this.expect(this.tok.T_NAMESPACE) && this.next();
+    let name;
+
     if (this.token == "{") {
-      this.currentNamespace = [""];
+      name = {
+        name: ""
+      };
+    } else {
+      name = this.read_namespace_name();
+    }
+    this.currentNamespace = name;
+
+    if (this.token == ";") {
+      this.currentNamespace = name;
+      body = this.next().read_top_statements();
+      this.expect(this.EOF);
+      return result(name.name, body, false);
+    } else if (this.token == "{") {
+      this.currentNamespace = name;
       body = this.next().read_top_statements();
       this.expect("}") && this.next();
-      return result([""], body, true);
-    } else {
-      const name = this.read_namespace_name();
-      if (this.token == ";") {
-        this.currentNamespace = name;
-        body = this.next().read_top_statements();
-        this.expect(this.EOF);
-        return result(name.name, body, false);
-      } else if (this.token == "{") {
-        this.currentNamespace = name;
-        body = this.next().read_top_statements();
-        this.expect("}") && this.next();
-        return result(name.name, body, true);
-      } else if (this.token === "(") {
-        // resolve ambuiguity between namespace & function call
-        name.resolution = this.ast.reference.RELATIVE_NAME;
-        name.name = name.name.substring(1);
-        result.destroy();
-        return this.node("call")(name, this.read_argument_list());
-      } else {
-        this.error(["{", ";"]);
-        // graceful mode :
-        this.currentNamespace = name;
-        body = this.read_top_statements();
-        this.expect(this.EOF);
-        return result(name, body, false);
+      if (
+        body.length === 0 &&
+        this.extractDoc &&
+        this._docs.length > this._docIndex
+      ) {
+        body.push(this.node("noop")());
       }
+      return result(name.name, body, true);
+    } else if (this.token === "(") {
+      // @fixme after merging #478
+      name.resolution = this.ast.reference.RELATIVE_NAME;
+      name.name = name.name.substring(1);
+      result.destroy();
+      return this.node("call")(name, this.read_argument_list());
+    } else {
+      this.error(["{", ";"]);
+      // graceful mode :
+      this.currentNamespace = name;
+      body = this.read_top_statements();
+      this.expect(this.EOF);
+      return result(name, body, false);
     }
   },
   /**

--- a/src/parser/namespace.js
+++ b/src/parser/namespace.js
@@ -25,7 +25,7 @@ module.exports = {
 
     if (this.token == "{") {
       name = {
-        name: ""
+        name: [""]
       };
     } else {
       name = this.read_namespace_name();

--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -311,6 +311,13 @@ module.exports = {
             // @todo : check declare_statement from php / not valid
             body.push(this.read_top_statement());
           }
+          if (
+            body.length === 0 &&
+            this.extractDoc &&
+            this._docs.length > this._docIndex
+          ) {
+            body.push(this.node("noop")());
+          }
           this.expect(this.tok.T_ENDDECLARE) && this.next();
           this.expectEndOfStatement();
           mode = this.ast.declare.MODE_SHORT;
@@ -319,6 +326,13 @@ module.exports = {
           while (this.token != this.EOF && this.token !== "}") {
             // @todo : check declare_statement from php / not valid
             body.push(this.read_top_statement());
+          }
+          if (
+            body.length === 0 &&
+            this.extractDoc &&
+            this._docs.length > this._docIndex
+          ) {
+            body.push(this.node("noop")());
           }
           this.expect("}") && this.next();
           mode = this.ast.declare.MODE_BLOCK;

--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -401,6 +401,13 @@ module.exports = {
     const body = top
       ? this.read_top_statements()
       : this.read_inner_statements();
+    if (
+      body.length === 0 &&
+      this.extractDoc &&
+      this._docs.length > this._docIndex
+    ) {
+      body.push(this.node("noop")());
+    }
     this.expect("}") && this.next();
     return result(null, body);
   }

--- a/src/parser/switch.js
+++ b/src/parser/switch.js
@@ -52,6 +52,13 @@ module.exports = {
     while (this.token !== this.EOF && this.token !== expect) {
       items.push(this.read_case_list(expect));
     }
+    if (
+      items.length === 0 &&
+      this.extractDoc &&
+      this._docs.length > this._docIndex
+    ) {
+      items.push(this.node("noop")());
+    }
     // CHECK END TOKEN
     this.expect(expect) && this.next();
     if (expect === this.tok.T_ENDSWITCH) {
@@ -86,6 +93,13 @@ module.exports = {
       this.token !== this.tok.T_DEFAULT
     ) {
       items.push(this.read_inner_statement());
+    }
+    if (
+      items.length === 0 &&
+      this.extractDoc &&
+      this._docs.length > this._docIndex
+    ) {
+      items.push(this.node("noop")());
     }
     return result(test, items.length > 0 ? body(null, items) : null);
   }

--- a/src/parser/switch.js
+++ b/src/parser/switch.js
@@ -94,13 +94,6 @@ module.exports = {
     ) {
       items.push(this.read_inner_statement());
     }
-    if (
-      items.length === 0 &&
-      this.extractDoc &&
-      this._docs.length > this._docIndex
-    ) {
-      items.push(this.node("noop")());
-    }
-    return result(test, items.length > 0 ? body(null, items) : null);
+    return result(test, body(null, items));
   }
 };

--- a/src/parser/utils.js
+++ b/src/parser/utils.js
@@ -18,6 +18,13 @@ module.exports = {
     while (this.token != this.EOF && this.token !== token) {
       items.push(this.read_inner_statement());
     }
+    if (
+      items.length === 0 &&
+      this.extractDoc &&
+      this._docs.length > this._docIndex
+    ) {
+      items.push(this.node("noop")());
+    }
     if (this.expect(token)) this.next();
     this.expectEndOfStatement();
     return body(null, items);

--- a/test/debug.js
+++ b/test/debug.js
@@ -19,13 +19,12 @@ const parser = require("../src/index");
 const ast = parser.parseCode(
   `
 <?php
-$a = 100_00;
-$bad = 100__00;
+declare(tick=1): /* 1 */ ENDDECLARE;
 `,
   {
     parser: {
-      debug: true
-      //extractDoc: true
+      debug: true,
+      extractDoc: true
     },
     ast: {
       withPositions: true,

--- a/test/snapshot/__snapshots__/acid.test.js.snap
+++ b/test/snapshot/__snapshots__/acid.test.js.snap
@@ -2230,7 +2230,24 @@ Program {
                     "body": Block {
                       "children": Array [
                         Case {
-                          "body": null,
+                          "body": Block {
+                            "children": Array [],
+                            "kind": "block",
+                            "loc": Location {
+                              "end": Position {
+                                "column": 19,
+                                "line": 63,
+                                "offset": 1314,
+                              },
+                              "source": "
+        ",
+                              "start": Position {
+                                "column": 8,
+                                "line": 64,
+                                "offset": 1323,
+                              },
+                            },
+                          },
                           "kind": "case",
                           "loc": Location {
                             "end": Position {

--- a/test/snapshot/__snapshots__/block.test.js.snap
+++ b/test/snapshot/__snapshots__/block.test.js.snap
@@ -1,5 +1,217 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`block empty class block 1`] = `
+Program {
+  "children": Array [
+    Class {
+      "body": Array [],
+      "extends": null,
+      "implements": null,
+      "isAbstract": false,
+      "isAnonymous": false,
+      "isFinal": false,
+      "kind": "class",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "foo",
+        "trailingComments": Array [
+          CommentBlock {
+            "kind": "commentblock",
+            "offset": 12,
+            "value": "/* 1 */",
+          },
+        ],
+      },
+    },
+  ],
+  "comments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 12,
+      "value": "/* 1 */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`block empty declare block 1`] = `
+Program {
+  "children": Array [
+    Declare {
+      "children": Array [],
+      "directives": Array [
+        DeclareDirective {
+          "key": Identifier {
+            "kind": "identifier",
+            "name": "tick",
+          },
+          "kind": "declaredirective",
+          "trailingComments": Array [
+            CommentBlock {
+              "kind": "commentblock",
+              "offset": 18,
+              "value": "/* 1 */",
+            },
+          ],
+          "value": Number {
+            "kind": "number",
+            "value": "1",
+          },
+        },
+      ],
+      "kind": "declare",
+      "mode": "block",
+    },
+  ],
+  "comments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 18,
+      "value": "/* 1 */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`block empty function block 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [],
+      "body": Block {
+        "children": Array [
+          Noop {
+            "kind": "noop",
+            "leadingComments": Array [
+              CommentBlock {
+                "kind": "commentblock",
+                "offset": 17,
+                "value": "/* 1 */",
+              },
+            ],
+          },
+        ],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "foo",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "comments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 17,
+      "value": "/* 1 */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`block empty method block 1`] = `
+Program {
+  "children": Array [
+    Class {
+      "body": Array [
+        Method {
+          "arguments": Array [],
+          "body": Block {
+            "children": Array [
+              Noop {
+                "kind": "noop",
+                "leadingComments": Array [
+                  CommentBlock {
+                    "kind": "commentblock",
+                    "offset": 30,
+                    "value": "/* 1 */",
+                  },
+                ],
+              },
+            ],
+            "kind": "block",
+          },
+          "byref": false,
+          "isAbstract": false,
+          "isFinal": false,
+          "isStatic": false,
+          "kind": "method",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "bar",
+          },
+          "nullable": false,
+          "type": null,
+          "visibility": "",
+        },
+      ],
+      "extends": null,
+      "implements": null,
+      "isAbstract": false,
+      "isAnonymous": false,
+      "isFinal": false,
+      "kind": "class",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "foo",
+      },
+    },
+  ],
+  "comments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 30,
+      "value": "/* 1 */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`block empty namespace block 1`] = `
+Program {
+  "children": Array [
+    Namespace {
+      "children": Array [
+        Noop {
+          "kind": "noop",
+          "leadingComments": Array [
+            CommentBlock {
+              "kind": "commentblock",
+              "offset": 16,
+              "value": "/* 1 */",
+            },
+          ],
+        },
+      ],
+      "kind": "namespace",
+      "name": "foo",
+      "withBrackets": true,
+    },
+  ],
+  "comments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 16,
+      "value": "/* 1 */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`block single 1`] = `
 Program {
   "children": Array [
@@ -25,6 +237,7 @@ Program {
       "kind": "block",
     },
   ],
+  "comments": Array [],
   "errors": Array [],
   "kind": "program",
 }

--- a/test/snapshot/__snapshots__/block.test.js.snap
+++ b/test/snapshot/__snapshots__/block.test.js.snap
@@ -203,6 +203,174 @@ Program {
 }
 `;
 
+exports[`block empty for 1`] = `
+Program {
+  "children": Array [
+    For {
+      "body": Block {
+        "children": Array [
+          Noop {
+            "kind": "noop",
+            "leadingComments": Array [
+              CommentBlock {
+                "kind": "commentblock",
+                "offset": 10,
+                "value": "/* foo */",
+              },
+            ],
+          },
+        ],
+        "kind": "block",
+      },
+      "increment": Array [],
+      "init": Array [],
+      "kind": "for",
+      "shortForm": false,
+      "test": Array [],
+    },
+  ],
+  "comments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 10,
+      "value": "/* foo */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`block empty for short form 1`] = `
+Program {
+  "children": Array [
+    For {
+      "body": Block {
+        "children": Array [
+          Noop {
+            "kind": "noop",
+            "leadingComments": Array [
+              CommentBlock {
+                "kind": "commentblock",
+                "offset": 10,
+                "value": "/* foo */",
+              },
+            ],
+          },
+        ],
+        "kind": "block",
+      },
+      "increment": Array [],
+      "init": Array [],
+      "kind": "for",
+      "shortForm": true,
+      "test": Array [],
+    },
+  ],
+  "comments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 10,
+      "value": "/* foo */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`block empty foreach 1`] = `
+Program {
+  "children": Array [
+    Foreach {
+      "body": Block {
+        "children": Array [
+          Noop {
+            "kind": "noop",
+            "leadingComments": Array [
+              CommentBlock {
+                "kind": "commentblock",
+                "offset": 24,
+                "value": "/* foo */",
+              },
+            ],
+          },
+        ],
+        "kind": "block",
+      },
+      "key": null,
+      "kind": "foreach",
+      "shortForm": false,
+      "source": Variable {
+        "curly": false,
+        "kind": "variable",
+        "name": "foo",
+      },
+      "value": Variable {
+        "curly": false,
+        "kind": "variable",
+        "name": "bar",
+      },
+    },
+  ],
+  "comments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 24,
+      "value": "/* foo */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`block empty foreach short form 1`] = `
+Program {
+  "children": Array [
+    Foreach {
+      "body": Block {
+        "children": Array [
+          Noop {
+            "kind": "noop",
+            "leadingComments": Array [
+              CommentBlock {
+                "kind": "commentblock",
+                "offset": 23,
+                "value": "/* foo */",
+              },
+            ],
+          },
+        ],
+        "kind": "block",
+      },
+      "key": null,
+      "kind": "foreach",
+      "shortForm": true,
+      "source": Variable {
+        "curly": false,
+        "kind": "variable",
+        "name": "foo",
+      },
+      "value": Variable {
+        "curly": false,
+        "kind": "variable",
+        "name": "bar",
+      },
+    },
+  ],
+  "comments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 23,
+      "value": "/* foo */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`block empty function block 1`] = `
 Program {
   "children": Array [
@@ -560,6 +728,48 @@ Program {
   ],
   "errors": Array [],
   "kind": "program",
+}
+`;
+
+exports[`block empty statement 1`] = `
+Program {
+  "children": Array [],
+  "comments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 0,
+      "value": "/* 1 */",
+    },
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 9,
+      "value": "/* 2 */",
+    },
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 20,
+      "value": "/* 3 */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+  "trailingComments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 0,
+      "value": "/* 1 */",
+    },
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 9,
+      "value": "/* 2 */",
+    },
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 20,
+      "value": "/* 3 */",
+    },
+  ],
 }
 `;
 

--- a/test/snapshot/__snapshots__/block.test.js.snap
+++ b/test/snapshot/__snapshots__/block.test.js.snap
@@ -40,7 +40,18 @@ exports[`block empty declare block 1`] = `
 Program {
   "children": Array [
     Declare {
-      "children": Array [],
+      "children": Array [
+        Noop {
+          "kind": "noop",
+          "leadingComments": Array [
+            CommentBlock {
+              "kind": "commentblock",
+              "offset": 18,
+              "value": "/* 1 */",
+            },
+          ],
+        },
+      ],
       "directives": Array [
         DeclareDirective {
           "key": Identifier {
@@ -48,13 +59,6 @@ Program {
             "name": "tick",
           },
           "kind": "declaredirective",
-          "trailingComments": Array [
-            CommentBlock {
-              "kind": "commentblock",
-              "offset": 18,
-              "value": "/* 1 */",
-            },
-          ],
           "value": Number {
             "kind": "number",
             "value": "1",
@@ -69,6 +73,51 @@ Program {
     CommentBlock {
       "kind": "commentblock",
       "offset": 18,
+      "value": "/* 1 */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`block empty declare short form 1`] = `
+Program {
+  "children": Array [
+    Declare {
+      "children": Array [
+        Noop {
+          "kind": "noop",
+          "leadingComments": Array [
+            CommentBlock {
+              "kind": "commentblock",
+              "offset": 17,
+              "value": "/* 1 */",
+            },
+          ],
+        },
+      ],
+      "directives": Array [
+        DeclareDirective {
+          "key": Identifier {
+            "kind": "identifier",
+            "name": "tick",
+          },
+          "kind": "declaredirective",
+          "value": Number {
+            "kind": "number",
+            "value": "1",
+          },
+        },
+      ],
+      "kind": "declare",
+      "mode": "short",
+    },
+  ],
+  "comments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 17,
       "value": "/* 1 */",
     },
   ],

--- a/test/snapshot/__snapshots__/block.test.js.snap
+++ b/test/snapshot/__snapshots__/block.test.js.snap
@@ -813,6 +813,54 @@ Program {
 }
 `;
 
+exports[`block empty switch case short form 1`] = `
+Program {
+  "children": Array [
+    Switch {
+      "body": Block {
+        "children": Array [
+          Case {
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+              "leadingComments": Array [
+                CommentBlock {
+                  "kind": "commentblock",
+                  "offset": 22,
+                  "value": "/* foo */",
+                },
+              ],
+            },
+            "kind": "case",
+            "test": Number {
+              "kind": "number",
+              "value": "1",
+            },
+          },
+        ],
+        "kind": "block",
+      },
+      "kind": "switch",
+      "shortForm": true,
+      "test": Variable {
+        "curly": false,
+        "kind": "variable",
+        "name": "foo",
+      },
+    },
+  ],
+  "comments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 22,
+      "value": "/* foo */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`block empty switch short form 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/__snapshots__/block.test.js.snap
+++ b/test/snapshot/__snapshots__/block.test.js.snap
@@ -245,6 +245,231 @@ Program {
 }
 `;
 
+exports[`block empty if #2 short form 1`] = `
+Program {
+  "children": Array [
+    If {
+      "alternate": null,
+      "body": Block {
+        "children": Array [
+          ExpressionStatement {
+            "expression": Variable {
+              "curly": false,
+              "kind": "variable",
+              "name": "a",
+            },
+            "kind": "expressionstatement",
+          },
+        ],
+        "kind": "block",
+        "leadingComments": Array [
+          CommentBlock {
+            "kind": "commentblock",
+            "offset": 10,
+            "value": "/* pre */",
+          },
+        ],
+        "trailingComments": Array [
+          CommentBlock {
+            "kind": "commentblock",
+            "offset": 24,
+            "value": "/* inner */",
+          },
+        ],
+      },
+      "kind": "if",
+      "shortForm": true,
+      "test": Variable {
+        "curly": false,
+        "kind": "variable",
+        "name": "foo",
+      },
+      "trailingComments": Array [
+        CommentBlock {
+          "kind": "commentblock",
+          "offset": 43,
+          "value": "/* out */",
+        },
+      ],
+    },
+  ],
+  "comments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 10,
+      "value": "/* pre */",
+    },
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 24,
+      "value": "/* inner */",
+    },
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 43,
+      "value": "/* out */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`block empty if #3 short form 1`] = `
+Program {
+  "children": Array [
+    If {
+      "alternate": If {
+        "alternate": Block {
+          "children": Array [],
+          "kind": "block",
+          "leadingComments": Array [
+            CommentBlock {
+              "kind": "commentblock",
+              "offset": 50,
+              "value": "/* bar */",
+            },
+          ],
+        },
+        "body": Block {
+          "children": Array [],
+          "kind": "block",
+          "leadingComments": Array [
+            CommentBlock {
+              "kind": "commentblock",
+              "offset": 34,
+              "value": "/* baz */",
+            },
+          ],
+        },
+        "kind": "if",
+        "shortForm": true,
+        "test": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "bar",
+        },
+      },
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+        "leadingComments": Array [
+          CommentBlock {
+            "kind": "commentblock",
+            "offset": 10,
+            "value": "/* foo */",
+          },
+        ],
+      },
+      "kind": "if",
+      "shortForm": true,
+      "test": Variable {
+        "curly": false,
+        "kind": "variable",
+        "name": "foo",
+      },
+    },
+  ],
+  "comments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 10,
+      "value": "/* foo */",
+    },
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 34,
+      "value": "/* baz */",
+    },
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 50,
+      "value": "/* bar */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`block empty if 1`] = `
+Program {
+  "children": Array [
+    If {
+      "alternate": null,
+      "body": Block {
+        "children": Array [
+          Noop {
+            "kind": "noop",
+            "leadingComments": Array [
+              CommentBlock {
+                "kind": "commentblock",
+                "offset": 11,
+                "value": "/* foo */",
+              },
+            ],
+          },
+        ],
+        "kind": "block",
+      },
+      "kind": "if",
+      "shortForm": false,
+      "test": Variable {
+        "curly": false,
+        "kind": "variable",
+        "name": "foo",
+      },
+    },
+  ],
+  "comments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 11,
+      "value": "/* foo */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`block empty if short form 1`] = `
+Program {
+  "children": Array [
+    If {
+      "alternate": null,
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+        "leadingComments": Array [
+          CommentBlock {
+            "kind": "commentblock",
+            "offset": 10,
+            "value": "/* foo */",
+          },
+        ],
+      },
+      "kind": "if",
+      "shortForm": true,
+      "test": Variable {
+        "curly": false,
+        "kind": "variable",
+        "name": "foo",
+      },
+    },
+  ],
+  "comments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 10,
+      "value": "/* foo */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`block empty method block 1`] = `
 Program {
   "children": Array [
@@ -331,6 +556,86 @@ Program {
       "kind": "commentblock",
       "offset": 16,
       "value": "/* 1 */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`block empty switch 1`] = `
+Program {
+  "children": Array [
+    Switch {
+      "body": Block {
+        "children": Array [
+          Noop {
+            "kind": "noop",
+            "leadingComments": Array [
+              CommentBlock {
+                "kind": "commentblock",
+                "offset": 15,
+                "value": "/* foo */",
+              },
+            ],
+          },
+        ],
+        "kind": "block",
+      },
+      "kind": "switch",
+      "shortForm": false,
+      "test": Variable {
+        "curly": false,
+        "kind": "variable",
+        "name": "foo",
+      },
+    },
+  ],
+  "comments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 15,
+      "value": "/* foo */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`block empty switch short form 1`] = `
+Program {
+  "children": Array [
+    Switch {
+      "body": Block {
+        "children": Array [
+          Noop {
+            "kind": "noop",
+            "leadingComments": Array [
+              CommentBlock {
+                "kind": "commentblock",
+                "offset": 14,
+                "value": "/* foo */",
+              },
+            ],
+          },
+        ],
+        "kind": "block",
+      },
+      "kind": "switch",
+      "shortForm": true,
+      "test": Variable {
+        "curly": false,
+        "kind": "variable",
+        "name": "foo",
+      },
+    },
+  ],
+  "comments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 14,
+      "value": "/* foo */",
     },
   ],
   "errors": Array [],

--- a/test/snapshot/__snapshots__/block.test.js.snap
+++ b/test/snapshot/__snapshots__/block.test.js.snap
@@ -1,5 +1,82 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`block check empty php blocks 1`] = `
+Program {
+  "children": Array [
+    Inline {
+      "kind": "inline",
+      "leadingComments": Array [
+        CommentBlock {
+          "kind": "commentblock",
+          "offset": 8,
+          "value": "/**
+   * Comment header
+   */",
+        },
+      ],
+      "raw": "
+SOME HTML OUTPUT
+",
+      "trailingComments": Array [
+        CommentBlock {
+          "kind": "commentblock",
+          "offset": 64,
+          "value": "/* Inner comment */",
+        },
+      ],
+      "value": "SOME HTML OUTPUT
+",
+    },
+  ],
+  "comments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 8,
+      "value": "/**
+   * Comment header
+   */",
+    },
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 64,
+      "value": "/* Inner comment */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`block check empty php file 1`] = `
+Program {
+  "children": Array [
+    Noop {
+      "kind": "noop",
+      "leadingComments": Array [
+        CommentBlock {
+          "kind": "commentblock",
+          "offset": 8,
+          "value": "/**
+   * Comment header
+   */",
+        },
+      ],
+    },
+  ],
+  "comments": Array [
+    CommentBlock {
+      "kind": "commentblock",
+      "offset": 8,
+      "value": "/**
+   * Comment header
+   */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`block empty class block 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/__snapshots__/comment.test.js.snap
+++ b/test/snapshot/__snapshots__/comment.test.js.snap
@@ -1249,7 +1249,19 @@ Program {
         },
       },
       "body": Block {
-        "children": Array [],
+        "children": Array [
+          Noop {
+            "kind": "noop",
+            "leadingComments": Array [
+              CommentLine {
+                "kind": "commentline",
+                "offset": 61,
+                "value": "# inner statement
+",
+              },
+            ],
+          },
+        ],
         "kind": "block",
         "leadingComments": Array [
           CommentBlock {
@@ -1276,14 +1288,6 @@ Program {
           },
         ],
         "raw": "true",
-        "trailingComments": Array [
-          CommentLine {
-            "kind": "commentline",
-            "offset": 61,
-            "value": "# inner statement
-",
-          },
-        ],
         "value": true,
       },
     },
@@ -1460,7 +1464,18 @@ Program {
   "children": Array [
     Try {
       "always": Block {
-        "children": Array [],
+        "children": Array [
+          Noop {
+            "kind": "noop",
+            "leadingComments": Array [
+              CommentBlock {
+                "kind": "commentblock",
+                "offset": 218,
+                "value": "/* ignore */",
+              },
+            ],
+          },
+        ],
         "kind": "block",
         "leadingComments": Array [
           CommentBlock {
@@ -1476,7 +1491,19 @@ Program {
         ],
       },
       "body": Block {
-        "children": Array [],
+        "children": Array [
+          Noop {
+            "kind": "noop",
+            "leadingComments": Array [
+              CommentLine {
+                "kind": "commentline",
+                "offset": 36,
+                "value": "# inner statement
+",
+              },
+            ],
+          },
+        ],
         "kind": "block",
         "leadingComments": Array [
           CommentBlock {
@@ -1489,7 +1516,18 @@ Program {
       "catches": Array [
         Catch {
           "body": Block {
-            "children": Array [],
+            "children": Array [
+              Noop {
+                "kind": "noop",
+                "leadingComments": Array [
+                  CommentBlock {
+                    "kind": "commentblock",
+                    "offset": 163,
+                    "value": "/* ee */",
+                  },
+                ],
+              },
+            ],
             "kind": "block",
             "leadingComments": Array [
               CommentBlock {
@@ -1506,23 +1544,10 @@ Program {
           },
           "kind": "catch",
           "leadingComments": Array [
-            CommentLine {
-              "kind": "commentline",
-              "offset": 36,
-              "value": "# inner statement
-",
-            },
             CommentBlock {
               "kind": "commentblock",
               "offset": 64,
               "value": "/* dd */",
-            },
-          ],
-          "trailingComments": Array [
-            CommentBlock {
-              "kind": "commentblock",
-              "offset": 218,
-              "value": "/* ignore */",
             },
           ],
           "variable": Variable {
@@ -1536,13 +1561,6 @@ Program {
               },
             ],
             "name": "e",
-            "trailingComments": Array [
-              CommentBlock {
-                "kind": "commentblock",
-                "offset": 163,
-                "value": "/* ee */",
-              },
-            ],
           },
           "what": Array [
             ClassReference {

--- a/test/snapshot/__snapshots__/namespace.test.js.snap
+++ b/test/snapshot/__snapshots__/namespace.test.js.snap
@@ -1171,7 +1171,9 @@ Program {
         },
       ],
       "kind": "namespace",
-      "name": "",
+      "name": Array [
+        "",
+      ],
       "withBrackets": true,
     },
   ],

--- a/test/snapshot/__snapshots__/namespace.test.js.snap
+++ b/test/snapshot/__snapshots__/namespace.test.js.snap
@@ -1171,9 +1171,7 @@ Program {
         },
       ],
       "kind": "namespace",
-      "name": Array [
-        "",
-      ],
+      "name": "",
       "withBrackets": true,
     },
   ],

--- a/test/snapshot/__snapshots__/switch.test.js.snap
+++ b/test/snapshot/__snapshots__/switch.test.js.snap
@@ -7,7 +7,10 @@ Program {
       "body": Block {
         "children": Array [
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -15,7 +18,10 @@ Program {
             },
           },
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -87,7 +93,10 @@ Program {
       "body": Block {
         "children": Array [
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -95,7 +104,10 @@ Program {
             },
           },
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -561,7 +573,10 @@ Program {
       "body": Block {
         "children": Array [
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -569,7 +584,10 @@ Program {
             },
           },
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -622,7 +640,10 @@ Program {
       "body": Block {
         "children": Array [
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -630,7 +651,10 @@ Program {
             },
           },
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -683,7 +707,10 @@ Program {
       "body": Block {
         "children": Array [
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -691,7 +718,10 @@ Program {
             },
           },
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -763,7 +793,10 @@ Program {
       "body": Block {
         "children": Array [
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -771,7 +804,10 @@ Program {
             },
           },
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -933,7 +969,10 @@ Program {
       "body": Block {
         "children": Array [
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -941,7 +980,10 @@ Program {
             },
           },
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -1013,7 +1055,10 @@ Program {
       "body": Block {
         "children": Array [
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -1021,7 +1066,10 @@ Program {
             },
           },
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -1487,7 +1535,10 @@ Program {
       "body": Block {
         "children": Array [
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -1495,7 +1546,10 @@ Program {
             },
           },
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -1548,7 +1602,10 @@ Program {
       "body": Block {
         "children": Array [
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -1556,7 +1613,10 @@ Program {
             },
           },
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -1609,7 +1669,10 @@ Program {
       "body": Block {
         "children": Array [
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -1617,7 +1680,10 @@ Program {
             },
           },
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -1689,7 +1755,10 @@ Program {
       "body": Block {
         "children": Array [
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -1697,7 +1766,10 @@ Program {
             },
           },
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",
@@ -1947,7 +2019,10 @@ Program {
       "body": Block {
         "children": Array [
           Case {
-            "body": null,
+            "body": Block {
+              "children": Array [],
+              "kind": "block",
+            },
             "kind": "case",
             "test": Number {
               "kind": "number",

--- a/test/snapshot/block.test.js
+++ b/test/snapshot/block.test.js
@@ -1,7 +1,20 @@
 const parser = require("../main");
 
 describe("block", () => {
-  it("single", () => {
-    expect(parser.parseEval("{ $var = 1; }")).toMatchSnapshot();
+  it.each([
+    ["single", "{ $var = 1; }"],
+    ["empty function block", "function foo() { /* 1 */ }"],
+    ["empty class block", "class foo { /* 1 */ }"],
+    ["empty method block", "class foo { function bar()  { /* 1 */ } }"],
+    ["empty namespace block", "namespace foo { /* 1 */ }"],
+    ["empty declare block", "declare(tick=1) { /* 1 */ }"]
+  ])("%s", function(_, code) {
+    expect(
+      parser.parseEval(code, {
+        parser: {
+          extractDoc: true
+        }
+      })
+    ).toMatchSnapshot();
   });
 });

--- a/test/snapshot/block.test.js
+++ b/test/snapshot/block.test.js
@@ -13,6 +13,10 @@ describe("block", () => {
     ["empty for", "for(;;) { /* foo */ }"],
     ["empty foreach", "foreach($foo as $bar) { /* foo */ }"],
     ["empty switch short form", "switch($foo): /* foo */ endswitch;"],
+    [
+      "empty switch case short form",
+      "switch($foo): case 1: /* foo */ endswitch;"
+    ],
     ["empty for short form", "for(;;):  /* foo */ endfor;"],
     [
       "empty foreach short form",

--- a/test/snapshot/block.test.js
+++ b/test/snapshot/block.test.js
@@ -8,7 +8,19 @@ describe("block", () => {
     ["empty method block", "class foo { function bar()  { /* 1 */ } }"],
     ["empty namespace block", "namespace foo { /* 1 */ }"],
     ["empty declare block", "declare(tick=1) { /* 1 */ }"],
-    ["empty declare short form", "declare(tick=1): /* 1 */ ENDDECLARE;"]
+    ["empty declare short form", "declare(tick=1): /* 1 */ ENDDECLARE;"],
+    ["empty switch", "switch($foo) { /* foo */ }"],
+    ["empty switch short form", "switch($foo): /* foo */ endswitch;"],
+    ["empty if", "if($foo) { /* foo */ }"],
+    ["empty if short form", "if($foo): /* foo */ endif;"],
+    [
+      "empty if #2 short form",
+      "if($foo): /* pre */ $a; /* inner */ endif; /* out */"
+    ],
+    [
+      "empty if #3 short form",
+      "if($foo): /* foo */ elseif($bar): /* baz */ else: /* bar */ endif;"
+    ]
   ])("%s", function(_, code) {
     expect(
       parser.parseEval(code, {

--- a/test/snapshot/block.test.js
+++ b/test/snapshot/block.test.js
@@ -10,8 +10,16 @@ describe("block", () => {
     ["empty declare block", "declare(tick=1) { /* 1 */ }"],
     ["empty declare short form", "declare(tick=1): /* 1 */ ENDDECLARE;"],
     ["empty switch", "switch($foo) { /* foo */ }"],
+    ["empty for", "for(;;) { /* foo */ }"],
+    ["empty foreach", "foreach($foo as $bar) { /* foo */ }"],
     ["empty switch short form", "switch($foo): /* foo */ endswitch;"],
+    ["empty for short form", "for(;;):  /* foo */ endfor;"],
+    [
+      "empty foreach short form",
+      "foreach($foo as $bar): /* foo */ endforeach;"
+    ],
     ["empty if", "if($foo) { /* foo */ }"],
+    ["empty statement", "/* 1 */; /* 2 */; ; /* 3 */"],
     ["empty if short form", "if($foo): /* foo */ endif;"],
     [
       "empty if #2 short form",

--- a/test/snapshot/block.test.js
+++ b/test/snapshot/block.test.js
@@ -7,7 +7,8 @@ describe("block", () => {
     ["empty class block", "class foo { /* 1 */ }"],
     ["empty method block", "class foo { function bar()  { /* 1 */ } }"],
     ["empty namespace block", "namespace foo { /* 1 */ }"],
-    ["empty declare block", "declare(tick=1) { /* 1 */ }"]
+    ["empty declare block", "declare(tick=1) { /* 1 */ }"],
+    ["empty declare short form", "declare(tick=1): /* 1 */ ENDDECLARE;"]
   ])("%s", function(_, code) {
     expect(
       parser.parseEval(code, {

--- a/test/snapshot/block.test.js
+++ b/test/snapshot/block.test.js
@@ -18,4 +18,42 @@ describe("block", () => {
       })
     ).toMatchSnapshot();
   });
+  it("check empty php blocks", function() {
+    expect(
+      parser.parseCode(
+        `<?php
+  /**
+   * Comment header
+   */
+?>
+SOME HTML OUTPUT
+<?php /* Inner comment */
+      `,
+        "test",
+        {
+          parser: {
+            extractDoc: true
+          }
+        }
+      )
+    ).toMatchSnapshot();
+  });
+
+  it("check empty php file", function() {
+    expect(
+      parser.parseCode(
+        `<?php
+  /**
+   * Comment header
+   */
+      `,
+        "test",
+        {
+          parser: {
+            extractDoc: true
+          }
+        }
+      )
+    ).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
When an empty block (without any statements) contains comments, we provide a noop node in order to attach on it it's comment - related to issues #135 & #272

