### PR TITLE
fix: correctly parse subnamespaces

### DIFF
--- a/src/parser/namespace.js
+++ b/src/parser/namespace.js
@@ -169,6 +169,9 @@ module.exports = {
       this.next();
       if (typed) {
         if (
+          this.token !== this.tok.T_NAME_RELATIVE &&
+          this.token !== this.tok.T_NAME_QUALIFIED &&
+          this.token !== this.tok.T_NAME_FULLY_QUALIFIED &&
           this.token !== this.tok.T_FUNCTION &&
           this.token !== this.tok.T_CONST &&
           this.token !== this.tok.T_STRING

--- a/test/snapshot/__snapshots__/usegroup.test.js.snap
+++ b/test/snapshot/__snapshots__/usegroup.test.js.snap
@@ -173,6 +173,34 @@ Program {
 }
 `;
 
+exports[`usegroup nested 4 1`] = `
+Program {
+  "children": Array [
+    UseGroup {
+      "items": Array [
+        UseItem {
+          "alias": null,
+          "kind": "useitem",
+          "name": "SubnamespaceOne\\\\ClassA",
+          "type": null,
+        },
+        UseItem {
+          "alias": null,
+          "kind": "useitem",
+          "name": "SubnamespaceOne\\\\ClassB",
+          "type": null,
+        },
+      ],
+      "kind": "usegroup",
+      "name": "Vendor\\\\Package\\\\SomeNamespace",
+      "type": null,
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`usegroup simple 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/usegroup.test.js
+++ b/test/snapshot/usegroup.test.js
@@ -35,4 +35,14 @@ describe("usegroup", () => {
       )
     ).toMatchSnapshot();
   });
+  it("nested 4", () => {
+    expect(
+      parser.parseEval(
+        `use Vendor\\Package\\SomeNamespace\\{
+            SubnamespaceOne\\ClassA,
+            SubnamespaceOne\\ClassB
+        };`
+      )
+    ).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
@MaartenStaa This fixes a regression:

Input:
```php
use Vendor\\Package\\SomeNamespace\\{
    SubnamespaceOne\\ClassA,
    SubnamespaceOne\\ClassB
};
```
Output: 
`SyntaxError: Parse Error : syntax error, unexpected 'Subname...' (T_NAME_QUALIFIED), expecting '}' on line 4`