### PR TITLE
Fix attribute parsing issues

### DIFF
--- a/src/lexer/attribute.js
+++ b/src/lexer/attribute.js
@@ -29,6 +29,9 @@ module.exports = {
       case ")":
       case ":":
       case "=":
+      case "|":
+      case "&":
+      case "^":
         return this.consume_TOKEN();
       case "[":
         listDepth++;

--- a/src/lexer/attribute.js
+++ b/src/lexer/attribute.js
@@ -6,8 +6,9 @@
 "use strict";
 
 module.exports = {
+  attributeIndex: 0,
+  attributeListDepth: {},
   matchST_ATTRIBUTE: function () {
-    let listDepth = 0;
     let ch = this.input();
     if (this.is_WHITESPACE()) {
       do {
@@ -18,11 +19,13 @@ module.exports = {
     }
     switch (ch) {
       case "]":
-        if (listDepth === 0) {
+        if (this.attributeListDepth[this.attributeIndex] === 0) {
+          delete this.attributeListDepth[this.attributeIndex];
+          this.attributeIndex--;
           this.popState();
         } else {
           /* istanbul ignore next */
-          listDepth--;
+          this.attributeListDepth[this.attributeIndex]--;
         }
         return "]";
       case "(":
@@ -42,7 +45,7 @@ module.exports = {
       case "!":
         return this.consume_TOKEN();
       case "[":
-        listDepth++;
+        this.attributeListDepth[this.attributeIndex]++;
         return "[";
       case ",":
         return ",";

--- a/src/lexer/attribute.js
+++ b/src/lexer/attribute.js
@@ -36,6 +36,9 @@ module.exports = {
       case "+":
       case "*":
       case "%":
+      case "~":
+      case "<":
+      case ">":
         return this.consume_TOKEN();
       case "[":
         listDepth++;

--- a/src/lexer/attribute.js
+++ b/src/lexer/attribute.js
@@ -39,6 +39,7 @@ module.exports = {
       case "~":
       case "<":
       case ">":
+      case "!":
         return this.consume_TOKEN();
       case "[":
         listDepth++;
@@ -67,7 +68,7 @@ module.exports = {
           break;
         }
       }
-      return this.tok.T_STRING;
+      return this.T_STRING();
     } else if (this.is_NUM()) {
       return this.consume_NUM();
     }

--- a/src/lexer/attribute.js
+++ b/src/lexer/attribute.js
@@ -32,6 +32,10 @@ module.exports = {
       case "|":
       case "&":
       case "^":
+      case "-":
+      case "+":
+      case "*":
+      case "%":
         return this.consume_TOKEN();
       case "[":
         listDepth++;
@@ -48,6 +52,8 @@ module.exports = {
         } else if (this._input[this.offset] === "*") {
           this.input();
           return this.T_DOC_COMMENT();
+        } else {
+          return this.consume_TOKEN();
         }
     }
     if (this.is_LABEL_START() || ch === "\\") {

--- a/src/lexer/scripting.js
+++ b/src/lexer/scripting.js
@@ -18,6 +18,7 @@ module.exports = {
       case "#":
         if (this.version >= 800 && this._input[this.offset] === "[") {
           this.input();
+          this.attributeListDepth[++this.attributeIndex] = 0;
           this.begin("ST_ATTRIBUTE");
           return this.tok.T_ATTRIBUTE;
         }

--- a/test/snapshot/__snapshots__/attributes.test.js.snap
+++ b/test/snapshot/__snapshots__/attributes.test.js.snap
@@ -1200,6 +1200,111 @@ Program {
 }
 `;
 
+exports[`Parse Attributes can parse params with mathematical expressions 1`] = `
+Program {
+  "children": Array [
+    Class {
+      "attrGroups": Array [
+        AttrGroup {
+          "attrs": Array [
+            Attribute {
+              "args": Array [
+                Bin {
+                  "kind": "bin",
+                  "left": Bin {
+                    "kind": "bin",
+                    "left": Bin {
+                      "kind": "bin",
+                      "left": Bin {
+                        "kind": "bin",
+                        "left": Unary {
+                          "kind": "unary",
+                          "type": "-",
+                          "what": Number {
+                            "kind": "number",
+                            "value": "20",
+                          },
+                        },
+                        "right": Bin {
+                          "kind": "bin",
+                          "left": Unary {
+                            "kind": "unary",
+                            "type": "+",
+                            "what": Number {
+                              "kind": "number",
+                              "value": "10",
+                            },
+                          },
+                          "parenthesizedExpression": true,
+                          "right": Number {
+                            "kind": "number",
+                            "value": "5",
+                          },
+                          "type": "/",
+                        },
+                        "type": "*",
+                      },
+                      "right": Number {
+                        "kind": "number",
+                        "value": "2",
+                      },
+                      "type": "%",
+                    },
+                    "right": Bin {
+                      "kind": "bin",
+                      "left": Number {
+                        "kind": "number",
+                        "value": "8",
+                      },
+                      "right": Number {
+                        "kind": "number",
+                        "value": "2",
+                      },
+                      "type": "**",
+                    },
+                    "type": "+",
+                  },
+                  "right": Unary {
+                    "kind": "unary",
+                    "type": "+",
+                    "what": Unary {
+                      "kind": "unary",
+                      "type": "-",
+                      "what": Number {
+                        "kind": "number",
+                        "value": "2",
+                      },
+                    },
+                  },
+                  "type": "-",
+                },
+              ],
+              "kind": "attribute",
+              "name": "Att1",
+            },
+          ],
+          "kind": "attrgroup",
+        },
+      ],
+      "body": Array [],
+      "extends": null,
+      "implements": null,
+      "isAbstract": false,
+      "isAnonymous": false,
+      "isFinal": false,
+      "kind": "class",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "A",
+      },
+    },
+  ],
+  "comments": Array [],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`Parse Attributes can parse parms with array values 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/__snapshots__/attributes.test.js.snap
+++ b/test/snapshot/__snapshots__/attributes.test.js.snap
@@ -727,6 +727,51 @@ Program {
 }
 `;
 
+exports[`Parse Attributes can parse params with argument labels 1`] = `
+Program {
+  "children": Array [
+    _Function {
+      "arguments": Array [],
+      "attrGroups": Array [
+        AttrGroup {
+          "attrs": Array [
+            Attribute {
+              "args": Array [
+                namedargument {
+                  "kind": "namedargument",
+                  "name": "value",
+                  "value": Number {
+                    "kind": "number",
+                    "value": "1234",
+                  },
+                },
+              ],
+              "kind": "attribute",
+              "name": "MyAttribute",
+            },
+          ],
+          "kind": "attrgroup",
+        },
+      ],
+      "body": Block {
+        "children": Array [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "a",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`Parse Attributes can parse params with comments 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/__snapshots__/attributes.test.js.snap
+++ b/test/snapshot/__snapshots__/attributes.test.js.snap
@@ -1832,3 +1832,150 @@ Program {
   "kind": "program",
 }
 `;
+
+exports[`Parse Attributes parses this complicated edge case 1`] = `
+Program {
+  "children": Array [
+    UseGroup {
+      "items": Array [
+        UseItem {
+          "alias": Identifier {
+            "kind": "identifier",
+            "name": "Assert",
+          },
+          "kind": "useitem",
+          "name": "Symfony\\\\Component\\\\Validator\\\\Constraints",
+          "type": null,
+        },
+      ],
+      "kind": "usegroup",
+      "name": null,
+      "type": null,
+    },
+    Class {
+      "attrGroups": Array [],
+      "body": Array [
+        PropertyStatement {
+          "isStatic": false,
+          "kind": "propertystatement",
+          "properties": Array [
+            Property {
+              "attrGroups": Array [
+                AttrGroup {
+                  "attrs": Array [
+                    Attribute {
+                      "args": Array [
+                        namedargument {
+                          "kind": "namedargument",
+                          "name": "allowNull",
+                          "value": Boolean {
+                            "kind": "boolean",
+                            "raw": "false",
+                            "value": false,
+                          },
+                        },
+                        namedargument {
+                          "kind": "namedargument",
+                          "name": "groups",
+                          "value": Array {
+                            "items": Array [
+                              Entry {
+                                "byRef": false,
+                                "key": null,
+                                "kind": "entry",
+                                "unpack": false,
+                                "value": String {
+                                  "isDoubleQuote": false,
+                                  "kind": "string",
+                                  "raw": "'foo'",
+                                  "unicode": false,
+                                  "value": "foo",
+                                },
+                              },
+                            ],
+                            "kind": "array",
+                            "shortForm": true,
+                          },
+                        },
+                      ],
+                      "kind": "attribute",
+                      "name": "Assert\\\\NotBlank",
+                    },
+                    Attribute {
+                      "args": Array [
+                        namedargument {
+                          "kind": "namedargument",
+                          "name": "max",
+                          "value": Number {
+                            "kind": "number",
+                            "value": "255",
+                          },
+                        },
+                        namedargument {
+                          "kind": "namedargument",
+                          "name": "groups",
+                          "value": Array {
+                            "items": Array [
+                              Entry {
+                                "byRef": false,
+                                "key": null,
+                                "kind": "entry",
+                                "unpack": false,
+                                "value": String {
+                                  "isDoubleQuote": false,
+                                  "kind": "string",
+                                  "raw": "'foo'",
+                                  "unicode": false,
+                                  "value": "foo",
+                                },
+                              },
+                            ],
+                            "kind": "array",
+                            "shortForm": true,
+                          },
+                        },
+                      ],
+                      "kind": "attribute",
+                      "name": "Assert\\\\Length",
+                    },
+                  ],
+                  "kind": "attrgroup",
+                },
+              ],
+              "kind": "property",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "value",
+              },
+              "nullable": true,
+              "readonly": false,
+              "type": TypeReference {
+                "kind": "typereference",
+                "name": "string",
+                "raw": "string",
+              },
+              "value": NullKeyword {
+                "kind": "nullkeyword",
+                "raw": "null",
+              },
+            },
+          ],
+          "visibility": "public",
+        },
+      ],
+      "extends": null,
+      "implements": null,
+      "isAbstract": false,
+      "isAnonymous": false,
+      "isFinal": false,
+      "kind": "class",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "ValueModel",
+      },
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;

--- a/test/snapshot/__snapshots__/attributes.test.js.snap
+++ b/test/snapshot/__snapshots__/attributes.test.js.snap
@@ -869,7 +869,7 @@ Program {
                     },
                     "what": Name {
                       "kind": "name",
-                      "name": "Att2",
+                      "name": "Att3",
                       "resolution": "uqn",
                     },
                   },
@@ -881,7 +881,7 @@ Program {
                     },
                     "what": Name {
                       "kind": "name",
-                      "name": "Att2",
+                      "name": "Att3",
                       "resolution": "uqn",
                     },
                   },
@@ -889,7 +889,96 @@ Program {
                 },
               ],
               "kind": "attribute",
-              "name": "Att2",
+              "name": "Att3",
+            },
+          ],
+          "kind": "attrgroup",
+        },
+        AttrGroup {
+          "attrs": Array [
+            Attribute {
+              "args": Array [
+                Unary {
+                  "kind": "unary",
+                  "type": "~",
+                  "what": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "name": "BAR",
+                    },
+                    "what": Name {
+                      "kind": "name",
+                      "name": "Att4",
+                      "resolution": "uqn",
+                    },
+                  },
+                },
+              ],
+              "kind": "attribute",
+              "name": "Att4",
+            },
+          ],
+          "kind": "attrgroup",
+        },
+        AttrGroup {
+          "attrs": Array [
+            Attribute {
+              "args": Array [
+                Bin {
+                  "kind": "bin",
+                  "left": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "name": "BAR",
+                    },
+                    "what": Name {
+                      "kind": "name",
+                      "name": "Att5",
+                      "resolution": "uqn",
+                    },
+                  },
+                  "right": Number {
+                    "kind": "number",
+                    "value": "1",
+                  },
+                  "type": ">>",
+                },
+              ],
+              "kind": "attribute",
+              "name": "Att5",
+            },
+          ],
+          "kind": "attrgroup",
+        },
+        AttrGroup {
+          "attrs": Array [
+            Attribute {
+              "args": Array [
+                Bin {
+                  "kind": "bin",
+                  "left": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "name": "BAR",
+                    },
+                    "what": Name {
+                      "kind": "name",
+                      "name": "Att6",
+                      "resolution": "uqn",
+                    },
+                  },
+                  "right": Number {
+                    "kind": "number",
+                    "value": "1",
+                  },
+                  "type": "<<",
+                },
+              ],
+              "kind": "attribute",
+              "name": "Att6",
             },
           ],
           "kind": "attrgroup",

--- a/test/snapshot/__snapshots__/attributes.test.js.snap
+++ b/test/snapshot/__snapshots__/attributes.test.js.snap
@@ -772,6 +772,148 @@ Program {
 }
 `;
 
+exports[`Parse Attributes can parse params with bitwise operations 1`] = `
+Program {
+  "children": Array [
+    Class {
+      "attrGroups": Array [
+        AttrGroup {
+          "attrs": Array [
+            Attribute {
+              "args": Array [
+                Bin {
+                  "kind": "bin",
+                  "left": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "name": "FOO",
+                    },
+                    "what": Name {
+                      "kind": "name",
+                      "name": "Att1",
+                      "resolution": "uqn",
+                    },
+                  },
+                  "right": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "name": "BAR",
+                    },
+                    "what": Name {
+                      "kind": "name",
+                      "name": "Att1",
+                      "resolution": "uqn",
+                    },
+                  },
+                  "type": "|",
+                },
+              ],
+              "kind": "attribute",
+              "name": "Att1",
+            },
+          ],
+          "kind": "attrgroup",
+        },
+        AttrGroup {
+          "attrs": Array [
+            Attribute {
+              "args": Array [
+                Bin {
+                  "kind": "bin",
+                  "left": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "name": "FOO",
+                    },
+                    "what": Name {
+                      "kind": "name",
+                      "name": "Att2",
+                      "resolution": "uqn",
+                    },
+                  },
+                  "right": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "name": "BAR",
+                    },
+                    "what": Name {
+                      "kind": "name",
+                      "name": "Att2",
+                      "resolution": "uqn",
+                    },
+                  },
+                  "type": "&",
+                },
+              ],
+              "kind": "attribute",
+              "name": "Att2",
+            },
+          ],
+          "kind": "attrgroup",
+        },
+        AttrGroup {
+          "attrs": Array [
+            Attribute {
+              "args": Array [
+                Bin {
+                  "kind": "bin",
+                  "left": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "name": "FOO",
+                    },
+                    "what": Name {
+                      "kind": "name",
+                      "name": "Att2",
+                      "resolution": "uqn",
+                    },
+                  },
+                  "right": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "name": "BAR",
+                    },
+                    "what": Name {
+                      "kind": "name",
+                      "name": "Att2",
+                      "resolution": "uqn",
+                    },
+                  },
+                  "type": "^",
+                },
+              ],
+              "kind": "attribute",
+              "name": "Att2",
+            },
+          ],
+          "kind": "attrgroup",
+        },
+      ],
+      "body": Array [],
+      "extends": null,
+      "implements": null,
+      "isAbstract": false,
+      "isAnonymous": false,
+      "isFinal": false,
+      "kind": "class",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "A",
+      },
+    },
+  ],
+  "comments": Array [],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`Parse Attributes can parse params with comments 1`] = `
 Program {
   "children": Array [
@@ -950,6 +1092,109 @@ Program {
       },
     },
   ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
+exports[`Parse Attributes can parse params with logical operations 1`] = `
+Program {
+  "children": Array [
+    Class {
+      "attrGroups": Array [
+        AttrGroup {
+          "attrs": Array [
+            Attribute {
+              "args": Array [
+                Bin {
+                  "kind": "bin",
+                  "left": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "name": "FOO",
+                    },
+                    "what": Name {
+                      "kind": "name",
+                      "name": "Att1",
+                      "resolution": "uqn",
+                    },
+                  },
+                  "right": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "name": "BAR",
+                    },
+                    "what": Name {
+                      "kind": "name",
+                      "name": "Att1",
+                      "resolution": "uqn",
+                    },
+                  },
+                  "type": "||",
+                },
+              ],
+              "kind": "attribute",
+              "name": "Att1",
+            },
+          ],
+          "kind": "attrgroup",
+        },
+        AttrGroup {
+          "attrs": Array [
+            Attribute {
+              "args": Array [
+                Bin {
+                  "kind": "bin",
+                  "left": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "name": "FOO",
+                    },
+                    "what": Name {
+                      "kind": "name",
+                      "name": "Att2",
+                      "resolution": "uqn",
+                    },
+                  },
+                  "right": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "name": "BAR",
+                    },
+                    "what": Name {
+                      "kind": "name",
+                      "name": "Att2",
+                      "resolution": "uqn",
+                    },
+                  },
+                  "type": "&&",
+                },
+              ],
+              "kind": "attribute",
+              "name": "Att2",
+            },
+          ],
+          "kind": "attrgroup",
+        },
+      ],
+      "body": Array [],
+      "extends": null,
+      "implements": null,
+      "isAbstract": false,
+      "isAnonymous": false,
+      "isFinal": false,
+      "kind": "class",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "A",
+      },
+    },
+  ],
+  "comments": Array [],
   "errors": Array [],
   "kind": "program",
 }

--- a/test/snapshot/__snapshots__/attributes.test.js.snap
+++ b/test/snapshot/__snapshots__/attributes.test.js.snap
@@ -1269,6 +1269,150 @@ Program {
           ],
           "kind": "attrgroup",
         },
+        AttrGroup {
+          "attrs": Array [
+            Attribute {
+              "args": Array [
+                Bin {
+                  "kind": "bin",
+                  "left": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "name": "FOO",
+                    },
+                    "what": Name {
+                      "kind": "name",
+                      "name": "Att3",
+                      "resolution": "uqn",
+                    },
+                  },
+                  "right": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "name": "BAR",
+                    },
+                    "what": Name {
+                      "kind": "name",
+                      "name": "Att3",
+                      "resolution": "uqn",
+                    },
+                  },
+                  "type": "or",
+                },
+              ],
+              "kind": "attribute",
+              "name": "Att3",
+            },
+          ],
+          "kind": "attrgroup",
+        },
+        AttrGroup {
+          "attrs": Array [
+            Attribute {
+              "args": Array [
+                Bin {
+                  "kind": "bin",
+                  "left": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "name": "FOO",
+                    },
+                    "what": Name {
+                      "kind": "name",
+                      "name": "Att4",
+                      "resolution": "uqn",
+                    },
+                  },
+                  "right": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "name": "BAR",
+                    },
+                    "what": Name {
+                      "kind": "name",
+                      "name": "Att4",
+                      "resolution": "uqn",
+                    },
+                  },
+                  "type": "and",
+                },
+              ],
+              "kind": "attribute",
+              "name": "Att4",
+            },
+          ],
+          "kind": "attrgroup",
+        },
+        AttrGroup {
+          "attrs": Array [
+            Attribute {
+              "args": Array [
+                Bin {
+                  "kind": "bin",
+                  "left": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "name": "FOO",
+                    },
+                    "what": Name {
+                      "kind": "name",
+                      "name": "Att5",
+                      "resolution": "uqn",
+                    },
+                  },
+                  "right": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "name": "BAR",
+                    },
+                    "what": Name {
+                      "kind": "name",
+                      "name": "Att5",
+                      "resolution": "uqn",
+                    },
+                  },
+                  "type": "xor",
+                },
+              ],
+              "kind": "attribute",
+              "name": "Att5",
+            },
+          ],
+          "kind": "attrgroup",
+        },
+        AttrGroup {
+          "attrs": Array [
+            Attribute {
+              "args": Array [
+                Unary {
+                  "kind": "unary",
+                  "type": "!",
+                  "what": StaticLookup {
+                    "kind": "staticlookup",
+                    "offset": Identifier {
+                      "kind": "identifier",
+                      "name": "FOO",
+                    },
+                    "what": Name {
+                      "kind": "name",
+                      "name": "Att6",
+                      "resolution": "uqn",
+                    },
+                  },
+                },
+              ],
+              "kind": "attribute",
+              "name": "Att6",
+            },
+          ],
+          "kind": "attrgroup",
+        },
       ],
       "body": Array [],
       "extends": null,

--- a/test/snapshot/attributes.test.js
+++ b/test/snapshot/attributes.test.js
@@ -65,6 +65,31 @@ describe("Parse Attributes", () => {
     `)
     ).toMatchSnapshot();
   });
+  it("can parse params with bitwise operations", () => {
+    expect(
+      parser.parseEval(
+        `
+        #[Att1(Att1::FOO | Att1::BAR)]
+        #[Att2(Att2::FOO & Att2::BAR)]
+        #[Att2(Att2::FOO ^ Att2::BAR)]
+        class A {}
+        `,
+        { parser: { extractDoc: true } }
+      )
+    ).toMatchSnapshot();
+  });
+  it("can parse params with logical operations", () => {
+    expect(
+      parser.parseEval(
+        `
+        #[Att1(Att1::FOO || Att1::BAR)]
+        #[Att2(Att2::FOO && Att2::BAR)]
+        class A {}
+        `,
+        { parser: { extractDoc: true } }
+      )
+    ).toMatchSnapshot();
+  });
   it("can parse params with end characters", () => {
     expect(
       parser.parseEval(`

--- a/test/snapshot/attributes.test.js
+++ b/test/snapshot/attributes.test.js
@@ -82,7 +82,10 @@ describe("Parse Attributes", () => {
         `
         #[Att1(Att1::FOO | Att1::BAR)]
         #[Att2(Att2::FOO & Att2::BAR)]
-        #[Att2(Att2::FOO ^ Att2::BAR)]
+        #[Att3(Att3::FOO ^ Att3::BAR)]
+        #[Att4(~ Att4::BAR)]
+        #[Att5(Att5::BAR >> 1)]
+        #[Att6(Att6::BAR << 1)]
         class A {}
         `,
         { parser: { extractDoc: true } }

--- a/test/snapshot/attributes.test.js
+++ b/test/snapshot/attributes.test.js
@@ -57,6 +57,14 @@ describe("Parse Attributes", () => {
     `)
     ).toMatchSnapshot();
   });
+  it("can parse params with argument labels", () => {
+    expect(
+      parser.parseEval(`
+    #[MyAttribute(value: 1234)]
+    function a() {}
+    `)
+    ).toMatchSnapshot();
+  });
   it("can parse params with end characters", () => {
     expect(
       parser.parseEval(`

--- a/test/snapshot/attributes.test.js
+++ b/test/snapshot/attributes.test.js
@@ -65,6 +65,17 @@ describe("Parse Attributes", () => {
     `)
     ).toMatchSnapshot();
   });
+  it("can parse params with mathematical expressions", () => {
+    expect(
+      parser.parseEval(
+        `
+        #[Att1(-20 * (+10 / 5) % 2 + 8 ** 2 - +-2)]
+        class A {}
+        `,
+        { parser: { extractDoc: true } }
+      )
+    ).toMatchSnapshot();
+  });
   it("can parse params with bitwise operations", () => {
     expect(
       parser.parseEval(

--- a/test/snapshot/attributes.test.js
+++ b/test/snapshot/attributes.test.js
@@ -98,6 +98,10 @@ describe("Parse Attributes", () => {
         `
         #[Att1(Att1::FOO || Att1::BAR)]
         #[Att2(Att2::FOO && Att2::BAR)]
+        #[Att3(Att3::FOO or Att3::BAR)]
+        #[Att4(Att4::FOO and Att4::BAR)]
+        #[Att5(Att5::FOO xor Att5::BAR)]
+        #[Att6(!Att6::FOO)]
         class A {}
         `,
         { parser: { extractDoc: true } }

--- a/test/snapshot/attributes.test.js
+++ b/test/snapshot/attributes.test.js
@@ -252,6 +252,24 @@ describe("Parse Attributes", () => {
     ).toMatchSnapshot();
   });
 
+  it("parses this complicated edge case", () => {
+    expect(
+      parser.parseEval(
+        `
+        use Symfony\\Component\\Validator\\Constraints as Assert;
+
+        class ValueModel
+        {
+            #[
+                Assert\\NotBlank(allowNull: false, groups: ['foo']),
+                Assert\\Length(max: 255, groups: ['foo']),
+            ]
+            public ?string $value = null;
+        }`
+      )
+    ).toMatchSnapshot();
+  });
+
   it("doesnt parse attributes for assignments", () => {
     expect(
       parser.parseEval(


### PR DESCRIPTION
This PR fixes some unsupported corner cases in parsing argument lists for attributes, in particular bitwise operations and mathematical operations, e.g.

```php
#[
    Attr1(Attr1::FOO | Attr1::BAR), 
    Attr2(-20 * 5 + 10)
]
class A {}
```

Fixes #654 
Fixes #899

Not sure if #486 has any remaining issues after this PR or not.