### PR TITLE
Parse namespaces as single tokens

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -416,7 +416,6 @@ AST.prototype.prepare = function (kind, docs, parser) {
       stack: new Error().stack.split("\n").slice(3, 5),
     };
     result.stackUid = this.stackUid;
-    // console.trace("node: ", kind, result.stackUid);
   }
 
   /**

--- a/src/ast.js
+++ b/src/ast.js
@@ -402,20 +402,21 @@ AST.prototype.prepare = function (kind, docs, parser) {
       result.postBuild(astNode);
     }
     if (parser.debug) {
-      delete AST.stack[result.stackUid];
+      delete self.stack[result.stackUid];
     }
     return self.resolvePrecedence(astNode, parser);
   };
   if (parser.debug) {
-    if (!AST.stack) {
-      AST.stack = {};
-      AST.stackUid = 1;
+    if (!this.stack) {
+      this.stack = {};
+      this.stackUid = 1;
     }
-    AST.stack[++AST.stackUid] = {
+    this.stack[++this.stackUid] = {
       position: start,
       stack: new Error().stack.split("\n").slice(3, 5),
     };
-    result.stackUid = AST.stackUid;
+    result.stackUid = this.stackUid;
+    // console.trace("node: ", kind, result.stackUid);
   }
 
   /**
@@ -451,7 +452,7 @@ AST.prototype.prepare = function (kind, docs, parser) {
       }
     }
     if (parser.debug) {
-      delete AST.stack[result.stackUid];
+      delete self.stack[result.stackUid];
     }
   };
   return result;
@@ -459,12 +460,13 @@ AST.prototype.prepare = function (kind, docs, parser) {
 
 AST.prototype.checkNodes = function () {
   const errors = [];
-  for (const k in AST.stack) {
-    if (Object.prototype.hasOwnProperty.call(AST.stack, k)) {
-      errors.push(AST.stack[k]);
+  for (const k in this.stack) {
+    if (Object.prototype.hasOwnProperty.call(this.stack, k)) {
+      this.stack[k].key = k;
+      errors.push(this.stack[k]);
     }
   }
-  AST.stack = {};
+  this.stack = {};
   return errors;
 };
 

--- a/src/ast/name.js
+++ b/src/ast/name.js
@@ -18,18 +18,10 @@ const KIND = "name";
  */
 const Name = Reference.extends(
   KIND,
-  function Name(name, isRelative, docs, location) {
+  function Name(name, resolution, docs, location) {
     Reference.apply(this, [KIND, docs, location]);
-    if (isRelative) {
-      this.resolution = Name.RELATIVE_NAME;
-    } else if (name.length === 1) {
-      this.resolution = Name.UNQUALIFIED_NAME;
-    } else if (!name[0]) {
-      this.resolution = Name.FULL_QUALIFIED_NAME;
-    } else {
-      this.resolution = Name.QUALIFIED_NAME;
-    }
-    this.name = name.join("\\");
+    this.name = name.replace(/\\$/, "");
+    this.resolution = resolution;
   }
 );
 

--- a/src/lexer/tokens.js
+++ b/src/lexer/tokens.js
@@ -112,7 +112,6 @@ module.exports = {
             ch = this.input();
           } while (ch === "\\");
 
-          console.log(ch);
           this.unput(1);
 
           return this.tok.T_NAME_FULLY_QUALIFIED;

--- a/src/parser.js
+++ b/src/parser.js
@@ -130,7 +130,6 @@ const Parser = function (lexer, ast) {
         this.tok.T_VARIABLE,
         "$",
         "&",
-        this.tok.T_NS_SEPARATOR,
         this.tok.T_STRING,
         this.tok.T_NAME_RELATIVE,
         this.tok.T_NAME_QUALIFIED,

--- a/src/parser.js
+++ b/src/parser.js
@@ -132,6 +132,9 @@ const Parser = function (lexer, ast) {
         "&",
         this.tok.T_NS_SEPARATOR,
         this.tok.T_STRING,
+        this.tok.T_NAME_RELATIVE,
+        this.tok.T_NAME_QUALIFIED,
+        this.tok.T_NAME_FULLY_QUALIFIED,
         this.tok.T_NAMESPACE,
         this.tok.T_STATIC,
       ].map(mapIt)
@@ -222,6 +225,9 @@ const Parser = function (lexer, ast) {
         "$",
         this.tok.T_NS_SEPARATOR,
         this.tok.T_STRING,
+        this.tok.T_NAME_RELATIVE,
+        this.tok.T_NAME_QUALIFIED,
+        this.tok.T_NAME_FULLY_QUALIFIED,
         // using SCALAR :
         this.tok.T_STRING, // @see variable.js line 45 > conflict with variable = shift/reduce :)
         this.tok.T_CONSTANT_ENCAPSED_STRING,

--- a/src/parser/expr.js
+++ b/src/parser/expr.js
@@ -784,6 +784,9 @@ module.exports = {
   read_new_class_name: function () {
     if (
       this.token === this.tok.T_NS_SEPARATOR ||
+      this.token === this.tok.T_NAME_RELATIVE ||
+      this.token === this.tok.T_NAME_QUALIFIED ||
+      this.token === this.tok.T_NAME_FULLY_QUALIFIED ||
       this.token === this.tok.T_STRING ||
       this.token === this.tok.T_NAMESPACE
     ) {

--- a/src/parser/function.js
+++ b/src/parser/function.js
@@ -406,6 +406,9 @@ module.exports = {
       this.next();
       return result("typereference", type.toLowerCase(), type);
     } else if (
+      this.token === this.tok.T_NAME_RELATIVE ||
+      this.token === this.tok.T_NAME_QUALIFIED ||
+      this.token === this.tok.T_NAME_FULLY_QUALIFIED ||
       this.token === this.tok.T_STRING ||
       this.token === this.tok.T_STATIC
     ) {

--- a/src/parser/function.js
+++ b/src/parser/function.js
@@ -428,13 +428,6 @@ module.exports = {
         result.destroy();
         return this.read_namespace_name();
       }
-    } else if (
-      this.token === this.tok.T_NAMESPACE ||
-      this.token === this.tok.T_NS_SEPARATOR
-    ) {
-      // fix : destroy not consumed node (release comments)
-      result.destroy();
-      return this.read_namespace_name();
     }
     // fix : destroy not consumed node (release comments)
     result.destroy();

--- a/src/parser/namespace.js
+++ b/src/parser/namespace.js
@@ -74,28 +74,38 @@ module.exports = {
    */
   read_namespace_name: function (resolveReference) {
     const result = this.node();
-    let relative = false;
-    if (this.token === this.tok.T_NAMESPACE) {
-      this.next().expect(this.tok.T_NS_SEPARATOR) && this.next();
-      relative = true;
+    let resolution;
+    let name = this.text();
+    switch (this.token) {
+      case this.tok.T_NAME_RELATIVE:
+        resolution = this.ast.name.RELATIVE_NAME;
+        name = name.replace(/^namespace\\/, "");
+        break;
+      case this.tok.T_NAME_QUALIFIED:
+        resolution = this.ast.name.QUALIFIED_NAME;
+        break;
+      case this.tok.T_NAME_FULLY_QUALIFIED:
+        resolution = this.ast.name.FULL_QUALIFIED_NAME;
+        break;
+      default:
+        resolution = this.ast.name.UNQUALIFIED_NAME;
+        if (!this.expect(this.tok.T_STRING)) {
+          // graceful mode
+          return result("name", "", this.ast.name.FULL_QUALIFIED_NAME);
+        }
     }
-    const names = this.read_list(
-      this.tok.T_STRING,
-      this.tok.T_NS_SEPARATOR,
-      true
-    );
-    if (
-      !relative &&
-      names.length === 1 &&
-      (resolveReference || this.token !== "(")
-    ) {
-      if (names[0].toLowerCase() === "parent") {
-        return result("parentreference", names[0]);
-      } else if (names[0].toLowerCase() === "self") {
-        return result("selfreference", names[0]);
+
+    this.next();
+
+    if (resolveReference || this.token !== "(") {
+      if (name.toLowerCase() === "parent") {
+        return result("parentreference", name);
+      } else if (name.toLowerCase() === "self") {
+        return result("selfreference", name);
       }
     }
-    return result("name", names, relative);
+
+    return result("name", name, resolution);
   },
   /*
    * Reads a use statement
@@ -172,6 +182,9 @@ module.exports = {
           break;
         }
       } else if (
+        this.token !== this.tok.T_NAME_RELATIVE &&
+        this.token !== this.tok.T_NAME_QUALIFIED &&
+        this.token !== this.tok.T_NAME_FULLY_QUALIFIED &&
         this.token !== this.tok.T_STRING &&
         this.token !== this.tok.T_NS_SEPARATOR
       ) {

--- a/src/parser/namespace.js
+++ b/src/parser/namespace.js
@@ -23,7 +23,7 @@ module.exports = {
     this.expect(this.tok.T_NAMESPACE) && this.next();
     let name;
 
-    if (this.token == "{") {
+    if (this.token === "{") {
       name = {
         name: [""],
       };
@@ -32,12 +32,12 @@ module.exports = {
     }
     this.currentNamespace = name;
 
-    if (this.token == ";") {
+    if (this.token === ";") {
       this.currentNamespace = name;
       body = this.next().read_top_statements();
       this.expect(this.EOF);
       return result(name.name, body, false);
-    } else if (this.token == "{") {
+    } else if (this.token === "{") {
       this.currentNamespace = name;
       body = this.next().read_top_statements();
       this.expect("}") && this.next();
@@ -49,12 +49,6 @@ module.exports = {
         body.push(this.node("noop")());
       }
       return result(name.name, body, true);
-    } else if (this.token === "(") {
-      // @fixme after merging #478
-      name.resolution = this.ast.reference.RELATIVE_NAME;
-      name.name = name.name.substring(1);
-      result.destroy();
-      return this.node("call")(name, this.read_argument_list());
     } else {
       this.error(["{", ";"]);
       // graceful mode :

--- a/src/parser/scalar.js
+++ b/src/parser/scalar.js
@@ -364,6 +364,7 @@ module.exports = {
         this.next();
         // check if lookup an offset
         // https://github.com/php/php-src/blob/master/Zend/zend_language_parser.y#L1243
+        result.destroy();
         if (this.token === "[") {
           name = name(varName, false);
           node = this.node("offsetlookup");

--- a/src/parser/variable.js
+++ b/src/parser/variable.js
@@ -38,6 +38,9 @@ module.exports = {
       this.is([
         this.tok.T_NS_SEPARATOR,
         this.tok.T_STRING,
+        this.tok.T_NAME_RELATIVE,
+        this.tok.T_NAME_QUALIFIED,
+        this.tok.T_NAME_FULLY_QUALIFIED,
         this.tok.T_NAMESPACE,
       ])
     ) {

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -156,6 +156,9 @@ const tokens = {
     238: "T_ATTRIBUTE",
     239: "T_ENUM",
     240: "T_READ_ONLY",
+    241: "T_NAME_RELATIVE",
+    242: "T_NAME_QUALIFIED",
+    243: "T_NAME_FULLY_QUALIFIED",
   },
   names: {
     T_HALT_COMPILER: 101,
@@ -298,6 +301,9 @@ const tokens = {
     T_ATTRIBUTE: 238,
     T_ENUM: 239,
     T_READ_ONLY: 240,
+    T_NAME_RELATIVE: 241,
+    T_NAME_QUALIFIED: 242,
+    T_NAME_FULLY_QUALIFIED: 243,
   },
 };
 

--- a/test/snapshot/__snapshots__/ast.test.js.snap
+++ b/test/snapshot/__snapshots__/ast.test.js.snap
@@ -529,6 +529,62 @@ Program {
 }
 `;
 
+exports[`Test AST structure test invalid namespace separator 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Error {
+        "expected": "SCALAR",
+        "kind": "error",
+        "line": 1,
+        "message": "Parse Error : syntax error, unexpected '\\\\' (T_NS_SEPARATOR) on line 1",
+        "token": "'\\\\' (T_NS_SEPARATOR)",
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": Number {
+          "kind": "number",
+          "value": "1",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    Inline {
+      "kind": "inline",
+      "raw": "
+ !",
+      "value": " !",
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": "SCALAR",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '\\\\' (T_NS_SEPARATOR) on line 1",
+      "token": "'\\\\' (T_NS_SEPARATOR)",
+    },
+    Error {
+      "expected": ";",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '$var' (T_VARIABLE), expecting ';' on line 1",
+      "token": "'$var' (T_VARIABLE)",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
 exports[`Test AST structure test magics 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/__snapshots__/interface.test.js.snap
+++ b/test/snapshot/__snapshots__/interface.test.js.snap
@@ -44,6 +44,55 @@ Program {
 }
 `;
 
+exports[`interface invalid private flag 1`] = `
+Program {
+  "children": Array [
+    Interface {
+      "attrGroups": Array [],
+      "body": Array [
+        ClassConstant {
+          "attrGroups": Array [],
+          "constants": Array [
+            Constant {
+              "kind": "constant",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "B",
+              },
+              "value": Number {
+                "kind": "number",
+                "value": "1",
+              },
+            },
+          ],
+          "kind": "classconstant",
+          "visibility": "",
+        },
+      ],
+      "extends": null,
+      "kind": "interface",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "A",
+      },
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": Array [
+        195,
+        196,
+      ],
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected 'private' (T_PRIVATE) on line 1",
+      "token": "'private' (T_PRIVATE)",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
 exports[`interface multiple extends 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/__snapshots__/namespace.test.js.snap
+++ b/test/snapshot/__snapshots__/namespace.test.js.snap
@@ -1143,6 +1143,56 @@ Program {
 }
 `;
 
+exports[`Test namespace statements test keywords 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Call {
+        "arguments": Array [],
+        "kind": "call",
+        "what": Name {
+          "kind": "name",
+          "name": "enum",
+          "resolution": "rn",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Call {
+        "arguments": Array [],
+        "kind": "call",
+        "what": Name {
+          "kind": "name",
+          "name": "\\\\foo\\\\trait\\\\class",
+          "resolution": "fqn",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": Name {
+          "kind": "name",
+          "name": "bar",
+          "resolution": "rn",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`Test namespace statements test multiple namespace 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/__snapshots__/namespace.test.js.snap
+++ b/test/snapshot/__snapshots__/namespace.test.js.snap
@@ -1300,14 +1300,17 @@ Program {
 exports[`Test namespace statements test namespace keyword 1`] = `
 Program {
   "children": Array [
-    Call {
-      "arguments": Array [],
-      "kind": "call",
-      "what": Name {
-        "kind": "name",
-        "name": "foo",
-        "resolution": undefined,
+    ExpressionStatement {
+      "expression": Call {
+        "arguments": Array [],
+        "kind": "call",
+        "what": Name {
+          "kind": "name",
+          "name": "foo",
+          "resolution": "rn",
+        },
       },
+      "kind": "expressionstatement",
     },
     ExpressionStatement {
       "expression": Assign {

--- a/test/snapshot/__snapshots__/namespace.test.js.snap
+++ b/test/snapshot/__snapshots__/namespace.test.js.snap
@@ -1143,6 +1143,33 @@ Program {
 }
 `;
 
+exports[`Test namespace statements test bare namespace separator 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Error {
+        "expected": "SCALAR",
+        "kind": "error",
+        "line": 1,
+        "message": "Parse Error : syntax error, unexpected '\\\\' (T_NS_SEPARATOR) on line 1",
+        "token": "'\\\\' (T_NS_SEPARATOR)",
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": "SCALAR",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '\\\\' (T_NS_SEPARATOR) on line 1",
+      "token": "'\\\\' (T_NS_SEPARATOR)",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
 exports[`Test namespace statements test keywords 1`] = `
 Program {
   "children": Array [
@@ -1169,6 +1196,25 @@ Program {
         },
       },
       "kind": "expressionstatement",
+    },
+    UseGroup {
+      "items": Array [
+        UseItem {
+          "alias": null,
+          "kind": "useitem",
+          "name": "a",
+          "type": null,
+        },
+        UseItem {
+          "alias": null,
+          "kind": "useitem",
+          "name": "b",
+          "type": null,
+        },
+      ],
+      "kind": "usegroup",
+      "name": "\\\\foo\\\\bar",
+      "type": null,
     },
     ExpressionStatement {
       "expression": Assign {

--- a/test/snapshot/__snapshots__/useitem.test.js.snap
+++ b/test/snapshot/__snapshots__/useitem.test.js.snap
@@ -141,6 +141,231 @@ Program {
 }
 `;
 
+exports[`useitem invalid use 1`] = `
+Program {
+  "children": Array [
+    UseGroup {
+      "items": Array [
+        UseItem {
+          "alias": null,
+          "kind": "useitem",
+          "name": "",
+          "type": null,
+        },
+      ],
+      "kind": "usegroup",
+      "name": null,
+      "type": "function",
+    },
+    ExpressionStatement {
+      "expression": Variable {
+        "curly": false,
+        "kind": "variable",
+        "name": "foo",
+      },
+      "kind": "expressionstatement",
+    },
+    UseGroup {
+      "items": Array [
+        UseItem {
+          "alias": null,
+          "kind": "useitem",
+          "name": "FOO",
+          "type": null,
+        },
+        UseItem {
+          "alias": null,
+          "kind": "useitem",
+          "name": "BAR",
+          "type": null,
+        },
+      ],
+      "kind": "usegroup",
+      "name": "",
+      "type": "const",
+    },
+    UseGroup {
+      "items": Array [
+        UseItem {
+          "alias": null,
+          "kind": "useitem",
+          "name": "foo",
+          "type": null,
+        },
+      ],
+      "kind": "usegroup",
+      "name": "some",
+      "type": null,
+    },
+    ExpressionStatement {
+      "expression": Variable {
+        "curly": false,
+        "kind": "variable",
+        "name": "error",
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": undefined,
+      "kind": "expressionstatement",
+    },
+    _Function {
+      "arguments": Array [
+        Parameter {
+          "attrGroups": Array [],
+          "byref": false,
+          "flags": 0,
+          "kind": "parameter",
+          "name": null,
+          "nullable": false,
+          "readonly": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+        Parameter {
+          "attrGroups": Array [],
+          "byref": false,
+          "flags": 0,
+          "kind": "parameter",
+          "name": null,
+          "nullable": false,
+          "readonly": false,
+          "type": null,
+          "value": null,
+          "variadic": false,
+        },
+      ],
+      "attrGroups": Array [],
+      "body": null,
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": false,
+      },
+      "nullable": false,
+      "type": null,
+    },
+    ExpressionStatement {
+      "expression": undefined,
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [
+    Error {
+      "expected": 105,
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '$foo' (T_VARIABLE), expecting T_STRING on line 1",
+      "token": "'$foo' (T_VARIABLE)",
+    },
+    Error {
+      "expected": ";",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '$foo' (T_VARIABLE), expecting ';' on line 1",
+      "token": "'$foo' (T_VARIABLE)",
+    },
+    Error {
+      "expected": "}",
+      "kind": "error",
+      "line": 8,
+      "message": "Parse Error : syntax error, unexpected '$error' (T_VARIABLE), expecting '}' on line 8",
+      "token": "'$error' (T_VARIABLE)",
+    },
+    Error {
+      "expected": ";",
+      "kind": "error",
+      "line": 8,
+      "message": "Parse Error : syntax error, unexpected '$error' (T_VARIABLE), expecting ';' on line 8",
+      "token": "'$error' (T_VARIABLE)",
+    },
+    Error {
+      "expected": ";",
+      "kind": "error",
+      "line": 8,
+      "message": "Parse Error : syntax error, unexpected ',', expecting ';' on line 8",
+      "token": "','",
+    },
+    Error {
+      "expected": "EXPR",
+      "kind": "error",
+      "line": 8,
+      "message": "Parse Error : syntax error, unexpected ',' on line 8",
+      "token": "','",
+    },
+    Error {
+      "expected": ";",
+      "kind": "error",
+      "line": 9,
+      "message": "Parse Error : syntax error, unexpected 'function' (T_FUNCTION), expecting ';' on line 9",
+      "token": "'function' (T_FUNCTION)",
+    },
+    Error {
+      "expected": "(",
+      "kind": "error",
+      "line": 9,
+      "message": "Parse Error : syntax error, unexpected '$bar' (T_VARIABLE), expecting '(' on line 9",
+      "token": "'$bar' (T_VARIABLE)",
+    },
+    Error {
+      "expected": "(",
+      "kind": "error",
+      "line": 9,
+      "message": "Parse Error : syntax error, unexpected ',', expecting '(' on line 9",
+      "token": "','",
+    },
+    Error {
+      "expected": 222,
+      "kind": "error",
+      "line": 9,
+      "message": "Parse Error : syntax error, unexpected ',', expecting T_VARIABLE on line 9",
+      "token": "','",
+    },
+    Error {
+      "expected": 222,
+      "kind": "error",
+      "line": 10,
+      "message": "Parse Error : syntax error, unexpected '}', expecting T_VARIABLE on line 10",
+      "token": "'}'",
+    },
+    Error {
+      "expected": Array [
+        ",",
+        ")",
+      ],
+      "kind": "error",
+      "line": 10,
+      "message": "Parse Error : syntax error, unexpected '}' on line 10",
+      "token": "'}'",
+    },
+    Error {
+      "expected": ")",
+      "kind": "error",
+      "line": 10,
+      "message": "Parse Error : syntax error, unexpected '}', expecting ')' on line 10",
+      "token": "'}'",
+    },
+    Error {
+      "expected": "{",
+      "kind": "error",
+      "line": 10,
+      "message": "Parse Error : syntax error, unexpected '}', expecting '{' on line 10",
+      "token": "'}'",
+    },
+    Error {
+      "expected": "EXPR",
+      "kind": "error",
+      "line": 10,
+      "message": "Parse Error : syntax error, unexpected '}' on line 10",
+      "token": "'}'",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
 exports[`useitem simple 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/ast.test.js
+++ b/test/snapshot/ast.test.js
@@ -56,6 +56,14 @@ describe("Test AST structure", function () {
     expect(parser.parseCode("<?php echo 'World'; ?>\r\n !")).toMatchSnapshot();
   });
 
+  it("test invalid namespace separator", function () {
+    expect(
+      parser.parseCode("<?php \\$var = 1; ?>\r\n !", {
+        parser: { suppressErrors: true },
+      })
+    ).toMatchSnapshot();
+  });
+
   it("test magics", function () {
     expect(parser.parseEval("echo __FILE__, __DIR__;")).toMatchSnapshot();
   });

--- a/test/snapshot/interface.test.js
+++ b/test/snapshot/interface.test.js
@@ -10,4 +10,11 @@ describe("interface", function () {
   it("multiple extends", function () {
     expect(parser.parseEval("interface A extends B, C {}")).toMatchSnapshot();
   });
+  it("invalid private flag", function () {
+    expect(
+      parser.parseEval("interface A { private const B = 1; }", {
+        parser: { suppressErrors: true },
+      })
+    ).toMatchSnapshot();
+  });
 });

--- a/test/snapshot/namespace.test.js
+++ b/test/snapshot/namespace.test.js
@@ -84,6 +84,23 @@ describe("Test namespace statements", function () {
     ).toMatchSnapshot();
   });
 
+  it("test keywords", function () {
+    expect(
+      parser.parseEval(
+        `
+      namespace\\enum();
+      \\foo\\trait\\class();
+      $var = namespace\\bar;
+    `,
+        {
+          parser: {
+            debug: false,
+          },
+        }
+      )
+    ).toMatchSnapshot();
+  });
+
   it("test namespace error", function () {
     expect(
       parser.parseEval(

--- a/test/snapshot/namespace.test.js
+++ b/test/snapshot/namespace.test.js
@@ -90,6 +90,7 @@ describe("Test namespace statements", function () {
         `
       namespace\\enum();
       \\foo\\trait\\class();
+      use \\foo\\bar\\{ a, b };
       $var = namespace\\bar;
     `,
         {
@@ -98,6 +99,16 @@ describe("Test namespace statements", function () {
           },
         }
       )
+    ).toMatchSnapshot();
+  });
+
+  it("test bare namespace separator", function () {
+    expect(
+      parser.parseEval(`\\`, {
+        parser: {
+          suppressErrors: true,
+        },
+      })
     ).toMatchSnapshot();
   });
 

--- a/test/snapshot/useitem.test.js
+++ b/test/snapshot/useitem.test.js
@@ -40,4 +40,23 @@ describe("useitem", () => {
       parser.parseEval("use const My\\Full\\CONSTANT as MY_CONST;")
     ).toMatchSnapshot();
   });
+  it("invalid use", () => {
+    expect(
+      parser.parseEval(
+        `use function $foo;
+        use const namespace\\{
+          FOO,
+          BAR,
+        };
+        use some\\{
+          namespace\\foo,
+          $error,
+          function $bar,
+        };`,
+        {
+          parser: { suppressErrors: true },
+        }
+      )
+    ).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
As in PHP itself, introduce the tokens `T_NAME_RELATIVE`, `T_NAME_QUALIFIED`, and `T_NAME_FULLY_QUALIFIED`.

Fixes #834.
Fixes #896.
