### PR TITLE
Fix `?->` with succeeding PHP keyword

### DIFF
--- a/src/lexer/tokens.js
+++ b/src/lexer/tokens.js
@@ -238,7 +238,8 @@ module.exports = {
         this._input[this.offset] === "-" &&
         this._input[this.offset + 1] === ">"
       ) {
-        this.consume(2);
+        this.consume(1);
+        this.begin("ST_LOOKING_FOR_PROPERTY").input();
         return this.tok.T_NULLSAFE_OBJECT_OPERATOR;
       }
       return "?";

--- a/test/snapshot/__snapshots__/lexer.test.js.snap
+++ b/test/snapshot/__snapshots__/lexer.test.js.snap
@@ -125,6 +125,30 @@ exports[`Test lexer test #148 - sensitive lexer 1`] = `
 ]
 `;
 
+exports[`Test lexer test #1003 - null-safe operator with reserved keyword 1`] = `
+Program {
+  "children": [
+    ExpressionStatement {
+      "expression": NullSafePropertyLookup {
+        "kind": "nullsafepropertylookup",
+        "offset": Identifier {
+          "kind": "identifier",
+          "name": "class",
+        },
+        "what": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "a",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+}
+`;
+
 exports[`Test lexer test comments 1`] = `
 Program {
   "children": [

--- a/test/snapshot/lexer.test.js
+++ b/test/snapshot/lexer.test.js
@@ -81,4 +81,8 @@ describe("Test lexer", function () {
   it("test #148 - sensitive lexer", function () {
     expect(parser.tokenGetAll("<?php $this-> list;")).toMatchSnapshot();
   });
+
+  it("test #1003 - null-safe operator with reserved keyword", function () {
+    expect(parser.parseCode("<?php $a?->class;")).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Fixes #1003

I'm going to be honest, I have no idea what I'm doing, but all the tests seem to pass. Feel free to point me in the correct direction if this is absolutely not how you're supposed to do this.