### PR TITLE
Fixed parsing of optional promoted properties when type is nullable

### DIFF
--- a/src/parser/function.js
+++ b/src/parser/function.js
@@ -220,11 +220,11 @@ module.exports = {
     let nullable = false;
     let attrs = [];
     if (this.token === this.tok.T_ATTRIBUTE) attrs = this.read_attr_list();
+    const flags = this.read_promoted();
     if (this.token === "?") {
       this.next();
       nullable = true;
     }
-    const flags = this.read_promoted();
     types = this.read_types();
     if (nullable && !types) {
       this.raiseError(

--- a/test/snapshot/__snapshots__/class.test.js.snap
+++ b/test/snapshot/__snapshots__/class.test.js.snap
@@ -874,6 +874,87 @@ Program {
 }
 `;
 
+exports[`Test classes Test promoted nullable properties php 8 1`] = `
+Program {
+  "children": Array [
+    Class {
+      "attrGroups": Array [],
+      "body": Array [
+        Method {
+          "arguments": Array [
+            Parameter {
+              "attrGroups": Array [],
+              "byref": false,
+              "flags": 1,
+              "kind": "parameter",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "maybe",
+              },
+              "nullable": true,
+              "type": TypeReference {
+                "kind": "typereference",
+                "name": "string",
+                "raw": "string",
+              },
+              "value": null,
+              "variadic": false,
+            },
+            Parameter {
+              "attrGroups": Array [],
+              "byref": false,
+              "flags": 4,
+              "kind": "parameter",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "opt",
+              },
+              "nullable": true,
+              "type": TypeReference {
+                "kind": "typereference",
+                "name": "int",
+                "raw": "int",
+              },
+              "value": null,
+              "variadic": false,
+            },
+          ],
+          "attrGroups": Array [],
+          "body": Block {
+            "children": Array [],
+            "kind": "block",
+          },
+          "byref": false,
+          "isAbstract": false,
+          "isFinal": false,
+          "isStatic": false,
+          "kind": "method",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "constructor",
+          },
+          "nullable": false,
+          "type": null,
+          "visibility": "public",
+        },
+      ],
+      "extends": null,
+      "implements": null,
+      "isAbstract": false,
+      "isAnonymous": false,
+      "isFinal": false,
+      "kind": "class",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "__proto__",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`Test classes Validate usual declarations 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/__snapshots__/function.test.js.snap
+++ b/test/snapshot/__snapshots__/function.test.js.snap
@@ -258,6 +258,7 @@ Program {
         "operator": "=",
         "right": Closure {
           "arguments": Array [],
+          "attrGroups": Array [],
           "body": Block {
             "children": Array [],
             "kind": "block",
@@ -298,6 +299,7 @@ Program {
         "operator": "=",
         "right": Closure {
           "arguments": Array [],
+          "attrGroups": Array [],
           "body": Block {
             "children": Array [],
             "kind": "block",
@@ -344,6 +346,7 @@ Program {
         "right": Closure {
           "arguments": Array [
             Parameter {
+              "attrGroups": Array [],
               "byref": false,
               "flags": 0,
               "kind": "parameter",
@@ -357,6 +360,7 @@ Program {
               "variadic": false,
             },
             Parameter {
+              "attrGroups": Array [],
               "byref": false,
               "flags": 0,
               "kind": "parameter",
@@ -370,6 +374,7 @@ Program {
               "variadic": false,
             },
           ],
+          "attrGroups": Array [],
           "body": Block {
             "children": Array [],
             "kind": "block",
@@ -416,6 +421,7 @@ Program {
         "operator": "=",
         "right": Closure {
           "arguments": Array [],
+          "attrGroups": Array [],
           "body": Block {
             "children": Array [],
             "kind": "block",
@@ -449,6 +455,7 @@ Program {
     _Function {
       "arguments": Array [
         Parameter {
+          "attrGroups": Array [],
           "byref": false,
           "flags": 0,
           "kind": "parameter",
@@ -462,6 +469,7 @@ Program {
           "variadic": false,
         },
         Parameter {
+          "attrGroups": Array [],
           "byref": false,
           "flags": 0,
           "kind": "parameter",
@@ -475,6 +483,7 @@ Program {
           "variadic": false,
         },
         Parameter {
+          "attrGroups": Array [],
           "byref": false,
           "flags": 0,
           "kind": "parameter",
@@ -488,6 +497,7 @@ Program {
           "variadic": false,
         },
       ],
+      "attrGroups": Array [],
       "body": Block {
         "children": Array [],
         "kind": "block",
@@ -521,6 +531,7 @@ Program {
         "operator": "=",
         "right": Closure {
           "arguments": Array [],
+          "attrGroups": Array [],
           "body": Block {
             "children": Array [],
             "kind": "block",
@@ -1162,6 +1173,7 @@ Program {
         "operator": "=",
         "right": Closure {
           "arguments": Array [],
+          "attrGroups": Array [],
           "body": Block {
             "children": Array [],
             "kind": "block",
@@ -1202,6 +1214,7 @@ Program {
         "operator": "=",
         "right": Closure {
           "arguments": Array [],
+          "attrGroups": Array [],
           "body": Block {
             "children": Array [],
             "kind": "block",

--- a/test/snapshot/class.test.js
+++ b/test/snapshot/class.test.js
@@ -145,6 +145,22 @@ describe("Test classes", function () {
     expect(ast).toMatchSnapshot();
   });
 
+  it("Test promoted nullable properties php 8", function () {
+    const ast = parser.parseEval(
+      `
+      class __proto__ {
+        public function constructor(public ?string $maybe, private ?int $opt) {}
+      }`,
+      {
+        parser: {
+          version: "8.0",
+          suppressErrors: true,
+        },
+      }
+    );
+    expect(ast).toMatchSnapshot();
+  });
+
   it("empty", function () {
     expect(parser.parseEval("class Foo {}")).toMatchSnapshot();
   });


### PR DESCRIPTION
There was a logic error, I was trying to pass the promotion keyword after the nullable type token. I have added a test, and re-ordered the parsing correctly.

This should fix:
https://github.com/glayzzle/php-parser/issues/486#issuecomment-897346495