### PR TITLE
Handle the ::class static keyword as a special case in parser/variable.js

### DIFF
--- a/src/parser/variable.js
+++ b/src/parser/variable.js
@@ -216,8 +216,15 @@ module.exports = {
             this.error();
           }
 
+          // Handle special "::class" static keyword
+          let classKeyword = null;
+          if (this.peek() === this.tok.T_CLASS) {
+              this.next();
+              classKeyword = this.node("identifier")(this.text());
+              this.next();
+          }
           node = this.node("staticlookup");
-          result = node(result, this.read_what(true));
+          result = node(result, classKeyword ?? this.read_what(true));
 
           // fix 185
           // static lookup dereferencables are limited to staticlookup over functions


### PR DESCRIPTION
Handle T_Class as a special case when it comes after T_DOUBLE_COLON in recursive_variable_chain_scan

This solves https://github.com/glayzzle/php-parser/issues/1135
```
$arrayVariable[0]::class;
$classVariable->classProp::class
```