### PR TITLE
Fix method flags in src location

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -128,21 +128,6 @@ const AST = function (withPositions, withSource) {
   this.withSource = withSource;
 };
 
-/**
- * Create a position node from specified parser
- * including it's lexer current state
- * @param {Parser}
- * @return {Position}
- * @private
- */
-AST.prototype.position = function (parser) {
-  return new Position(
-    parser.lexer.yylloc.first_line,
-    parser.lexer.yylloc.first_column,
-    parser.lexer.yylloc.first_offset
-  );
-};
-
 // operators in ascending order of precedence
 AST.precedence = {};
 [
@@ -353,7 +338,7 @@ AST.prototype.resolvePrecedence = function (result, parser) {
 AST.prototype.prepare = function (kind, docs, parser) {
   let start = null;
   if (this.withPositions || this.withSource) {
-    start = this.position(parser);
+    start = parser.position();
   }
   const self = this;
   // returns the node

--- a/src/parser.js
+++ b/src/parser.js
@@ -5,6 +5,8 @@
  */
 "use strict";
 
+const Position = require("./ast/position");
+
 /**
  * @private
  */
@@ -375,6 +377,19 @@ parser.prototype.error = function (expect) {
     msg += msgExpect;
   }
   return this.raiseError(msg, msgExpect, expect, token);
+};
+
+/**
+ * Create a position node from the lexers position
+ *
+ * @return {Position}
+ */
+parser.prototype.position = function () {
+  return new Position(
+    this.lexer.yylloc.first_line,
+    this.lexer.yylloc.first_column,
+    this.lexer.yylloc.first_offset
+  );
 };
 
 /**

--- a/src/parser/class.js
+++ b/src/parser/class.js
@@ -82,6 +82,9 @@ module.exports = {
       if (this.token === this.tok.T_ATTRIBUTE) {
         attrs = this.read_attr_list();
       }
+
+      const locStart = this.position();
+
       // read member flags
       const flags = this.read_member_flags(false);
 
@@ -104,7 +107,7 @@ module.exports = {
 
       if (this.token === this.tok.T_FUNCTION) {
         // reads a function
-        result.push(this.read_function(false, flags, attrs));
+        result.push(this.read_function(false, flags, attrs, locStart));
         attrs = [];
       } else if (
         this.token === this.tok.T_VARIABLE ||
@@ -389,6 +392,9 @@ module.exports = {
         result.push(this.read_doc_comment());
         continue;
       }
+
+      const locStart = this.position();
+
       attrs = this.read_attr_list();
       // read member flags
       const flags = this.read_member_flags(true);
@@ -403,7 +409,12 @@ module.exports = {
         attrs = [];
       } else if (this.token === this.tok.T_FUNCTION) {
         // reads a function
-        const method = this.read_function_declaration(2, flags, attrs);
+        const method = this.read_function_declaration(
+          2,
+          flags,
+          attrs,
+          locStart
+        );
         method.parseFlags(flags);
         result.push(method);
         if (this.expect(";")) {

--- a/test/snapshot/__snapshots__/acid.test.js.snap
+++ b/test/snapshot/__snapshots__/acid.test.js.snap
@@ -1571,11 +1571,11 @@ Program {
                   "line": 46,
                   "offset": 934,
                 },
-                "source": "function doSomething()",
+                "source": "final public function doSomething()",
                 "start": Position {
-                  "column": 17,
+                  "column": 4,
                   "line": 39,
-                  "offset": 713,
+                  "offset": 700,
                 },
               },
               "name": Identifier {
@@ -1720,11 +1720,11 @@ Program {
                   "line": 50,
                   "offset": 1014,
                 },
-                "source": "function Am_I_Uggly() : bool",
+                "source": "public function Am_I_Uggly() : bool",
                 "start": Position {
-                  "column": 11,
+                  "column": 4,
                   "line": 50,
-                  "offset": 986,
+                  "offset": 979,
                 },
               },
               "name": Identifier {
@@ -1780,11 +1780,11 @@ Program {
                   "line": 51,
                   "offset": 1054,
                 },
-                "source": "function broken() : bool",
+                "source": "protected function broken() : bool",
                 "start": Position {
-                  "column": 14,
+                  "column": 4,
                   "line": 51,
-                  "offset": 1030,
+                  "offset": 1020,
                 },
               },
               "name": Identifier {
@@ -1840,11 +1840,11 @@ Program {
                   "line": 52,
                   "offset": 1111,
                 },
-                "source": "function isWhiteSnowAlive() : bool",
+                "source": "static protected function isWhiteSnowAlive() : bool",
                 "start": Position {
-                  "column": 21,
+                  "column": 4,
                   "line": 52,
-                  "offset": 1077,
+                  "offset": 1060,
                 },
               },
               "name": Identifier {
@@ -2829,11 +2829,11 @@ Program {
                   "line": 72,
                   "offset": 1498,
                 },
-                "source": "function draw(bool $arrow = false) : string",
+                "source": "public function draw(bool $arrow = false) : string",
                 "start": Position {
-                  "column": 11,
+                  "column": 4,
                   "line": 61,
-                  "offset": 1220,
+                  "offset": 1213,
                 },
               },
               "name": Identifier {
@@ -2942,11 +2942,11 @@ Program {
                   "line": 75,
                   "offset": 1563,
                 },
-                "source": "function shuut()",
+                "source": "private function shuut()",
                 "start": Position {
-                  "column": 12,
+                  "column": 4,
                   "line": 73,
-                  "offset": 1511,
+                  "offset": 1503,
                 },
               },
               "name": Identifier {

--- a/test/snapshot/__snapshots__/location.test.js.snap
+++ b/test/snapshot/__snapshots__/location.test.js.snap
@@ -8386,11 +8386,11 @@ Program {
               "line": 1,
               "offset": 39,
             },
-            "source": "function method()",
+            "source": "public function method()",
             "start": Position {
-              "column": 19,
+              "column": 12,
               "line": 1,
-              "offset": 19,
+              "offset": 12,
             },
           },
           "name": Identifier {

--- a/test/snapshot/__snapshots__/namespace.test.js.snap
+++ b/test/snapshot/__snapshots__/namespace.test.js.snap
@@ -453,9 +453,9 @@ Program {
                 },
                 "source": null,
                 "start": Position {
-                  "column": 15,
+                  "column": 8,
                   "line": 16,
-                  "offset": 267,
+                  "offset": 260,
                 },
               },
               "name": Identifier {
@@ -986,9 +986,9 @@ Program {
                 },
                 "source": null,
                 "start": Position {
-                  "column": 15,
+                  "column": 8,
                   "line": 16,
-                  "offset": 267,
+                  "offset": 260,
                 },
               },
               "name": Identifier {

--- a/test/snapshot/class.test.js
+++ b/test/snapshot/class.test.js
@@ -184,4 +184,27 @@ describe("Test classes", function () {
       })
     ).toMatchSnapshot();
   });
+
+  it("knows where a function definiton starts", function () {
+    const phpCode = `
+class b { 
+  // prettier-ignore
+  public static function a() {}
+}
+    `;
+    const ast = parser.parseEval(phpCode, {
+      ast: {
+        withPositions: true,
+        withSource: true,
+      },
+    });
+    const funcStart = ast.children[0].body[0].loc.start.offset;
+    const funcEnd = ast.children[0].body[0].loc.end.offset;
+    expect(phpCode.substr(funcStart, funcEnd - funcStart)).toEqual(
+      "public static function a() {}"
+    );
+    expect(ast.children[0].body[0].loc.source).toEqual(
+      "public static function a()"
+    );
+  });
 });


### PR DESCRIPTION
Fix method flags in src location parsing classes and interfaces

This will fix problems when using prettier-ignore in front of a function and that static/private/etc/ disappears.

Not sure if this is the best way to do this, but it appears to work correctly.

Can @czosel merge this into php8 branch?