### PR TITLE
PHP8 Attrributes repeating

### DIFF
--- a/src/parser/class.js
+++ b/src/parser/class.js
@@ -105,6 +105,7 @@ module.exports = {
       if (this.token === this.tok.T_FUNCTION) {
         // reads a function
         result.push(this.read_function(false, flags, attrs));
+        attrs = [];
       } else if (
         this.token === this.tok.T_VARIABLE ||
         // support https://wiki.php.net/rfc/typed_properties_v2
@@ -399,6 +400,7 @@ module.exports = {
           this.next();
         }
         result = result.concat(constants);
+        attrs = [];
       } else if (this.token === this.tok.T_FUNCTION) {
         // reads a function
         const method = this.read_function_declaration(2, flags, attrs);
@@ -407,6 +409,7 @@ module.exports = {
         if (this.expect(";")) {
           this.next();
         }
+        attrs = [];
       } else {
         // raise an error
         this.error([this.tok.T_CONST, this.tok.T_FUNCTION]);

--- a/test/snapshot/__snapshots__/attributes.test.js.snap
+++ b/test/snapshot/__snapshots__/attributes.test.js.snap
@@ -1004,3 +1004,98 @@ Program {
   "kind": "program",
 }
 `;
+
+exports[`Parse Attributes doesnt repeat attributes from previous function 1`] = `
+Program {
+  "children": Array [
+    Class {
+      "attrGroups": Array [],
+      "body": Array [
+        Method {
+          "arguments": Array [],
+          "attrGroups": Array [
+            AttrGroup {
+              "attrs": Array [
+                Attribute {
+                  "args": Array [],
+                  "kind": "attribute",
+                  "name": "Att1",
+                },
+              ],
+              "kind": "attrgroup",
+            },
+          ],
+          "body": Block {
+            "children": Array [],
+            "kind": "block",
+          },
+          "byref": false,
+          "isAbstract": false,
+          "isFinal": false,
+          "isStatic": false,
+          "kind": "method",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "b",
+          },
+          "nullable": false,
+          "type": null,
+          "visibility": "",
+        },
+        Method {
+          "arguments": Array [],
+          "attrGroups": Array [],
+          "body": Block {
+            "children": Array [],
+            "kind": "block",
+          },
+          "byref": false,
+          "isAbstract": false,
+          "isFinal": false,
+          "isStatic": false,
+          "kind": "method",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "c",
+          },
+          "nullable": false,
+          "type": null,
+          "visibility": "",
+        },
+        Method {
+          "arguments": Array [],
+          "attrGroups": Array [],
+          "body": Block {
+            "children": Array [],
+            "kind": "block",
+          },
+          "byref": false,
+          "isAbstract": false,
+          "isFinal": false,
+          "isStatic": false,
+          "kind": "method",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "d",
+          },
+          "nullable": false,
+          "type": null,
+          "visibility": "",
+        },
+      ],
+      "extends": null,
+      "implements": null,
+      "isAbstract": false,
+      "isAnonymous": false,
+      "isFinal": false,
+      "kind": "class",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "a",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;

--- a/test/snapshot/attributes.test.js
+++ b/test/snapshot/attributes.test.js
@@ -144,4 +144,17 @@ describe("Parse Attributes", () => {
     `)
     ).toMatchSnapshot();
   });
+
+  it("doesnt repeat attributes from previous function", () => {
+    expect(
+      parser.parseEval(`
+      class a {
+        #[Att1]
+        function b(){}
+        function c(){}
+        function d(){}
+        }
+    `)
+    ).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Reported in prettier:
https://github.com/prettier/plugin-php/pull/1761#issuecomment-913770153

> Hello i have found a bug in this version when creating a class with multiple methods and you add an attribute just in the first one... all the following methods will have the same attribute... like the last one is stuck for all the rests...

I have added a test case, and a fix for it.