### PR TITLE
chore: prepare new release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "php-parser",
-  "version": "3.0.3",
+  "version": "3.1.0-beta.0",
   "description": "Parse PHP code from JS and returns its AST",
   "main": "src/index.js",
   "browser": "dist/php-parser.js",


### PR DESCRIPTION
Since I don't have publish permissions on npm, this changes the package name to `php-parser-next`. I'm not sure if we actually have breaking changes, since the last release is quite long ago. I figured even without breaking changes we can release it as `4.0.0` (beta, for now).