### PR TITLE
Fixed a problem where the return value of tokenGetAll is represented as an array of AST Strings, but actually returns a string.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -199,8 +199,8 @@ Engine.tokenGetAll = function (buffer, options) {
 /**
  * Extract tokens from the specified buffer.
  * > Note that the output tokens are *STRICLY* similar to PHP function `token_get_all`
- * @param {String} buffer
- * @return {String[]} - Each item can be a string or an array with following informations [token_name, text, line_number]
+ * @param {string} buffer
+ * @return {string[]} - Each item can be a string or an array with following informations [token_name, text, line_number]
  */
 Engine.prototype.tokenGetAll = function (buffer) {
   this.lexer.mode_eval = false;

--- a/types.d.ts
+++ b/types.d.ts
@@ -990,7 +990,7 @@ declare module "php-parser" {
          * > Note that the output tokens are *STRICLY* similar to PHP function `token_get_all`
          * @returns - Each item can be a string or an array with following informations [token_name, text, line_number]
          */
-        tokenGetAll(buffer: string): String[];
+        tokenGetAll(buffer: string): string[];
         lexer: Lexer;
         parser: Parser;
         ast: AST;


### PR DESCRIPTION
## Example

```typescript
const engine = new PHPParser.Engine({
      parser: {
        extractDoc: true,
      },
      lexer: {
        all_tokens: true,
      },
    });

const tokens: string[] = engine.tokenGetAll('<?php echo "hello";'); // error
```

## Expected

No error.

## Actual

I happen error following.

`Type 'String[]' is not assignable to type 'string[]'.`

The return value of tokenGetAll is represented in the doc comment as an array of AST's String class, but it is actually an array of strings.