### PR TITLE
Added fixes for new flexible heredoc from php7.3

### DIFF
--- a/src/lexer.js
+++ b/src/lexer.js
@@ -164,6 +164,7 @@ lexer.prototype.setInput = function(input) {
     length: 0,
     indentation: 0,
     indentation_uses_spaces: false,
+    finished: false,
     /**
      * this used for parser to detemine the if current node segment is first encaps node.
      * if ture, the indentation will remove from the begining. and if false, the prev node

--- a/src/lexer/strings.js
+++ b/src/lexer/strings.js
@@ -146,7 +146,7 @@ module.exports = {
     // reset heredoc_label structure
     let indentation = 0;
     let leading_ch = this._input.substring(offset - 1, offset);
-
+    const valid_endings = ["\t", " ", ",", ")", "]", "\n", "\r", ";"];
     while (leading_ch === "\t" || leading_ch === " ") {
       if (leading_ch === " ") {
         indentation_uses_spaces = true;
@@ -168,7 +168,7 @@ module.exports = {
       ) === this.heredoc_label.label
     ) {
       const ch = this._input[offset - 1 + this.heredoc_label.length];
-      if (ch === "\n" || ch === "\r" || ch === ";") {
+      if (valid_endings.includes(ch)) {
         if (consumeLeadingSpaces) {
           this.consume(indentation);
           // https://wiki.php.net/rfc/flexible_heredoc_nowdoc_syntaxes

--- a/src/lexer/strings.js
+++ b/src/lexer/strings.js
@@ -146,7 +146,12 @@ module.exports = {
     // reset heredoc_label structure
     let indentation = 0;
     let leading_ch = this._input.substring(offset - 1, offset);
-    const valid_endings = ["\t", " ", ",", ")", "]", "\n", "\r", ";"];
+    let valid_endings = ["\n", "\r", ";"];
+
+    if (this.version >= 703) {
+      valid_endings = valid_endings.concat(["\t", " ", ",", ")", "]"]);
+    }
+
     while (leading_ch === "\t" || leading_ch === " ") {
       if (leading_ch === " ") {
         indentation_uses_spaces = true;

--- a/src/lexer/strings.js
+++ b/src/lexer/strings.js
@@ -67,6 +67,7 @@ module.exports = {
             // go go go
             this.heredoc_label.label = yylabel;
             this.heredoc_label.length = yylabel.length;
+            this.heredoc_label.finished = false;
             yyoffset = this.offset - revert;
             this.offset = revert;
             this.consume(yyoffset);

--- a/src/parser/scalar.js
+++ b/src/parser/scalar.js
@@ -128,7 +128,11 @@ module.exports = {
         inCoutingState = false;
       }
 
-      if (inCheckState && leadingWhitespaceCharCount < indentation) {
+      if (
+        text[offset] !== "\n" &&
+        inCheckState &&
+        leadingWhitespaceCharCount < indentation
+      ) {
         this.raiseError(
           `Invalid body indentation level (expecting an indentation at least ${indentation})`
         );
@@ -335,12 +339,14 @@ module.exports = {
       result = result(
         "string",
         false,
-        this.remove_heredoc_leading_whitespace_chars(
-          this.resolve_special_chars(text, isDoubleQuote),
-          this.lexer.heredoc_label.indentation,
-          this.lexer.heredoc_label.indentation_uses_spaces,
-          this.lexer.heredoc_label.first_encaps_node
-        ),
+        this.version >= 703
+          ? this.remove_heredoc_leading_whitespace_chars(
+              this.resolve_special_chars(text, isDoubleQuote),
+              this.lexer.heredoc_label.indentation,
+              this.lexer.heredoc_label.indentation_uses_spaces,
+              this.lexer.heredoc_label.first_encaps_node
+            )
+          : text,
         false,
         text
       );

--- a/src/parser/scalar.js
+++ b/src/parser/scalar.js
@@ -339,7 +339,7 @@ module.exports = {
       result = result(
         "string",
         false,
-        this.version >= 703
+        this.version >= 703 && !this.lexer.heredoc_label.finished
           ? this.remove_heredoc_leading_whitespace_chars(
               this.resolve_special_chars(text, isDoubleQuote),
               this.lexer.heredoc_label.indentation,
@@ -473,6 +473,7 @@ module.exports = {
 
     if (expect === this.tok.T_END_HEREDOC) {
       node.label = this.lexer.heredoc_label.label;
+      this.lexer.heredoc_label.finished = true;
     }
     return node;
   },

--- a/test/snapshot/__snapshots__/heredoc.test.js.snap
+++ b/test/snapshot/__snapshots__/heredoc.test.js.snap
@@ -177,6 +177,78 @@ Program {
 }
 `;
 
+exports[`heredoc Flexible heredoc syntax: empty lines 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "values",
+        },
+        "operator": "=",
+        "right": Array {
+          "items": Array [
+            Entry {
+              "byRef": false,
+              "key": null,
+              "kind": "entry",
+              "unpack": false,
+              "value": Encapsed {
+                "kind": "encapsed",
+                "label": "END",
+                "raw": "<<<END
+        a
+
+      b
+
+    c
+
+    END",
+                "type": "heredoc",
+                "value": Array [
+                  EncapsedPart {
+                    "curly": false,
+                    "expression": String {
+                      "isDoubleQuote": false,
+                      "kind": "string",
+                      "raw": "        a
+
+      b
+
+    c
+
+    ",
+                      "unicode": false,
+                      "value": "        a
+
+      b
+
+    c
+
+    ",
+                    },
+                    "kind": "encapsedpart",
+                    "syntax": null,
+                  },
+                ],
+              },
+            },
+          ],
+          "kind": "array",
+          "shortForm": true,
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`heredoc Flexible heredoc syntax: mixing spaces and tabs in body 1`] = `
 Program {
   "children": Array [
@@ -247,6 +319,207 @@ Program {
       "token": undefined,
     },
   ],
+  "kind": "program",
+}
+`;
+
+exports[`heredoc Flexible heredoc syntax: parentheses 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Call {
+        "arguments": Array [
+          Encapsed {
+            "kind": "encapsed",
+            "label": "END",
+            "raw": "<<<END
+   a
+  b
+ c
+END",
+            "type": "heredoc",
+            "value": Array [
+              EncapsedPart {
+                "curly": false,
+                "expression": String {
+                  "isDoubleQuote": false,
+                  "kind": "string",
+                  "raw": "   a
+  b
+ c
+",
+                  "unicode": false,
+                  "value": "   a
+  b
+ c",
+                },
+                "kind": "encapsedpart",
+                "syntax": null,
+              },
+            ],
+          },
+        ],
+        "kind": "call",
+        "what": Name {
+          "kind": "name",
+          "name": "stringManipulator",
+          "resolution": "uqn",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`heredoc Flexible heredoc syntax: symbols after ending 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "values",
+        },
+        "operator": "=",
+        "right": Array {
+          "items": Array [
+            Entry {
+              "byRef": false,
+              "key": null,
+              "kind": "entry",
+              "unpack": false,
+              "value": Encapsed {
+                "kind": "encapsed",
+                "label": "END",
+                "raw": "<<<END
+a
+b
+c
+END",
+                "type": "heredoc",
+                "value": Array [
+                  EncapsedPart {
+                    "curly": false,
+                    "expression": String {
+                      "isDoubleQuote": false,
+                      "kind": "string",
+                      "raw": "a
+b
+c
+",
+                      "unicode": false,
+                      "value": "a
+b
+c",
+                    },
+                    "kind": "encapsedpart",
+                    "syntax": null,
+                  },
+                ],
+              },
+            },
+            Entry {
+              "byRef": false,
+              "key": null,
+              "kind": "entry",
+              "unpack": false,
+              "value": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "'d e f'",
+                "unicode": false,
+                "value": "d e f",
+              },
+            },
+          ],
+          "kind": "array",
+          "shortForm": true,
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`heredoc Flexible heredoc syntax: symbols after ending with whitespace 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "values",
+        },
+        "operator": "=",
+        "right": Array {
+          "items": Array [
+            Entry {
+              "byRef": false,
+              "key": null,
+              "kind": "entry",
+              "unpack": false,
+              "value": Encapsed {
+                "kind": "encapsed",
+                "label": "END",
+                "raw": "<<<END
+a
+b
+c
+END          ",
+                "type": "heredoc",
+                "value": Array [
+                  EncapsedPart {
+                    "curly": false,
+                    "expression": String {
+                      "isDoubleQuote": false,
+                      "kind": "string",
+                      "raw": "a
+b
+c
+",
+                      "unicode": false,
+                      "value": "a
+b
+c",
+                    },
+                    "kind": "encapsedpart",
+                    "syntax": null,
+                  },
+                ],
+              },
+            },
+            Entry {
+              "byRef": false,
+              "key": null,
+              "kind": "entry",
+              "unpack": false,
+              "value": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "'d e f'",
+                "unicode": false,
+                "value": "d e f",
+              },
+            },
+          ],
+          "kind": "array",
+          "shortForm": true,
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
   "kind": "program",
 }
 `;

--- a/test/snapshot/__snapshots__/heredoc.test.js.snap
+++ b/test/snapshot/__snapshots__/heredoc.test.js.snap
@@ -790,6 +790,41 @@ test",
       },
       "kind": "expressionstatement",
     },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "c",
+        },
+        "operator": "=",
+        "right": Encapsed {
+          "kind": "encapsed",
+          "label": "TOE",
+          "raw": "<<< TOE
+  a
+  TOE",
+          "type": "heredoc",
+          "value": Array [
+            EncapsedPart {
+              "curly": false,
+              "expression": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "  a
+  ",
+                "unicode": false,
+                "value": "a",
+              },
+              "kind": "encapsedpart",
+              "syntax": null,
+            },
+          ],
+        },
+      },
+      "kind": "expressionstatement",
+    },
   ],
   "errors": Array [],
   "kind": "program",
@@ -815,6 +850,9 @@ Program {
   EOT;
 $b = \\"{$x}
 test\\";
+$c = <<<TOE
+  a
+  TOE;
 ",
           "type": "heredoc",
           "value": Array [
@@ -874,7 +912,35 @@ test\\";
 ",
                 "unicode": false,
                 "value": "
-test\\";",
+test\\";
+",
+              },
+              "kind": "encapsedpart",
+              "syntax": null,
+            },
+            EncapsedPart {
+              "curly": false,
+              "expression": Variable {
+                "curly": false,
+                "kind": "variable",
+                "name": "c",
+              },
+              "kind": "encapsedpart",
+              "syntax": "simple",
+            },
+            EncapsedPart {
+              "curly": false,
+              "expression": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": " = <<<TOE
+  a
+  TOE;
+",
+                "unicode": false,
+                "value": " = <<<TOE
+  a
+  TOE;",
               },
               "kind": "encapsedpart",
               "syntax": null,
@@ -889,8 +955,8 @@ test\\";",
     Error {
       "expected": 220,
       "kind": "error",
-      "line": 6,
-      "message": "Parse Error : syntax error, expecting T_END_HEREDOC on line 6",
+      "line": 9,
+      "message": "Parse Error : syntax error, expecting T_END_HEREDOC on line 9",
       "token": "the end of file (EOF)",
     },
   ],

--- a/test/snapshot/__snapshots__/heredoc.test.js.snap
+++ b/test/snapshot/__snapshots__/heredoc.test.js.snap
@@ -249,6 +249,95 @@ Program {
 }
 `;
 
+exports[`heredoc Flexible heredoc syntax: empty lines 2`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "values",
+        },
+        "operator": "=",
+        "right": Array {
+          "items": Array [
+            Entry {
+              "byRef": false,
+              "key": null,
+              "kind": "entry",
+              "unpack": false,
+              "value": Encapsed {
+                "kind": "encapsed",
+                "label": "END",
+                "raw": "<<<END
+        a
+
+      b
+
+    c
+
+    END];
+",
+                "type": "heredoc",
+                "value": Array [
+                  EncapsedPart {
+                    "curly": false,
+                    "expression": String {
+                      "isDoubleQuote": false,
+                      "kind": "string",
+                      "raw": "        a
+
+      b
+
+    c
+
+    END];
+",
+                      "unicode": false,
+                      "value": "        a
+
+      b
+
+    c
+
+    END];",
+                    },
+                    "kind": "encapsedpart",
+                    "syntax": null,
+                  },
+                ],
+              },
+            },
+          ],
+          "kind": "array",
+          "shortForm": true,
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": 220,
+      "kind": "error",
+      "line": 10,
+      "message": "Parse Error : syntax error, expecting T_END_HEREDOC on line 10",
+      "token": "the end of file (EOF)",
+    },
+    Error {
+      "expected": "]",
+      "kind": "error",
+      "line": 10,
+      "message": "Parse Error : syntax error, expecting ']' on line 10",
+      "token": "the end of file (EOF)",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
 exports[`heredoc Flexible heredoc syntax: mixing spaces and tabs in body 1`] = `
 Program {
   "children": Array [
@@ -374,6 +463,75 @@ END",
 }
 `;
 
+exports[`heredoc Flexible heredoc syntax: parentheses 2`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Call {
+        "arguments": Array [
+          Encapsed {
+            "kind": "encapsed",
+            "label": "END",
+            "raw": "<<<END
+   a
+  b
+ c
+END);
+",
+            "type": "heredoc",
+            "value": Array [
+              EncapsedPart {
+                "curly": false,
+                "expression": String {
+                  "isDoubleQuote": false,
+                  "kind": "string",
+                  "raw": "   a
+  b
+ c
+END);
+",
+                  "unicode": false,
+                  "value": "   a
+  b
+ c
+END);",
+                },
+                "kind": "encapsedpart",
+                "syntax": null,
+              },
+            ],
+          },
+        ],
+        "kind": "call",
+        "what": Name {
+          "kind": "name",
+          "name": "stringManipulator",
+          "resolution": "uqn",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": 220,
+      "kind": "error",
+      "line": 7,
+      "message": "Parse Error : syntax error, expecting T_END_HEREDOC on line 7",
+      "token": "the end of file (EOF)",
+    },
+    Error {
+      "expected": ")",
+      "kind": "error",
+      "line": 7,
+      "message": "Parse Error : syntax error, expecting ')' on line 7",
+      "token": "the end of file (EOF)",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
 exports[`heredoc Flexible heredoc syntax: symbols after ending 1`] = `
 Program {
   "children": Array [
@@ -449,6 +607,86 @@ c",
 }
 `;
 
+exports[`heredoc Flexible heredoc syntax: symbols after ending 2`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "values",
+        },
+        "operator": "=",
+        "right": Array {
+          "items": Array [
+            Entry {
+              "byRef": false,
+              "key": null,
+              "kind": "entry",
+              "unpack": false,
+              "value": Encapsed {
+                "kind": "encapsed",
+                "label": "END",
+                "raw": "<<<END
+a
+b
+c
+END, 'd e f'];
+",
+                "type": "heredoc",
+                "value": Array [
+                  EncapsedPart {
+                    "curly": false,
+                    "expression": String {
+                      "isDoubleQuote": false,
+                      "kind": "string",
+                      "raw": "a
+b
+c
+END, 'd e f'];
+",
+                      "unicode": false,
+                      "value": "a
+b
+c
+END, 'd e f'];",
+                    },
+                    "kind": "encapsedpart",
+                    "syntax": null,
+                  },
+                ],
+              },
+            },
+          ],
+          "kind": "array",
+          "shortForm": true,
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": 220,
+      "kind": "error",
+      "line": 7,
+      "message": "Parse Error : syntax error, expecting T_END_HEREDOC on line 7",
+      "token": "the end of file (EOF)",
+    },
+    Error {
+      "expected": "]",
+      "kind": "error",
+      "line": 7,
+      "message": "Parse Error : syntax error, expecting ']' on line 7",
+      "token": "the end of file (EOF)",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
 exports[`heredoc Flexible heredoc syntax: symbols after ending with whitespace 1`] = `
 Program {
   "children": Array [
@@ -520,6 +758,86 @@ c",
     },
   ],
   "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`heredoc Flexible heredoc syntax: symbols after ending with whitespace 2`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "values",
+        },
+        "operator": "=",
+        "right": Array {
+          "items": Array [
+            Entry {
+              "byRef": false,
+              "key": null,
+              "kind": "entry",
+              "unpack": false,
+              "value": Encapsed {
+                "kind": "encapsed",
+                "label": "END",
+                "raw": "<<<END
+a
+b
+c
+END          , 'd e f'];
+",
+                "type": "heredoc",
+                "value": Array [
+                  EncapsedPart {
+                    "curly": false,
+                    "expression": String {
+                      "isDoubleQuote": false,
+                      "kind": "string",
+                      "raw": "a
+b
+c
+END          , 'd e f'];
+",
+                      "unicode": false,
+                      "value": "a
+b
+c
+END          , 'd e f'];",
+                    },
+                    "kind": "encapsedpart",
+                    "syntax": null,
+                  },
+                ],
+              },
+            },
+          ],
+          "kind": "array",
+          "shortForm": true,
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": 220,
+      "kind": "error",
+      "line": 7,
+      "message": "Parse Error : syntax error, expecting T_END_HEREDOC on line 7",
+      "token": "the end of file (EOF)",
+    },
+    Error {
+      "expected": "]",
+      "kind": "error",
+      "line": 7,
+      "message": "Parse Error : syntax error, expecting ']' on line 7",
+      "token": "the end of file (EOF)",
+    },
+  ],
   "kind": "program",
 }
 `;

--- a/test/snapshot/__snapshots__/heredoc.test.js.snap
+++ b/test/snapshot/__snapshots__/heredoc.test.js.snap
@@ -723,6 +723,181 @@ a
 }
 `;
 
+exports[`heredoc Flexible heredoc syntax: indentation bracket bug 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "a",
+        },
+        "operator": "=",
+        "right": Encapsed {
+          "kind": "encapsed",
+          "label": "EOT",
+          "raw": "<<<EOT
+  EOT",
+          "type": "heredoc",
+          "value": Array [],
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "b",
+        },
+        "operator": "=",
+        "right": Encapsed {
+          "kind": "encapsed",
+          "raw": "\\"{$x}
+test\\"",
+          "type": "string",
+          "value": Array [
+            EncapsedPart {
+              "curly": false,
+              "expression": Variable {
+                "curly": false,
+                "kind": "variable",
+                "name": "x",
+              },
+              "kind": "encapsedpart",
+              "syntax": "complex",
+            },
+            EncapsedPart {
+              "curly": false,
+              "expression": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "
+test",
+                "unicode": false,
+                "value": "
+test",
+              },
+              "kind": "encapsedpart",
+              "syntax": null,
+            },
+          ],
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`heredoc Flexible heredoc syntax: indentation bracket bug 2`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "a",
+        },
+        "operator": "=",
+        "right": Encapsed {
+          "kind": "encapsed",
+          "label": "EOT",
+          "raw": "<<<EOT
+  EOT;
+$b = \\"{$x}
+test\\";
+",
+          "type": "heredoc",
+          "value": Array [
+            EncapsedPart {
+              "curly": false,
+              "expression": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "  EOT;
+",
+                "unicode": false,
+                "value": "  EOT;
+",
+              },
+              "kind": "encapsedpart",
+              "syntax": null,
+            },
+            EncapsedPart {
+              "curly": false,
+              "expression": Variable {
+                "curly": false,
+                "kind": "variable",
+                "name": "b",
+              },
+              "kind": "encapsedpart",
+              "syntax": "simple",
+            },
+            EncapsedPart {
+              "curly": false,
+              "expression": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": " = \\"",
+                "unicode": false,
+                "value": " = \\"",
+              },
+              "kind": "encapsedpart",
+              "syntax": null,
+            },
+            EncapsedPart {
+              "curly": false,
+              "expression": Variable {
+                "curly": false,
+                "kind": "variable",
+                "name": "x",
+              },
+              "kind": "encapsedpart",
+              "syntax": "complex",
+            },
+            EncapsedPart {
+              "curly": false,
+              "expression": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "
+test\\";
+",
+                "unicode": false,
+                "value": "
+test\\";",
+              },
+              "kind": "encapsedpart",
+              "syntax": null,
+            },
+          ],
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": 220,
+      "kind": "error",
+      "line": 6,
+      "message": "Parse Error : syntax error, expecting T_END_HEREDOC on line 6",
+      "token": "the end of file (EOF)",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
 exports[`heredoc Flexible heredoc syntax: mixing spaces and tabs in body 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/__snapshots__/heredoc.test.js.snap
+++ b/test/snapshot/__snapshots__/heredoc.test.js.snap
@@ -91,13 +91,6 @@ c",
       "message": "Invalid body indentation level (expecting an indentation at least 1) on line 6",
       "token": undefined,
     },
-    Error {
-      "expected": undefined,
-      "kind": "error",
-      "line": 6,
-      "message": "Invalid body indentation level (expecting an indentation at least 1) on line 6",
-      "token": undefined,
-    },
   ],
   "kind": "program",
 }
@@ -158,20 +151,6 @@ Program {
       "message": "Invalid body indentation level (expecting an indentation at least 2) on line 4",
       "token": undefined,
     },
-    Error {
-      "expected": undefined,
-      "kind": "error",
-      "line": 4,
-      "message": "Invalid body indentation level (expecting an indentation at least 2) on line 4",
-      "token": undefined,
-    },
-    Error {
-      "expected": undefined,
-      "kind": "error",
-      "line": 4,
-      "message": "Invalid body indentation level (expecting an indentation at least 2) on line 4",
-      "token": undefined,
-    },
   ],
   "kind": "program",
 }
@@ -189,56 +168,43 @@ Program {
           "name": "values",
         },
         "operator": "=",
-        "right": Array {
-          "items": Array [
-            Entry {
-              "byRef": false,
-              "key": null,
-              "kind": "entry",
-              "unpack": false,
-              "value": Encapsed {
-                "kind": "encapsed",
-                "label": "END",
-                "raw": "<<<END
+        "right": Encapsed {
+          "kind": "encapsed",
+          "label": "END",
+          "raw": "<<<END
         a
 
       b
-
+  
     c
 
     END",
-                "type": "heredoc",
-                "value": Array [
-                  EncapsedPart {
-                    "curly": false,
-                    "expression": String {
-                      "isDoubleQuote": false,
-                      "kind": "string",
-                      "raw": "        a
+          "type": "heredoc",
+          "value": Array [
+            EncapsedPart {
+              "curly": false,
+              "expression": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "        a
 
       b
-
+  
     c
 
     ",
-                      "unicode": false,
-                      "value": "        a
+                "unicode": false,
+                "value": "    a
 
-      b
-
-    c
-
-    ",
-                    },
-                    "kind": "encapsedpart",
-                    "syntax": null,
-                  },
-                ],
+  b
+  
+c
+",
               },
+              "kind": "encapsedpart",
+              "syntax": null,
             },
           ],
-          "kind": "array",
-          "shortForm": true,
         },
       },
       "kind": "expressionstatement",
@@ -261,58 +227,228 @@ Program {
           "name": "values",
         },
         "operator": "=",
-        "right": Array {
-          "items": Array [
-            Entry {
-              "byRef": false,
-              "key": null,
-              "kind": "entry",
-              "unpack": false,
-              "value": Encapsed {
-                "kind": "encapsed",
-                "label": "END",
-                "raw": "<<<END
+        "right": Encapsed {
+          "kind": "encapsed",
+          "label": "END",
+          "raw": "<<<END
+        a
+  
+      b
+
+    c
+    END",
+          "type": "heredoc",
+          "value": Array [
+            EncapsedPart {
+              "curly": false,
+              "expression": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "        a
+  
+      b
+
+    c
+    ",
+                "unicode": false,
+                "value": "    a
+  
+  b
+
+c",
+              },
+              "kind": "encapsedpart",
+              "syntax": null,
+            },
+          ],
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`heredoc Flexible heredoc syntax: empty lines 3`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "values",
+        },
+        "operator": "=",
+        "right": Encapsed {
+          "kind": "encapsed",
+          "label": "END",
+          "raw": "<<<END
+        a
+  
+      b
+
+    c
+  
+    END",
+          "type": "heredoc",
+          "value": Array [
+            EncapsedPart {
+              "curly": false,
+              "expression": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "        a
+  
+      b
+
+    c
+  
+    ",
+                "unicode": false,
+                "value": "    a
+  
+  b
+
+c
+  ",
+              },
+              "kind": "encapsedpart",
+              "syntax": null,
+            },
+          ],
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`heredoc Flexible heredoc syntax: empty lines 4`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "values",
+        },
+        "operator": "=",
+        "right": Encapsed {
+          "kind": "encapsed",
+          "label": "END",
+          "raw": "<<<END
+        a
+  
+      b
+
+   c
+  
+    END",
+          "type": "heredoc",
+          "value": Array [
+            EncapsedPart {
+              "curly": false,
+              "expression": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "        a
+  
+      b
+
+   c
+  
+    ",
+                "unicode": false,
+                "value": "    a
+  
+  b
+
+   c
+  ",
+              },
+              "kind": "encapsedpart",
+              "syntax": null,
+            },
+          ],
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": undefined,
+      "kind": "error",
+      "line": 9,
+      "message": "Invalid body indentation level (expecting an indentation at least 4) on line 9",
+      "token": undefined,
+    },
+  ],
+  "kind": "program",
+}
+`;
+
+exports[`heredoc Flexible heredoc syntax: empty lines 5`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "values",
+        },
+        "operator": "=",
+        "right": Encapsed {
+          "kind": "encapsed",
+          "label": "END",
+          "raw": "<<<END
         a
 
       b
-
+  
     c
 
-    END];
+    END;
 ",
-                "type": "heredoc",
-                "value": Array [
-                  EncapsedPart {
-                    "curly": false,
-                    "expression": String {
-                      "isDoubleQuote": false,
-                      "kind": "string",
-                      "raw": "        a
+          "type": "heredoc",
+          "value": Array [
+            EncapsedPart {
+              "curly": false,
+              "expression": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "        a
 
       b
-
+  
     c
 
-    END];
+    END;
 ",
-                      "unicode": false,
-                      "value": "        a
+                "unicode": false,
+                "value": "        a
 
       b
-
+  
     c
 
-    END];",
-                    },
-                    "kind": "encapsedpart",
-                    "syntax": null,
-                  },
-                ],
+    END;",
               },
+              "kind": "encapsedpart",
+              "syntax": null,
             },
           ],
-          "kind": "array",
-          "shortForm": true,
         },
       },
       "kind": "expressionstatement",
@@ -326,11 +462,260 @@ Program {
       "message": "Parse Error : syntax error, expecting T_END_HEREDOC on line 10",
       "token": "the end of file (EOF)",
     },
+  ],
+  "kind": "program",
+}
+`;
+
+exports[`heredoc Flexible heredoc syntax: empty lines 6`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "values",
+        },
+        "operator": "=",
+        "right": Encapsed {
+          "kind": "encapsed",
+          "label": "END",
+          "raw": "<<<END
+        a
+  
+      b
+
+    c
+    END;
+",
+          "type": "heredoc",
+          "value": Array [
+            EncapsedPart {
+              "curly": false,
+              "expression": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "        a
+  
+      b
+
+    c
+    END;
+",
+                "unicode": false,
+                "value": "        a
+  
+      b
+
+    c
+    END;",
+              },
+              "kind": "encapsedpart",
+              "syntax": null,
+            },
+          ],
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [
     Error {
-      "expected": "]",
+      "expected": 220,
+      "kind": "error",
+      "line": 9,
+      "message": "Parse Error : syntax error, expecting T_END_HEREDOC on line 9",
+      "token": "the end of file (EOF)",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
+exports[`heredoc Flexible heredoc syntax: empty lines 7`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "values",
+        },
+        "operator": "=",
+        "right": Encapsed {
+          "kind": "encapsed",
+          "label": "END",
+          "raw": "<<<END
+        a
+  
+      b
+
+    c
+  
+    END;
+",
+          "type": "heredoc",
+          "value": Array [
+            EncapsedPart {
+              "curly": false,
+              "expression": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "        a
+  
+      b
+
+    c
+  
+    END;
+",
+                "unicode": false,
+                "value": "        a
+  
+      b
+
+    c
+  
+    END;",
+              },
+              "kind": "encapsedpart",
+              "syntax": null,
+            },
+          ],
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": 220,
       "kind": "error",
       "line": 10,
-      "message": "Parse Error : syntax error, expecting ']' on line 10",
+      "message": "Parse Error : syntax error, expecting T_END_HEREDOC on line 10",
+      "token": "the end of file (EOF)",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
+exports[`heredoc Flexible heredoc syntax: empty lines 8`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "values",
+        },
+        "operator": "=",
+        "right": Encapsed {
+          "kind": "encapsed",
+          "label": "END",
+          "raw": "<<<END
+        a
+  
+      b
+
+   c
+  
+    END;
+",
+          "type": "heredoc",
+          "value": Array [
+            EncapsedPart {
+              "curly": false,
+              "expression": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "        a
+  
+      b
+
+   c
+  
+    END;
+",
+                "unicode": false,
+                "value": "        a
+  
+      b
+
+   c
+  
+    END;",
+              },
+              "kind": "encapsedpart",
+              "syntax": null,
+            },
+          ],
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": 220,
+      "kind": "error",
+      "line": 10,
+      "message": "Parse Error : syntax error, expecting T_END_HEREDOC on line 10",
+      "token": "the end of file (EOF)",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
+exports[`heredoc Flexible heredoc syntax: ending label breaks old versions 1`] = `
+Program {
+  "children": Array [
+    Echo {
+      "expressions": Array [
+        Encapsed {
+          "kind": "encapsed",
+          "label": "END",
+          "raw": "<<<END
+a
+ END;
+",
+          "type": "heredoc",
+          "value": Array [
+            EncapsedPart {
+              "curly": false,
+              "expression": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "a
+ END;
+",
+                "unicode": false,
+                "value": "a
+ END;",
+              },
+              "kind": "encapsedpart",
+              "syntax": null,
+            },
+          ],
+        },
+      ],
+      "kind": "echo",
+      "shortForm": false,
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": 220,
+      "kind": "error",
+      "line": 5,
+      "message": "Parse Error : syntax error, expecting T_END_HEREDOC on line 5",
       "token": "the end of file (EOF)",
     },
   ],
@@ -372,20 +757,6 @@ Program {
     },
   ],
   "errors": Array [
-    Error {
-      "expected": undefined,
-      "kind": "error",
-      "line": 4,
-      "message": "Invalid body indentation level (expecting an indentation at least 2) on line 4",
-      "token": undefined,
-    },
-    Error {
-      "expected": undefined,
-      "kind": "error",
-      "line": 4,
-      "message": "Invalid body indentation level (expecting an indentation at least 2) on line 4",
-      "token": undefined,
-    },
     Error {
       "expected": undefined,
       "kind": "error",

--- a/test/snapshot/heredoc.test.js
+++ b/test/snapshot/heredoc.test.js
@@ -219,6 +219,23 @@ END);
 `
       )
     ).toMatchSnapshot();
+
+    expect(
+      parser.parseEval(
+        `
+stringManipulator(<<<END
+   a
+  b
+ c
+END);
+`,
+
+        {
+          parser: { version: 702, suppressErrors: true, debug: false },
+          lexer: { debug: false }
+        }
+      )
+    ).toMatchSnapshot();
   });
 
   it("Flexible heredoc syntax: symbols after ending", () => {
@@ -233,6 +250,23 @@ END, 'd e f'];
 `
       )
     ).toMatchSnapshot();
+
+    expect(
+      parser.parseEval(
+        `
+$values = [<<<END
+a
+b
+c
+END, 'd e f'];
+`,
+
+        {
+          parser: { version: 702, suppressErrors: true, debug: false },
+          lexer: { debug: false }
+        }
+      )
+    ).toMatchSnapshot();
   });
 
   it("Flexible heredoc syntax: symbols after ending with whitespace", () => {
@@ -245,6 +279,23 @@ b
 c
 END          , 'd e f'];
 `
+      )
+    ).toMatchSnapshot();
+
+    expect(
+      parser.parseEval(
+        `
+$values = [<<<END
+a
+b
+c
+END          , 'd e f'];
+`,
+
+        {
+          parser: { version: 702, suppressErrors: true, debug: false },
+          lexer: { debug: false }
+        }
       )
     ).toMatchSnapshot();
   });
@@ -262,6 +313,26 @@ $values = [<<<END
 
     END];
 `
+      )
+    ).toMatchSnapshot();
+
+    expect(
+      parser.parseEval(
+        `
+$values = [<<<END
+        a
+
+      b
+
+    c
+
+    END];
+`,
+
+        {
+          parser: { version: 702, suppressErrors: true, debug: false },
+          lexer: { debug: false }
+        }
       )
     ).toMatchSnapshot();
   });

--- a/test/snapshot/heredoc.test.js
+++ b/test/snapshot/heredoc.test.js
@@ -206,4 +206,63 @@ c
       )
     ).toMatchSnapshot();
   });
+
+  it("Flexible heredoc syntax: parentheses", () => {
+    expect(
+      parser.parseEval(
+        `
+stringManipulator(<<<END
+   a
+  b
+ c
+END);
+`
+      )
+    ).toMatchSnapshot();
+  });
+
+  it("Flexible heredoc syntax: symbols after ending", () => {
+    expect(
+      parser.parseEval(
+        `
+$values = [<<<END
+a
+b
+c
+END, 'd e f'];
+`
+      )
+    ).toMatchSnapshot();
+  });
+
+  it("Flexible heredoc syntax: symbols after ending with whitespace", () => {
+    expect(
+      parser.parseEval(
+        `
+$values = [<<<END
+a
+b
+c
+END          , 'd e f'];
+`
+      )
+    ).toMatchSnapshot();
+  });
+
+  it("Flexible heredoc syntax: empty lines", () => {
+    expect(
+      parser.parseEval(
+        `
+$values = [<<<END
+        a
+
+      b
+
+    c
+
+    END];
+`
+      )
+    ).toMatchSnapshot();
+  });
 });

--- a/test/snapshot/heredoc.test.js
+++ b/test/snapshot/heredoc.test.js
@@ -456,4 +456,30 @@ $values = <<<END
       )
     ).toMatchSnapshot();
   });
+
+  it("Flexible heredoc syntax: indentation bracket bug", () => {
+    expect(
+      parser.parseEval(
+        `
+$a = <<<EOT
+  EOT;
+$b = "{$x}\ntest";
+`
+      )
+    ).toMatchSnapshot();
+
+    expect(
+      parser.parseEval(
+        `
+$a = <<<EOT
+  EOT;
+$b = "{$x}\ntest";
+`,
+        {
+          parser: { version: 702, suppressErrors: true, debug: false },
+          lexer: { debug: false }
+        }
+      )
+    ).toMatchSnapshot();
+  });
 });

--- a/test/snapshot/heredoc.test.js
+++ b/test/snapshot/heredoc.test.js
@@ -207,6 +207,22 @@ c
     ).toMatchSnapshot();
   });
 
+  it("Flexible heredoc syntax: ending label breaks old versions", () => {
+    expect(
+      parser.parseEval(
+        `
+echo <<<END
+a
+ END;
+`,
+        {
+          parser: { version: 702, suppressErrors: true, debug: false },
+          lexer: { debug: false }
+        }
+      )
+    ).toMatchSnapshot();
+  });
+
   it("Flexible heredoc syntax: parentheses", () => {
     expect(
       parser.parseEval(
@@ -304,14 +320,14 @@ END          , 'd e f'];
     expect(
       parser.parseEval(
         `
-$values = [<<<END
+$values = <<<END
         a
 
       b
-
+  
     c
 
-    END];
+    END;
 `
       )
     ).toMatchSnapshot();
@@ -319,16 +335,120 @@ $values = [<<<END
     expect(
       parser.parseEval(
         `
-$values = [<<<END
+$values = <<<END
         a
-
+  
       b
 
     c
+    END;
+`
+      )
+    ).toMatchSnapshot();
 
-    END];
+    expect(
+      parser.parseEval(
+        `
+$values = <<<END
+        a
+  
+      b
+
+    c
+  
+    END;
+`
+      )
+    ).toMatchSnapshot();
+
+    expect(
+      parser.parseEval(
+        `
+$values = <<<END
+        a
+  
+      b
+
+   c
+  
+    END;
 `,
+        {
+          parser: { suppressErrors: true, debug: false },
+          lexer: { debug: false }
+        }
+      )
+    ).toMatchSnapshot();
 
+    // check that it still breaks in old versions
+    expect(
+      parser.parseEval(
+        `
+$values = <<<END
+        a
+
+      b
+  
+    c
+
+    END;
+`,
+        {
+          parser: { version: 702, suppressErrors: true, debug: false },
+          lexer: { debug: false }
+        }
+      )
+    ).toMatchSnapshot();
+
+    expect(
+      parser.parseEval(
+        `
+$values = <<<END
+        a
+  
+      b
+
+    c
+    END;
+`,
+        {
+          parser: { version: 702, suppressErrors: true, debug: false },
+          lexer: { debug: false }
+        }
+      )
+    ).toMatchSnapshot();
+
+    expect(
+      parser.parseEval(
+        `
+$values = <<<END
+        a
+  
+      b
+
+    c
+  
+    END;
+`,
+        {
+          parser: { version: 702, suppressErrors: true, debug: false },
+          lexer: { debug: false }
+        }
+      )
+    ).toMatchSnapshot();
+
+    expect(
+      parser.parseEval(
+        `
+$values = <<<END
+        a
+  
+      b
+
+   c
+  
+    END;
+`,
         {
           parser: { version: 702, suppressErrors: true, debug: false },
           lexer: { debug: false }

--- a/test/snapshot/heredoc.test.js
+++ b/test/snapshot/heredoc.test.js
@@ -464,6 +464,9 @@ $values = <<<END
 $a = <<<EOT
   EOT;
 $b = "{$x}\ntest";
+$c = <<< TOE
+  a
+  TOE;
 `
       )
     ).toMatchSnapshot();
@@ -474,6 +477,9 @@ $b = "{$x}\ntest";
 $a = <<<EOT
   EOT;
 $b = "{$x}\ntest";
+$c = <<<TOE
+  a
+  TOE;
 `,
         {
           parser: { version: 702, suppressErrors: true, debug: false },


### PR DESCRIPTION
This pull provides heredoc fixes for the following situations which are all valid in php7.3:
```php
stringManipulator(<<<END
   a
  b
 c
END);
```
```php
$values = [<<<END
a
b
c
END, 'd e f'];
```
```php
$values = [<<<END
a
b
c
END          , 'd e f'];
```
```php
$values = [<<<END
        a

      b

    c

    END];
```