### PR TITLE
feat(php8 dangling comma): Support dangling comma in use-block

### DIFF
--- a/src/parser/function.js
+++ b/src/parser/function.js
@@ -160,6 +160,12 @@ module.exports = {
    * ```
    */
   read_lexical_var: function () {
+    // a trailing separator is allowed in PHP8, which would put us right on the
+    // closing parenthesis. the ")" can be ignored here, the actually closing
+    // of the list is done in `read_lexical_vars`
+    if (this.version >= 800 && this.token === ")") {
+      return;
+    }
     if (this.token === "&") {
       return this.read_byref(this.read_lexical_var.bind(this));
     }

--- a/test/snapshot/__snapshots__/function.test.js.snap
+++ b/test/snapshot/__snapshots__/function.test.js.snap
@@ -233,6 +233,46 @@ Program {
 }
 `;
 
+exports[`Function tests test danging comma in closure use-block php 8.0 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "test",
+        },
+        "operator": "=",
+        "right": Closure {
+          "arguments": Array [],
+          "body": Block {
+            "children": Array [],
+            "kind": "block",
+          },
+          "byref": false,
+          "isStatic": false,
+          "kind": "closure",
+          "nullable": false,
+          "type": null,
+          "uses": Array [
+            Variable {
+              "curly": false,
+              "kind": "variable",
+              "name": "one",
+            },
+          ],
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`Function tests test danging comma in function php 8.0 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/__snapshots__/function.test.js.snap
+++ b/test/snapshot/__snapshots__/function.test.js.snap
@@ -273,6 +273,165 @@ Program {
 }
 `;
 
+exports[`Function tests test danging comma in closure use-block with multiple php 8.0 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "test",
+        },
+        "operator": "=",
+        "right": Closure {
+          "arguments": Array [],
+          "body": Block {
+            "children": Array [],
+            "kind": "block",
+          },
+          "byref": false,
+          "isStatic": false,
+          "kind": "closure",
+          "nullable": false,
+          "type": null,
+          "uses": Array [
+            Variable {
+              "curly": false,
+              "kind": "variable",
+              "name": "one",
+            },
+            Variable {
+              "curly": false,
+              "kind": "variable",
+              "name": "two",
+            },
+          ],
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Function tests test danging comma in closure use-block with multiple/refs php 8.0 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "test",
+        },
+        "operator": "=",
+        "right": Closure {
+          "arguments": Array [
+            Parameter {
+              "byref": false,
+              "flags": 0,
+              "kind": "parameter",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "one",
+              },
+              "nullable": false,
+              "type": null,
+              "value": null,
+              "variadic": false,
+            },
+            Parameter {
+              "byref": false,
+              "flags": 0,
+              "kind": "parameter",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "two",
+              },
+              "nullable": false,
+              "type": null,
+              "value": null,
+              "variadic": false,
+            },
+          ],
+          "body": Block {
+            "children": Array [],
+            "kind": "block",
+          },
+          "byref": false,
+          "isStatic": false,
+          "kind": "closure",
+          "nullable": false,
+          "type": null,
+          "uses": Array [
+            Variable {
+              "curly": false,
+              "kind": "variable",
+              "name": "three",
+            },
+            Variable {
+              "byref": true,
+              "curly": false,
+              "kind": "variable",
+              "name": "four",
+            },
+          ],
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Function tests test danging comma in closure use-block with refs php 8.0 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "test",
+        },
+        "operator": "=",
+        "right": Closure {
+          "arguments": Array [],
+          "body": Block {
+            "children": Array [],
+            "kind": "block",
+          },
+          "byref": false,
+          "isStatic": false,
+          "kind": "closure",
+          "nullable": false,
+          "type": null,
+          "uses": Array [
+            Variable {
+              "byref": true,
+              "curly": false,
+              "kind": "variable",
+              "name": "one",
+            },
+          ],
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`Function tests test danging comma in function php 8.0 1`] = `
 Program {
   "children": Array [
@@ -333,6 +492,59 @@ Program {
     },
   ],
   "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Function tests test double danging comma in closure use-block php 8.0 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "test",
+        },
+        "operator": "=",
+        "right": Closure {
+          "arguments": Array [],
+          "body": Block {
+            "children": Array [],
+            "kind": "block",
+          },
+          "byref": false,
+          "isStatic": false,
+          "kind": "closure",
+          "nullable": false,
+          "type": null,
+          "uses": Array [
+            Variable {
+              "curly": false,
+              "kind": "variable",
+              "name": "one",
+            },
+            Variable {
+              "curly": false,
+              "kind": "variable",
+              "name": "",
+            },
+          ],
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": 222,
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected ',', expecting T_VARIABLE on line 1",
+      "token": "','",
+    },
+  ],
   "kind": "program",
 }
 `;
@@ -907,6 +1119,87 @@ Program {
       "token": undefined,
     },
   ],
+  "kind": "program",
+}
+`;
+
+exports[`Function tests test without danging comma in closure use-block php 8.0 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "test",
+        },
+        "operator": "=",
+        "right": Closure {
+          "arguments": Array [],
+          "body": Block {
+            "children": Array [],
+            "kind": "block",
+          },
+          "byref": false,
+          "isStatic": false,
+          "kind": "closure",
+          "nullable": false,
+          "type": null,
+          "uses": Array [
+            Variable {
+              "curly": false,
+              "kind": "variable",
+              "name": "one",
+            },
+          ],
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Function tests test without danging comma in closure use-block with refs php 8.0 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "test",
+        },
+        "operator": "=",
+        "right": Closure {
+          "arguments": Array [],
+          "body": Block {
+            "children": Array [],
+            "kind": "block",
+          },
+          "byref": false,
+          "isStatic": false,
+          "kind": "closure",
+          "nullable": false,
+          "type": null,
+          "uses": Array [
+            Variable {
+              "byref": true,
+              "curly": false,
+              "kind": "variable",
+              "name": "one",
+            },
+          ],
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
   "kind": "program",
 }
 `;

--- a/test/snapshot/function.test.js
+++ b/test/snapshot/function.test.js
@@ -108,10 +108,68 @@ describe("Function tests", function () {
     expect(astErr).toMatchSnapshot();
   });
 
-  it("test danging comma in closure use-block php 8.0", function () {
-    const astErr = parser.parseEval("$test = function () use ($one,) {}", {
+  it("test without danging comma in closure use-block php 8.0", function () {
+    const ast = parser.parseEval("$test = function () use ($one) {}", {
       parser: {
         version: "8.0",
+      },
+    });
+    expect(ast).toMatchSnapshot();
+  });
+
+  it("test danging comma in closure use-block php 8.0", function () {
+    const ast = parser.parseEval("$test = function () use ($one,) {}", {
+      parser: {
+        version: "8.0",
+      },
+    });
+    expect(ast).toMatchSnapshot();
+  });
+
+  it("test without danging comma in closure use-block with refs php 8.0", function () {
+    const ast = parser.parseEval("$test = function () use (&$one) {}", {
+      parser: {
+        version: "8.0",
+      },
+    });
+    expect(ast).toMatchSnapshot();
+  });
+
+  it("test danging comma in closure use-block with refs php 8.0", function () {
+    const ast = parser.parseEval("$test = function () use (&$one) {}", {
+      parser: {
+        version: "8.0",
+      },
+    });
+    expect(ast).toMatchSnapshot();
+  });
+
+  it("test danging comma in closure use-block with multiple php 8.0", function () {
+    const ast = parser.parseEval("$test = function () use ($one, $two,) {}", {
+      parser: {
+        version: "8.0",
+      },
+    });
+    expect(ast).toMatchSnapshot();
+  });
+
+  it("test danging comma in closure use-block with multiple/refs php 8.0", function () {
+    const ast = parser.parseEval(
+      "$test = function ($one, $two) use ($three, &$four,) {}",
+      {
+        parser: {
+          version: "8.0",
+        },
+      }
+    );
+    expect(ast).toMatchSnapshot();
+  });
+
+  it("test double danging comma in closure use-block php 8.0", function () {
+    const astErr = parser.parseEval("$test = function () use ($one, ,) {}", {
+      parser: {
+        version: "8.0",
+        suppressErrors: true,
       },
     });
     expect(astErr).toMatchSnapshot();

--- a/test/snapshot/function.test.js
+++ b/test/snapshot/function.test.js
@@ -107,4 +107,13 @@ describe("Function tests", function () {
     );
     expect(astErr).toMatchSnapshot();
   });
+
+  it("test danging comma in closure use-block php 8.0", function () {
+    const astErr = parser.parseEval("$test = function () use ($one,) {}", {
+      parser: {
+        version: "8.0",
+      },
+    });
+    expect(astErr).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Allow for dangling commas to exist in the use-block of a closure.

This becomes valid:

```php
$foo = function() use ($bar,) {};
```

Walking over the variables is done in an external function and would need significant refactoring to allow for dangling commas, this might be too impactful.

This change is possible because `read_lexical_var` is only used for parsing the `use`-block.