### PR TITLE
Fix error on variadic function calls.

### DIFF
--- a/test/snapshot/__snapshots__/call.test.js.snap
+++ b/test/snapshot/__snapshots__/call.test.js.snap
@@ -199,6 +199,91 @@ Program {
 }
 `;
 
+exports[`Test call handles spread operator at call site 1`] = `
+Program {
+  "children": Array [
+    ExpressionStatement {
+      "expression": Call {
+        "arguments": Array [
+          variadic {
+            "kind": "variadic",
+            "what": Variable {
+              "curly": false,
+              "kind": "variable",
+              "name": "bar",
+            },
+          },
+        ],
+        "kind": "call",
+        "what": Name {
+          "kind": "name",
+          "name": "foo",
+          "resolution": "uqn",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Call {
+        "arguments": Array [
+          Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "bar",
+          },
+          variadic {
+            "kind": "variadic",
+            "what": Variable {
+              "curly": false,
+              "kind": "variable",
+              "name": "baz",
+            },
+          },
+        ],
+        "kind": "call",
+        "what": Name {
+          "kind": "name",
+          "name": "foo",
+          "resolution": "uqn",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Call {
+        "arguments": Array [
+          variadic {
+            "kind": "variadic",
+            "what": Variable {
+              "curly": false,
+              "kind": "variable",
+              "name": "bar",
+            },
+          },
+          variadic {
+            "kind": "variadic",
+            "what": Variable {
+              "curly": false,
+              "kind": "variable",
+              "name": "baz",
+            },
+          },
+        ],
+        "kind": "call",
+        "what": Name {
+          "kind": "name",
+          "name": "foo",
+          "resolution": "uqn",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": Array [],
+  "kind": "program",
+}
+`;
+
 exports[`Test call inside offsetlookup 1`] = `
 Program {
   "children": Array [

--- a/test/snapshot/__snapshots__/function.test.js.snap
+++ b/test/snapshot/__snapshots__/function.test.js.snap
@@ -1722,88 +1722,11 @@ Program {
 }
 `;
 
-exports[`Function tests test variadic error 1`] = `
-Program {
-  "children": Array [
-    ExpressionStatement {
-      "expression": Assign {
-        "kind": "assign",
-        "left": Variable {
-          "curly": false,
-          "kind": "variable",
-          "name": "b",
-        },
-        "operator": "=",
-        "right": Call {
-          "arguments": Array [
-            variadic {
-              "kind": "variadic",
-              "what": Array {
-                "items": Array [
-                  Entry {
-                    "byRef": false,
-                    "key": null,
-                    "kind": "entry",
-                    "unpack": false,
-                    "value": Number {
-                      "kind": "number",
-                      "value": "1",
-                    },
-                  },
-                  Entry {
-                    "byRef": false,
-                    "key": null,
-                    "kind": "entry",
-                    "unpack": false,
-                    "value": Number {
-                      "kind": "number",
-                      "value": "2",
-                    },
-                  },
-                  Entry {
-                    "byRef": false,
-                    "key": null,
-                    "kind": "entry",
-                    "unpack": false,
-                    "value": Number {
-                      "kind": "number",
-                      "value": "3",
-                    },
-                  },
-                ],
-                "kind": "array",
-                "shortForm": true,
-              },
-            },
-            Variable {
-              "curly": false,
-              "kind": "variable",
-              "name": "a",
-            },
-          ],
-          "kind": "call",
-          "what": Name {
-            "kind": "name",
-            "name": "foo",
-            "resolution": "uqn",
-          },
-        },
-      },
-      "kind": "expressionstatement",
-    },
-  ],
-  "errors": Array [
-    Error {
-      "expected": undefined,
-      "kind": "error",
-      "line": 1,
-      "message": "Unexpected argument after a variadic argument on line 1",
-      "token": undefined,
-    },
-  ],
-  "kind": "program",
-}
-`;
+exports[`Function tests test variadic call error 1`] = `"Unexpected non-variadic argument after a variadic argument on line 1"`;
+
+exports[`Function tests test variadic function error 1 1`] = `"Unexpected parameter after a variadic parameter on line 1"`;
+
+exports[`Function tests test variadic function error 2 1`] = `"Unexpected parameter after a variadic parameter on line 1"`;
 
 exports[`Function tests test without danging comma in closure use-block php 8.0 1`] = `
 Program {

--- a/test/snapshot/call.test.js
+++ b/test/snapshot/call.test.js
@@ -303,4 +303,13 @@ describe("Test call", function () {
     );
     expect(astErr).toMatchSnapshot();
   });
+  it("handles spread operator at call site", function () {
+    expect(
+      parser.parseEval(`
+        foo(...$bar);
+        foo($bar, ...$baz);
+        foo(...$bar, ...$baz);
+      `)
+    ).toMatchSnapshot();
+  });
 });

--- a/test/snapshot/function.test.js
+++ b/test/snapshot/function.test.js
@@ -100,13 +100,22 @@ describe("Function tests", function () {
     expect(ast).toMatchSnapshot();
   });
 
-  it("test variadic error", function () {
-    const astErr = parser.parseEval(`$b = foo(...[1, 2, 3], $a);`, {
-      parser: {
-        suppressErrors: true,
-      },
-    });
-    expect(astErr).toMatchSnapshot();
+  it("test variadic call error", function () {
+    expect(() =>
+      parser.parseEval(`$b = foo(...[1, 2, 3], $a);`)
+    ).toThrowErrorMatchingSnapshot();
+  });
+
+  it("test variadic function error 1", function () {
+    expect(() =>
+      parser.parseEval(`function foo(...$bar, $baz) {}`)
+    ).toThrowErrorMatchingSnapshot();
+  });
+
+  it("test variadic function error 2", function () {
+    expect(() =>
+      parser.parseEval(`function foo(...$bar, ...$baz) {}`)
+    ).toThrowErrorMatchingSnapshot();
   });
 
   it("test reserved word for function name error", function () {


### PR DESCRIPTION
Fixes a parse error when passing multiple argument spreads such as
`foo(...$bar, ...$baz)`. Adds extra checks for function definitions with
variadic parameters, followed by any other parameters.

Fixes #946