### PR TITLE
Fix intersection types with by-ref variable

### DIFF
--- a/test/snapshot/__snapshots__/union.test.js.snap
+++ b/test/snapshot/__snapshots__/union.test.js.snap
@@ -1,0 +1,597 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test unions intersection mixed with union 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "attrGroups": Array [],
+          "byref": false,
+          "flags": 0,
+          "kind": "parameter",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "test",
+          },
+          "nullable": false,
+          "readonly": false,
+          "type": IntersectionType {
+            "kind": "intersectiontype",
+            "name": null,
+            "types": Array [
+              Name {
+                "kind": "name",
+                "name": "foo",
+                "resolution": "uqn",
+              },
+              Name {
+                "kind": "name",
+                "name": "bar",
+                "resolution": "uqn",
+              },
+              Name {
+                "kind": "name",
+                "name": "baz",
+                "resolution": "uqn",
+              },
+            ],
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "attrGroups": Array [],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": false,
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": undefined,
+      "kind": "error",
+      "line": 1,
+      "message": "Unexpect token \\"|\\", \\"|\\" and \\"&\\" can not be mixed on line 1",
+      "token": undefined,
+    },
+  ],
+  "kind": "program",
+}
+`;
+
+exports[`Test unions intersection with reference 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "attrGroups": Array [],
+          "byref": true,
+          "flags": 0,
+          "kind": "parameter",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "test",
+          },
+          "nullable": false,
+          "readonly": false,
+          "type": IntersectionType {
+            "kind": "intersectiontype",
+            "name": null,
+            "types": Array [
+              Name {
+                "kind": "name",
+                "name": "foo",
+                "resolution": "uqn",
+              },
+              Name {
+                "kind": "name",
+                "name": "bar",
+                "resolution": "uqn",
+              },
+            ],
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "attrGroups": Array [],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": false,
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unions intersection with three types 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "attrGroups": Array [],
+          "byref": false,
+          "flags": 0,
+          "kind": "parameter",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "test",
+          },
+          "nullable": false,
+          "readonly": false,
+          "type": IntersectionType {
+            "kind": "intersectiontype",
+            "name": null,
+            "types": Array [
+              Name {
+                "kind": "name",
+                "name": "foo",
+                "resolution": "uqn",
+              },
+              Name {
+                "kind": "name",
+                "name": "bar",
+                "resolution": "uqn",
+              },
+              Name {
+                "kind": "name",
+                "name": "baz",
+                "resolution": "uqn",
+              },
+            ],
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "attrGroups": Array [],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": false,
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unions intersection with variadic 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "attrGroups": Array [],
+          "byref": false,
+          "flags": 0,
+          "kind": "parameter",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "test",
+          },
+          "nullable": false,
+          "readonly": false,
+          "type": IntersectionType {
+            "kind": "intersectiontype",
+            "name": null,
+            "types": Array [
+              Name {
+                "kind": "name",
+                "name": "foo",
+                "resolution": "uqn",
+              },
+              Name {
+                "kind": "name",
+                "name": "bar",
+                "resolution": "uqn",
+              },
+            ],
+          },
+          "value": null,
+          "variadic": true,
+        },
+      ],
+      "attrGroups": Array [],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": false,
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unions simple intersection 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "attrGroups": Array [],
+          "byref": false,
+          "flags": 0,
+          "kind": "parameter",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "test",
+          },
+          "nullable": false,
+          "readonly": false,
+          "type": IntersectionType {
+            "kind": "intersectiontype",
+            "name": null,
+            "types": Array [
+              Name {
+                "kind": "name",
+                "name": "foo",
+                "resolution": "uqn",
+              },
+              Name {
+                "kind": "name",
+                "name": "bar",
+                "resolution": "uqn",
+              },
+            ],
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "attrGroups": Array [],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": false,
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unions simple union 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "attrGroups": Array [],
+          "byref": false,
+          "flags": 0,
+          "kind": "parameter",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "test",
+          },
+          "nullable": false,
+          "readonly": false,
+          "type": UnionType {
+            "kind": "uniontype",
+            "name": null,
+            "types": Array [
+              Name {
+                "kind": "name",
+                "name": "foo",
+                "resolution": "uqn",
+              },
+              Name {
+                "kind": "name",
+                "name": "bar",
+                "resolution": "uqn",
+              },
+            ],
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "attrGroups": Array [],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": false,
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unions union mixed with intersection 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "attrGroups": Array [],
+          "byref": false,
+          "flags": 0,
+          "kind": "parameter",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "test",
+          },
+          "nullable": false,
+          "readonly": false,
+          "type": UnionType {
+            "kind": "uniontype",
+            "name": null,
+            "types": Array [
+              Name {
+                "kind": "name",
+                "name": "foo",
+                "resolution": "uqn",
+              },
+              Name {
+                "kind": "name",
+                "name": "bar",
+                "resolution": "uqn",
+              },
+              Name {
+                "kind": "name",
+                "name": "baz",
+                "resolution": "uqn",
+              },
+            ],
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "attrGroups": Array [],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": false,
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": undefined,
+      "kind": "error",
+      "line": 1,
+      "message": "Unexpect token \\"&\\", \\"|\\" and \\"&\\" can not be mixed on line 1",
+      "token": undefined,
+    },
+  ],
+  "kind": "program",
+}
+`;
+
+exports[`Test unions union with reference 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "attrGroups": Array [],
+          "byref": true,
+          "flags": 0,
+          "kind": "parameter",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "test",
+          },
+          "nullable": false,
+          "readonly": false,
+          "type": UnionType {
+            "kind": "uniontype",
+            "name": null,
+            "types": Array [
+              Name {
+                "kind": "name",
+                "name": "foo",
+                "resolution": "uqn",
+              },
+              Name {
+                "kind": "name",
+                "name": "bar",
+                "resolution": "uqn",
+              },
+            ],
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "attrGroups": Array [],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": false,
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unions union with three types 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "attrGroups": Array [],
+          "byref": false,
+          "flags": 0,
+          "kind": "parameter",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "test",
+          },
+          "nullable": false,
+          "readonly": false,
+          "type": UnionType {
+            "kind": "uniontype",
+            "name": null,
+            "types": Array [
+              Name {
+                "kind": "name",
+                "name": "foo",
+                "resolution": "uqn",
+              },
+              Name {
+                "kind": "name",
+                "name": "bar",
+                "resolution": "uqn",
+              },
+              Name {
+                "kind": "name",
+                "name": "baz",
+                "resolution": "uqn",
+              },
+            ],
+          },
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "attrGroups": Array [],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": false,
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unions union with variadic 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "attrGroups": Array [],
+          "byref": false,
+          "flags": 0,
+          "kind": "parameter",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "test",
+          },
+          "nullable": false,
+          "readonly": false,
+          "type": UnionType {
+            "kind": "uniontype",
+            "name": null,
+            "types": Array [
+              Name {
+                "kind": "name",
+                "name": "foo",
+                "resolution": "uqn",
+              },
+              Name {
+                "kind": "name",
+                "name": "bar",
+                "resolution": "uqn",
+              },
+            ],
+          },
+          "value": null,
+          "variadic": true,
+        },
+      ],
+      "attrGroups": Array [],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": false,
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;

--- a/test/snapshot/union.test.js
+++ b/test/snapshot/union.test.js
@@ -1,0 +1,61 @@
+const parser = require("../main");
+
+describe("Test unions", function () {
+  it("simple union", function () {
+    expect(parser.parseEval("function(foo|bar $test) {}")).toMatchSnapshot();
+  });
+
+  it("simple intersection", function () {
+    expect(parser.parseEval("function(foo&bar $test) {}")).toMatchSnapshot();
+  });
+
+  it("union with reference", function () {
+    expect(parser.parseEval("function(foo|bar &$test) {}")).toMatchSnapshot();
+  });
+
+  it("intersection with reference", function () {
+    expect(parser.parseEval("function(foo&bar &$test) {}")).toMatchSnapshot();
+  });
+
+  it("union with variadic", function () {
+    expect(parser.parseEval("function(foo|bar ...$test) {}")).toMatchSnapshot();
+  });
+
+  it("intersection with variadic", function () {
+    expect(parser.parseEval("function(foo&bar ...$test) {}")).toMatchSnapshot();
+  });
+
+  it("union with three types", function () {
+    expect(
+      parser.parseEval("function(foo|bar|baz $test) {}")
+    ).toMatchSnapshot();
+  });
+
+  it("intersection with three types", function () {
+    expect(
+      parser.parseEval("function(foo&bar&baz $test) {}")
+    ).toMatchSnapshot();
+  });
+
+  it("union mixed with intersection", function () {
+    const astErr = parser.parseEval("function(foo|bar&baz $test) {}", {
+      parser: {
+        version: "8.1",
+        suppressErrors: true,
+      },
+    });
+
+    expect(astErr).toMatchSnapshot();
+  });
+
+  it("intersection mixed with union", function () {
+    const astErr = parser.parseEval("function(foo&bar|baz $test) {}", {
+      parser: {
+        version: "8.1",
+        suppressErrors: true,
+      },
+    });
+
+    expect(astErr).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Previously the following code would produce the wrong AST:

```php
function test(foo|bar &$input) {}
```

It would convert the union to an intersection. (See the [Prettier playground])

This PR changes this behavior by checking for the next token first, before setting the "mode" of the multiple types.

PHP does not allow mixing `|` and `&`, an additional change here is that the parser now follows that rule.

[Prettier playground]: https://loilo.github.io/prettier-php-playground/#N4IgDgTgpgLjCWUIHkwIPYDsDOIBcok8mMA6vACYwAW+AHAAwA0IMAhgEblW14AsLAK7YoAFU648AMzYAbES2zEA5rKgBFQehhR8M+VBZhqYAGpIlWfCACsAOj4gWMCG3iyVAYXQBbH2wAFAAkA-BdBQxAOVwBjKABlGABPNWswbAgAWgAmJxBoAEdBeGgA12V-PTkFEGIRCBgytgq2KoMAXxYoCngYdBQ0eCxJUDZsGDaRTtrMMEEJvBAAHgB+YzAAHUwtqUFMGIxMAAIdcYAKKXR0AB8ONggjgDIAEmI5mABKI+B2kHagA