### PR TITLE
Fix problem with heredoc parsing \n as newlines, not as literal string

### DIFF
--- a/test/snapshot/heredoc.test.js
+++ b/test/snapshot/heredoc.test.js
@@ -505,4 +505,16 @@ $b = <<<'EOT'
       )
     ).toMatchSnapshot();
   });
+
+  it("Can parse HEREDOC with escaped characters #1130", () => {
+    expect(
+      parser.parseEval(`
+ if (true) {
+    echo <<<STR
+    \na
+    STR;
+}   
+    `)
+    ).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
I am trying to fox #1130 however need some help with this one, for the prettier plugin we want to keep the original intent, and not parse the \n as a newline, so we can rebuild the original string in the output. 

Do I create a special AST token for \n in a HEREDOC, or should ignore the \n as a special case, and parse it as a regular string? 