### PR TITLE
WIP php8-attributes

### DIFF
--- a/src/lexer.js
+++ b/src/lexer.js
@@ -474,6 +474,7 @@ lexer.prototype.next = function () {
 
 // extends the lexer with states
 [
+  require("./lexer/attribute.js"),
   require("./lexer/comments.js"),
   require("./lexer/initial.js"),
   require("./lexer/numbers.js"),

--- a/src/lexer/attribute.js
+++ b/src/lexer/attribute.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2018 Glayzzle (BSD3 License)
+ * @authors https://github.com/glayzzle/php-parser/graphs/contributors
+ * @url http://glayzzle.com
+ */
+"use strict";
+
+module.exports = {
+  matchST_ATTRIBUTE: function () {
+    const ch = this.input();
+    // console.log("Char:", ch);
+    if (this.is_LABEL_START()) {
+      this.consume_LABEL();
+      return this.tok.T_STRING;
+    }
+
+    if (ch === "]") {
+      this.popState();
+      return "]";
+    } else if (ch === "(") {
+      return this.consume_TOKEN();
+      // return "(";
+    } else if (ch === ":") {
+      return this.consume_TOKEN();
+    } else if (ch === ")") {
+      return this.consume_TOKEN();
+    } else if (ch === ",") {
+      return ch;
+    } else if (ch === '"') {
+      return this.ST_DOUBLE_QUOTES();
+    } else if (ch === "'") {
+      return this.T_CONSTANT_ENCAPSED_STRING();
+    } else if (this.is_NUM()) {
+      return this.consume_NUM();
+    } else if (this.is_TABSPACE()) {
+      return this.consume_TABSPACE();
+    }
+
+    throw new Error("what now?");
+  },
+};

--- a/src/lexer/scripting.js
+++ b/src/lexer/scripting.js
@@ -16,6 +16,11 @@ module.exports = {
       case "\r\n":
         return this.T_WHITESPACE();
       case "#":
+        if (this._input[this.offset] === "[") {
+          this.input();
+          this.begin("ST_ATTRIBUTE");
+          return this.tok.T_ATTRIBUTE;
+        }
         return this.T_COMMENT();
       case "/":
         if (this._input[this.offset] === "/") {

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -148,6 +148,7 @@ module.exports = {
     235: "T_FN",
     236: "T_NULLSAFE_OBJECT_OPERATOR",
     237: "T_MATCH",
+    238: "T_ATTRIBUTE",
   },
   names: {
     T_HALT_COMPILER: 101,
@@ -287,5 +288,6 @@ module.exports = {
     T_FN: 235,
     T_NULLSAFE_OBJECT_OPERATOR: 236,
     T_MATCH: 237,
+    T_ATTRIBUTE: 238,
   },
 };


### PR DESCRIPTION
@ichiriac  @czosel 

The Current implementation can handle code like `<?php #[Attribute("aoeu",'stnh'),Attribute(),SUP] class Whatever {}`  as well as named properties `<?php #[Attribute(someProp: 'stnh')] class Whatever {}`. But it feels like i duplicated logic. Any feedback?

The tokens are equal to `token_get_all` in php

## todo
-  handle `\n`  in attributes 
- tests
-