### PR TITLE
Fix nowdoc followed by string interpolation

### DIFF
--- a/src/parser/scalar.js
+++ b/src/parser/scalar.js
@@ -263,6 +263,7 @@ module.exports = {
               raw,
               this.lexer.heredoc_label.label
             );
+            this.lexer.heredoc_label.finished = true;
             return node;
           } else {
             return this.read_encapsed_string(this.tok.T_END_HEREDOC);

--- a/test/snapshot/__snapshots__/nowdoc.test.js.snap
+++ b/test/snapshot/__snapshots__/nowdoc.test.js.snap
@@ -56,6 +56,76 @@ c",
 }
 `;
 
+exports[`nowdoc Followed by string interpolation 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "x",
+        },
+        "operator": "=",
+        "right": Nowdoc {
+          "kind": "nowdoc",
+          "label": "NOWDOC",
+          "raw": "<<<'NOWDOC'
+      ...
+      NOWDOC",
+          "value": "...",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "y",
+        },
+        "operator": "=",
+        "right": Encapsed {
+          "kind": "encapsed",
+          "raw": "\\"_$z\\"",
+          "type": "string",
+          "value": Array [
+            EncapsedPart {
+              "curly": false,
+              "expression": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "_",
+                "unicode": false,
+                "value": "_",
+              },
+              "kind": "encapsedpart",
+              "syntax": null,
+            },
+            EncapsedPart {
+              "curly": false,
+              "expression": Variable {
+                "curly": false,
+                "kind": "variable",
+                "name": "z",
+              },
+              "kind": "encapsedpart",
+              "syntax": "simple",
+            },
+          ],
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`nowdoc empty 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/nowdoc.test.js
+++ b/test/snapshot/nowdoc.test.js
@@ -144,4 +144,16 @@ TEST;
     `)
     ).toMatchSnapshot();
   });
+
+  it("Followed by string interpolation", function () {
+    expect(
+      parser.parseEval(`
+      $x = <<<'NOWDOC'
+      ...
+      NOWDOC;
+
+      $y = "_$z";
+    `)
+    ).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Fixes #560 

When using nowdoc (as opposed to heredoc), `this.lexer.heredoc_finished` was not being set to false. This caused `remove_heredoc_leading_whitespace_chars` to be called later on when processing a string.