### PR TITLE
[8.1] - Add support for intersection type

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -522,6 +522,7 @@ AST.prototype.checkNodes = function () {
   require("./ast/include"),
   require("./ast/inline"),
   require("./ast/interface"),
+  require("./ast/intersectiontype"),
   require("./ast/isset"),
   require("./ast/label"),
   require("./ast/list"),

--- a/src/ast/intersectiontype.js
+++ b/src/ast/intersectiontype.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2018 Glayzzle (BSD3 License)
+ * @authors https://github.com/glayzzle/php-parser/graphs/contributors
+ * @url http://glayzzle.com
+ */
+"use strict";
+
+const Declaration = require("./declaration");
+const KIND = "intersectiontype";
+
+/**
+ * A union of types
+ * @constructor IntersectionType
+ * @extends {Declaration}
+ * @property {TypeReference[]} types
+ */
+module.exports = Declaration.extends(
+  KIND,
+  function IntersectionType(types, docs, location) {
+    Declaration.apply(this, [KIND, null, docs, location]);
+    this.types = types;
+  }
+);

--- a/src/parser.js
+++ b/src/parser.js
@@ -35,6 +35,7 @@ const Parser = function (lexer, ast) {
   this.EOF = lexer.EOF;
   this.token = null;
   this.prev = null;
+  this.previous_token = null;
   this.debug = false;
   this.version = 801;
   this.extractDoc = false;
@@ -589,6 +590,8 @@ Parser.prototype.text = function () {
  * @memberOf module:php-parser
  */
 Parser.prototype.next = function () {
+  this.previous_token = this.token;
+
   // prepare the back command
   if (this.token !== ";" || this.lexer.yytext === ";") {
     // ignore '?>' from automated resolution

--- a/test/snapshot/__snapshots__/function.test.js.snap
+++ b/test/snapshot/__snapshots__/function.test.js.snap
@@ -144,6 +144,51 @@ Program {
 }
 `;
 
+exports[`Function tests array pass by reference are not confused with intersection 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "attrGroups": Array [],
+          "byref": true,
+          "flags": 0,
+          "kind": "parameter",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "params",
+          },
+          "nullable": false,
+          "readonly": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "array",
+            "raw": "array",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "attrGroups": Array [],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "foo",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`Function tests implement #113 : typehint nodes 1`] = `
 Program {
   "children": Array [
@@ -364,6 +409,51 @@ Program {
       "kind": "commentblock",
       "offset": 18,
       "value": "/* f */",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Function tests spread array pass by reference are not intersection 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "attrGroups": Array [],
+          "byref": true,
+          "flags": 0,
+          "kind": "parameter",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "params",
+          },
+          "nullable": false,
+          "readonly": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "array",
+            "raw": "array",
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "attrGroups": Array [],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": true,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "foo",
+      },
+      "nullable": false,
+      "type": null,
     },
   ],
   "errors": Array [],
@@ -724,6 +814,110 @@ Program {
       "token": "','",
     },
   ],
+  "kind": "program",
+}
+`;
+
+exports[`Function tests test function intersection types 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "attrGroups": Array [],
+          "byref": false,
+          "flags": 0,
+          "kind": "parameter",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "a",
+          },
+          "nullable": false,
+          "readonly": false,
+          "type": IntersectionType {
+            "kind": "intersectiontype",
+            "name": null,
+            "types": Array [
+              TypeReference {
+                "kind": "typereference",
+                "name": "int",
+                "raw": "int",
+              },
+              TypeReference {
+                "kind": "typereference",
+                "name": "float",
+                "raw": "float",
+              },
+            ],
+          },
+          "value": Number {
+            "kind": "number",
+            "value": "1",
+          },
+          "variadic": false,
+        },
+        Parameter {
+          "attrGroups": Array [],
+          "byref": false,
+          "flags": 0,
+          "kind": "parameter",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "b",
+          },
+          "nullable": false,
+          "readonly": false,
+          "type": IntersectionType {
+            "kind": "intersectiontype",
+            "name": null,
+            "types": Array [
+              Name {
+                "kind": "name",
+                "name": "Foo",
+                "resolution": "uqn",
+              },
+              Name {
+                "kind": "name",
+                "name": "Bar",
+                "resolution": "uqn",
+              },
+            ],
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "attrGroups": Array [],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "foo",
+      },
+      "nullable": false,
+      "type": IntersectionType {
+        "kind": "intersectiontype",
+        "name": null,
+        "types": Array [
+          TypeReference {
+            "kind": "typereference",
+            "name": "string",
+            "raw": "string",
+          },
+          TypeReference {
+            "kind": "typereference",
+            "name": "int",
+            "raw": "int",
+          },
+        ],
+      },
+    },
+  ],
+  "errors": Array [],
   "kind": "program",
 }
 `;
@@ -1095,6 +1289,113 @@ Program {
       "token": "'list' (T_LIST)",
     },
   ],
+  "kind": "program",
+}
+`;
+
+exports[`Function tests test short function intersection types 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Closure {
+        "arguments": Array [
+          Parameter {
+            "attrGroups": Array [],
+            "byref": false,
+            "flags": 0,
+            "kind": "parameter",
+            "name": Identifier {
+              "kind": "identifier",
+              "name": "a",
+            },
+            "nullable": false,
+            "readonly": false,
+            "type": IntersectionType {
+              "kind": "intersectiontype",
+              "name": null,
+              "types": Array [
+                TypeReference {
+                  "kind": "typereference",
+                  "name": "int",
+                  "raw": "int",
+                },
+                TypeReference {
+                  "kind": "typereference",
+                  "name": "float",
+                  "raw": "float",
+                },
+              ],
+            },
+            "value": Number {
+              "kind": "number",
+              "value": "1",
+            },
+            "variadic": false,
+          },
+          Parameter {
+            "attrGroups": Array [],
+            "byref": false,
+            "flags": 0,
+            "kind": "parameter",
+            "name": Identifier {
+              "kind": "identifier",
+              "name": "b",
+            },
+            "nullable": false,
+            "readonly": false,
+            "type": IntersectionType {
+              "kind": "intersectiontype",
+              "name": null,
+              "types": Array [
+                Name {
+                  "kind": "name",
+                  "name": "Foo",
+                  "resolution": "uqn",
+                },
+                Name {
+                  "kind": "name",
+                  "name": "Bar",
+                  "resolution": "uqn",
+                },
+              ],
+            },
+            "value": null,
+            "variadic": false,
+          },
+        ],
+        "attrGroups": Array [],
+        "body": String {
+          "isDoubleQuote": true,
+          "kind": "string",
+          "raw": "\\"\\"",
+          "unicode": false,
+          "value": "",
+        },
+        "byref": false,
+        "isStatic": false,
+        "kind": "arrowfunc",
+        "nullable": false,
+        "type": IntersectionType {
+          "kind": "intersectiontype",
+          "name": null,
+          "types": Array [
+            TypeReference {
+              "kind": "typereference",
+              "name": "string",
+              "raw": "string",
+            },
+            TypeReference {
+              "kind": "typereference",
+              "name": "int",
+              "raw": "int",
+            },
+          ],
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
   "kind": "program",
 }
 `;

--- a/test/snapshot/function.test.js
+++ b/test/snapshot/function.test.js
@@ -32,6 +32,48 @@ describe("Function tests", function () {
     expect(ast).toMatchSnapshot();
   });
 
+  it("test function intersection types", function () {
+    const ast = parser.parseEval(
+      `
+      function foo(int&float $a = 1, Foo&Bar $b) : string&int {}
+      `
+    );
+    expect(ast).toMatchSnapshot();
+  });
+
+  it("test short function intersection types", function () {
+    const ast = parser.parseEval(
+      `
+      fn (int&float $a = 1, Foo&Bar $b) : string&int => "";
+      `
+    );
+    expect(ast).toMatchSnapshot();
+  });
+
+  it("array pass by reference are not confused with intersection", function () {
+    expect(
+      parser.parseEval(
+        `
+      function foo(array &$params)  {
+        // inner comment
+      }
+      `
+      )
+    ).toMatchSnapshot();
+  });
+
+  it("spread array pass by reference are not intersection", function () {
+    expect(
+      parser.parseEval(
+        `
+      function &foo(array &$params) {
+        // inner comment
+      }
+      `
+      )
+    ).toMatchSnapshot();
+  });
+
   it("implement #113 : typehint nodes", function () {
     expect(
       parser.parseEval(


### PR DESCRIPTION
Copied the approach for union type support.

But one thing was tricky: parameter pass by reference. 

```php
function a(Foo&Bar &$something)
```

The  loop finding all the type in the intersection/union return a null type for the last `&`. By doing so, the "active" token in the parser is now on `$something`, and so[ the call to `is_reference()`](https://github.com/glayzzle/php-parser/blob/main/src/parser/function.js#L265) is returning false. In order to fix this, I added the concept of a `previous_token` and check its value in is_reference. 

I am not a big fan of this solution because it make a strict assumption on what is the order of the call of the functions. I tried to [add a new token type](https://github.com/glayzzle/php-parser/blob/main/src/lexer/tokens.js#L254) for the union and intersection type, but could not make it work. So I thought this was good enough with the unit test coverage 🤷 

