### PR TITLE
Fix Array type definition

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -26,7 +26,7 @@ declare module "php-parser" {
         /**
          * List of array items
         */
-        items: Entry | Expression | Variable;
+        items: (Entry | Expression | Variable)[];
         /**
          * Indicate if the short array syntax is used, ex `[]` instead `array()`
         */


### PR DESCRIPTION
Thanks for this great library! I was really stoked when I saw that someone made the effort to write a PHP parser in JavaScript and it's a perfect match for the project I'm currently working on :)

While using it, I noticed a small issue with the TypeScript definition of the Array class. The items are an array of the combined type (Entry | Expression | Variable) instead of being just one of those types.