### PR TITLE
Fix Typed Class Constants parsing

### DIFF
--- a/src/ast/classconstant.js
+++ b/src/ast/classconstant.js
@@ -20,26 +20,13 @@ const IS_PRIVATE = "private";
  * @extends {ConstantStatement}
  * @property {string} visibility
  * @property {boolean} final
- * @property {boolean} nullable
- * @property {TypeReference|IntersectionType|UnionType|null} type
  * @property {AttrGroup[]} attrGroups
  */
 const ClassConstant = ConstantStatement.extends(
   KIND,
-  function ClassConstant(
-    kind,
-    constants,
-    flags,
-    nullable,
-    type,
-    attrGroups,
-    docs,
-    location,
-  ) {
+  function ClassConstant(kind, constants, flags, attrGroups, docs, location) {
     ConstantStatement.apply(this, [kind || KIND, constants, docs, location]);
     this.parseFlags(flags);
-    this.nullable = nullable;
-    this.type = type;
     this.attrGroups = attrGroups;
   },
 );

--- a/src/ast/constant.js
+++ b/src/ast/constant.js
@@ -15,12 +15,16 @@ const KIND = "constant";
  * @extends {Node}
  * @property {string} name
  * @property {Node|string|number|boolean|null} value
+ * @property {boolean} nullable
+ * @property {TypeReference|IntersectionType|UnionType|null} type
  */
 module.exports = Node.extends(
   KIND,
-  function Constant(name, value, docs, location) {
+  function Constant(name, value, nullable, type, docs, location) {
     Node.apply(this, [KIND, docs, location]);
     this.name = name;
     this.value = value;
+    this.nullable = nullable;
+    this.type = type;
   },
 );

--- a/src/parser/class.js
+++ b/src/parser/class.js
@@ -235,7 +235,7 @@ module.exports = {
     }
 
     const [nullable, type] =
-      this.version >= 830 ? this.read_optional_type() : [false, null];
+      this.version >= 803 ? this.read_optional_type() : [false, null];
 
     const result = this.node("classconstant");
     const items = this.read_list(

--- a/src/parser/class.js
+++ b/src/parser/class.js
@@ -234,8 +234,7 @@ module.exports = {
       this.next();
     }
 
-    const result = this.node("classconstant");
-    const items = this.read_list(
+    return this.read_list(
       /*
        * Reads a constant declaration
        *
@@ -245,7 +244,9 @@ module.exports = {
        * @return {Constant} [:link:](AST.md#constant)
        */
       function read_constant_declaration() {
-        const result = this.node("constant");
+        const class_constant = this.node("classconstant");
+
+        const constant = this.node("constant");
         const nullable = false;
 
         let type = this.read_types();
@@ -273,12 +274,17 @@ module.exports = {
           );
         }
 
-        return result(constName, value, nullable, type);
+        return class_constant(
+          null,
+          [constant(constName, value)],
+          flags,
+          nullable,
+          type,
+          attrs || [],
+        );
       },
       ",",
     );
-
-    return result(null, items, flags, attrs || []);
   },
   /*
    * Read member flags

--- a/src/parser/class.js
+++ b/src/parser/class.js
@@ -234,7 +234,8 @@ module.exports = {
       this.next();
     }
 
-    return this.read_list(
+    const class_constant = this.node("classconstant");
+    const items = this.read_list(
       /*
        * Reads a constant declaration
        *
@@ -244,8 +245,6 @@ module.exports = {
        * @return {Constant} [:link:](AST.md#constant)
        */
       function read_constant_declaration() {
-        const class_constant = this.node("classconstant");
-
         const constant = this.node("constant");
         const nullable = false;
 
@@ -273,18 +272,11 @@ module.exports = {
             "Parse Error: Typed Class Constants requires PHP 8.3+",
           );
         }
-
-        return class_constant(
-          null,
-          [constant(constName, value)],
-          flags,
-          nullable,
-          type,
-          attrs || [],
-        );
+        return constant(constName, value, nullable, type);
       },
       ",",
     );
+    return class_constant(null, items, flags, attrs || []);
   },
   /*
    * Read member flags

--- a/src/parser/class.js
+++ b/src/parser/class.js
@@ -253,23 +253,26 @@ module.exports = {
         let name = null;
         let value = null;
 
-        if (
-          this.version >= 803 &&
-          type &&
-          (type.kind === "typereference" || type.kind === "uniontype")
-        ) {
+        if (type && type.kind === "name") {
+          constName = this.node("identifier");
+          constName = constName(type.name);
+          type = null;
+          value = this.next().read_expr();
+        } else {
           constName = this.node("identifier");
           name = this.text();
           constName = constName(name);
           this.next();
           this.expect("=");
           value = this.next().read_expr();
-        } else if (type && type.kind === "name") {
-          constName = this.node("identifier");
-          constName = constName(type.name);
-          type = null;
-          value = this.next().read_expr();
         }
+
+        if (this.version < 803 && type !== null) {
+          this.raiseError(
+            "Parse Error: Typed Class Constants requires PHP 8.3+",
+          );
+        }
+
         return result(constName, value, nullable, type);
       },
       ",",

--- a/src/parser/class.js
+++ b/src/parser/class.js
@@ -254,8 +254,9 @@ module.exports = {
         let value = null;
 
         if (
-          (type.kind === "typereference" || type.kind === "uniontype") &&
-          this.version >= 803
+          this.version >= 803 &&
+          type &&
+          (type.kind === "typereference" || type.kind === "uniontype")
         ) {
           constName = this.node("identifier");
           name = this.text();
@@ -263,7 +264,7 @@ module.exports = {
           this.next();
           this.expect("=");
           value = this.next().read_expr();
-        } else if (type.kind === "name") {
+        } else if (type && type.kind === "name") {
           constName = this.node("identifier");
           constName = constName(type.name);
           type = null;

--- a/src/parser/class.js
+++ b/src/parser/class.js
@@ -234,7 +234,7 @@ module.exports = {
       this.next();
     }
 
-    const class_constant = this.node("classconstant");
+    const class_constant_node = this.node("classconstant");
     const items = this.read_list(
       /*
        * Reads a constant declaration
@@ -245,38 +245,33 @@ module.exports = {
        * @return {Constant} [:link:](AST.md#constant)
        */
       function read_constant_declaration() {
-        const constant = this.node("constant");
-        const nullable = false;
+        const constant_node = this.node("constant");
 
-        let type = this.read_types();
-        let constName = null;
-        let name = null;
+        // eslint-disable-next-line prefer-const
+        let [nullable, type] = this.read_optional_type();
+        let propName = this.node("identifier");
         let value = null;
 
         if (type && type.kind === "name") {
-          constName = this.node("identifier");
-          constName = constName(type.name);
+          propName = propName(type.name);
           type = null;
-          value = this.next().read_expr();
         } else {
-          constName = this.node("identifier");
-          name = this.text();
-          constName = constName(name);
+          propName = propName(this.text());
           this.next();
-          this.expect("=");
-          value = this.next().read_expr();
         }
+        this.expect("=");
+        value = this.next().read_expr();
 
         if (this.version < 803 && type !== null) {
           this.raiseError(
             "Parse Error: Typed Class Constants requires PHP 8.3+",
           );
         }
-        return constant(constName, value, nullable, type);
+        return constant_node(propName, value, nullable, type);
       },
       ",",
     );
-    return class_constant(null, items, flags, attrs || []);
+    return class_constant_node(null, items, flags, attrs || []);
   },
   /*
    * Read member flags

--- a/test/snapshot/__snapshots__/acid.test.js.snap
+++ b/test/snapshot/__snapshots__/acid.test.js.snap
@@ -755,22 +755,23 @@ Program {
               ],
             },
             ClassConstant {
-              "attrGroups": Location {
-                "end": Position {
-                  "column": 27,
-                  "line": 31,
-                  "offset": 561,
-                },
-                "source": "FOOBAR = 'BARFOO'",
-                "start": Position {
-                  "column": 10,
-                  "line": 31,
-                  "offset": 544,
-                },
-              },
+              "attrGroups": [],
               "constants": [
                 Constant {
                   "kind": "constant",
+                  "loc": Location {
+                    "end": Position {
+                      "column": 27,
+                      "line": 31,
+                      "offset": 561,
+                    },
+                    "source": "FOOBAR = 'BARFOO'",
+                    "start": Position {
+                      "column": 10,
+                      "line": 31,
+                      "offset": 544,
+                    },
+                  },
                   "name": Identifier {
                     "kind": "identifier",
                     "loc": Location {
@@ -812,7 +813,20 @@ Program {
               ],
               "final": false,
               "kind": "classconstant",
-              "nullable": [],
+              "loc": Location {
+                "end": Position {
+                  "column": 27,
+                  "line": 31,
+                  "offset": 561,
+                },
+                "source": "FOOBAR = 'BARFOO'",
+                "start": Position {
+                  "column": 10,
+                  "line": 31,
+                  "offset": 544,
+                },
+              },
+              "nullable": false,
               "type": null,
               "visibility": "",
             },

--- a/test/snapshot/__snapshots__/acid.test.js.snap
+++ b/test/snapshot/__snapshots__/acid.test.js.snap
@@ -426,19 +426,6 @@ Program {
           "constants": [
             Constant {
               "kind": "constant",
-              "loc": Location {
-                "end": Position {
-                  "column": 28,
-                  "line": 20,
-                  "offset": 360,
-                },
-                "source": "FOOBAR = 'foo & bar'",
-                "start": Position {
-                  "column": 8,
-                  "line": 20,
-                  "offset": 340,
-                },
-              },
               "name": Identifier {
                 "kind": "identifier",
                 "loc": Location {
@@ -455,6 +442,20 @@ Program {
                   },
                 },
                 "name": "FOOBAR",
+              },
+              "nullable": null,
+              "type": Location {
+                "end": Position {
+                  "column": 28,
+                  "line": 20,
+                  "offset": 360,
+                },
+                "source": "FOOBAR = 'foo & bar'",
+                "start": Position {
+                  "column": 8,
+                  "line": 20,
+                  "offset": 340,
+                },
               },
               "value": String {
                 "isDoubleQuote": false,
@@ -789,6 +790,8 @@ Program {
                     },
                     "name": "FOOBAR",
                   },
+                  "nullable": false,
+                  "type": null,
                   "value": String {
                     "isDoubleQuote": false,
                     "kind": "string",
@@ -826,8 +829,6 @@ Program {
                   "offset": 544,
                 },
               },
-              "nullable": false,
-              "type": null,
               "visibility": "",
             },
             PropertyStatement {

--- a/test/snapshot/__snapshots__/acid.test.js.snap
+++ b/test/snapshot/__snapshots__/acid.test.js.snap
@@ -755,23 +755,22 @@ Program {
               ],
             },
             ClassConstant {
-              "attrGroups": [],
+              "attrGroups": Location {
+                "end": Position {
+                  "column": 27,
+                  "line": 31,
+                  "offset": 561,
+                },
+                "source": "FOOBAR = 'BARFOO'",
+                "start": Position {
+                  "column": 10,
+                  "line": 31,
+                  "offset": 544,
+                },
+              },
               "constants": [
                 Constant {
                   "kind": "constant",
-                  "loc": Location {
-                    "end": Position {
-                      "column": 27,
-                      "line": 31,
-                      "offset": 561,
-                    },
-                    "source": "FOOBAR = 'BARFOO'",
-                    "start": Position {
-                      "column": 10,
-                      "line": 31,
-                      "offset": 544,
-                    },
-                  },
                   "name": Identifier {
                     "kind": "identifier",
                     "loc": Location {
@@ -780,11 +779,11 @@ Program {
                         "line": 31,
                         "offset": 550,
                       },
-                      "source": "FOOBAR",
+                      "source": " ",
                       "start": Position {
-                        "column": 10,
+                        "column": 17,
                         "line": 31,
-                        "offset": 544,
+                        "offset": 551,
                       },
                     },
                     "name": "FOOBAR",
@@ -813,20 +812,7 @@ Program {
               ],
               "final": false,
               "kind": "classconstant",
-              "loc": Location {
-                "end": Position {
-                  "column": 27,
-                  "line": 31,
-                  "offset": 561,
-                },
-                "source": "FOOBAR = 'BARFOO'",
-                "start": Position {
-                  "column": 10,
-                  "line": 31,
-                  "offset": 544,
-                },
-              },
-              "nullable": false,
+              "nullable": [],
               "type": null,
               "visibility": "",
             },

--- a/test/snapshot/__snapshots__/ast.test.js.snap
+++ b/test/snapshot/__snapshots__/ast.test.js.snap
@@ -253,6 +253,8 @@ Program {
             "kind": "identifier",
             "name": "FOO",
           },
+          "nullable": null,
+          "type": undefined,
           "value": Number {
             "kind": "number",
             "value": "3.14",

--- a/test/snapshot/__snapshots__/attributes.test.js.snap
+++ b/test/snapshot/__snapshots__/attributes.test.js.snap
@@ -308,18 +308,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": [
-            AttrGroup {
-              "attrs": [
-                Attribute {
-                  "args": [],
-                  "kind": "attribute",
-                  "name": "B",
-                },
-              ],
-              "kind": "attrgroup",
-            },
-          ],
+          "attrGroups": undefined,
           "constants": [
             Constant {
               "kind": "constant",
@@ -335,7 +324,18 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
+          "nullable": [
+            AttrGroup {
+              "attrs": [
+                Attribute {
+                  "args": [],
+                  "kind": "attribute",
+                  "name": "B",
+                },
+              ],
+              "kind": "attrgroup",
+            },
+          ],
           "type": null,
           "visibility": "",
         },
@@ -499,18 +499,7 @@ Program {
       ],
       "body": [
         ClassConstant {
-          "attrGroups": [
-            AttrGroup {
-              "attrs": [
-                Attribute {
-                  "args": [],
-                  "kind": "attribute",
-                  "name": "C",
-                },
-              ],
-              "kind": "attrgroup",
-            },
-          ],
+          "attrGroups": undefined,
           "constants": [
             Constant {
               "kind": "constant",
@@ -526,7 +515,18 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
+          "nullable": [
+            AttrGroup {
+              "attrs": [
+                Attribute {
+                  "args": [],
+                  "kind": "attribute",
+                  "name": "C",
+                },
+              ],
+              "kind": "attrgroup",
+            },
+          ],
           "type": null,
           "visibility": "",
         },

--- a/test/snapshot/__snapshots__/attributes.test.js.snap
+++ b/test/snapshot/__snapshots__/attributes.test.js.snap
@@ -308,7 +308,18 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [
+            AttrGroup {
+              "attrs": [
+                Attribute {
+                  "args": [],
+                  "kind": "attribute",
+                  "name": "B",
+                },
+              ],
+              "kind": "attrgroup",
+            },
+          ],
           "constants": [
             Constant {
               "kind": "constant",
@@ -324,18 +335,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [
-            AttrGroup {
-              "attrs": [
-                Attribute {
-                  "args": [],
-                  "kind": "attribute",
-                  "name": "B",
-                },
-              ],
-              "kind": "attrgroup",
-            },
-          ],
+          "nullable": false,
           "type": null,
           "visibility": "",
         },
@@ -499,7 +499,18 @@ Program {
       ],
       "body": [
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [
+            AttrGroup {
+              "attrs": [
+                Attribute {
+                  "args": [],
+                  "kind": "attribute",
+                  "name": "C",
+                },
+              ],
+              "kind": "attrgroup",
+            },
+          ],
           "constants": [
             Constant {
               "kind": "constant",
@@ -515,18 +526,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [
-            AttrGroup {
-              "attrs": [
-                Attribute {
-                  "args": [],
-                  "kind": "attribute",
-                  "name": "C",
-                },
-              ],
-              "kind": "attrgroup",
-            },
-          ],
+          "nullable": false,
           "type": null,
           "visibility": "",
         },

--- a/test/snapshot/__snapshots__/attributes.test.js.snap
+++ b/test/snapshot/__snapshots__/attributes.test.js.snap
@@ -327,6 +327,8 @@ Program {
                 "kind": "identifier",
                 "name": "B",
               },
+              "nullable": false,
+              "type": null,
               "value": Number {
                 "kind": "number",
                 "value": "1",
@@ -335,8 +337,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": null,
           "visibility": "",
         },
       ],
@@ -518,6 +518,8 @@ Program {
                 "kind": "identifier",
                 "name": "D",
               },
+              "nullable": false,
+              "type": null,
               "value": Number {
                 "kind": "number",
                 "value": "0",
@@ -526,8 +528,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": null,
           "visibility": "",
         },
         Method {

--- a/test/snapshot/__snapshots__/class.test.js.snap
+++ b/test/snapshot/__snapshots__/class.test.js.snap
@@ -148,7 +148,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": [],
+          "attrGroups": undefined,
           "constants": [
             Constant {
               "kind": "constant",
@@ -164,7 +164,8 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "leadingComments": [
+          "nullable": [],
+          "type": [
             CommentLine {
               "kind": "commentline",
               "offset": 332,
@@ -172,8 +173,6 @@ Program {
 ",
             },
           ],
-          "nullable": false,
-          "type": null,
           "visibility": "",
         },
         Method {
@@ -218,7 +217,7 @@ Program {
     Trait {
       "body": [
         ClassConstant {
-          "attrGroups": [],
+          "attrGroups": undefined,
           "constants": [
             Constant {
               "kind": "constant",
@@ -234,7 +233,8 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "leadingComments": [
+          "nullable": [],
+          "type": [
             CommentLine {
               "kind": "commentline",
               "offset": 455,
@@ -242,8 +242,6 @@ Program {
 ",
             },
           ],
-          "nullable": false,
-          "type": null,
           "visibility": "",
         },
         Method {

--- a/test/snapshot/__snapshots__/class.test.js.snap
+++ b/test/snapshot/__snapshots__/class.test.js.snap
@@ -1321,7 +1321,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": [],
+          "attrGroups": undefined,
           "constants": [
             Constant {
               "kind": "constant",
@@ -1340,7 +1340,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
+          "nullable": [],
           "type": null,
           "visibility": "",
         },
@@ -1433,7 +1433,7 @@ Program {
           "visibility": "public",
         },
         ClassConstant {
-          "attrGroups": [],
+          "attrGroups": undefined,
           "constants": [
             Constant {
               "kind": "constant",
@@ -1452,7 +1452,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
+          "nullable": [],
           "type": null,
           "visibility": "",
         },

--- a/test/snapshot/__snapshots__/class.test.js.snap
+++ b/test/snapshot/__snapshots__/class.test.js.snap
@@ -156,6 +156,8 @@ Program {
                 "kind": "identifier",
                 "name": "A",
               },
+              "nullable": false,
+              "type": null,
               "value": Number {
                 "kind": "number",
                 "value": "1.5",
@@ -172,8 +174,6 @@ Program {
 ",
             },
           ],
-          "nullable": false,
-          "type": null,
           "visibility": "",
         },
         Method {
@@ -226,6 +226,8 @@ Program {
                 "kind": "identifier",
                 "name": "A",
               },
+              "nullable": false,
+              "type": null,
               "value": Number {
                 "kind": "number",
                 "value": "1.5",
@@ -242,8 +244,6 @@ Program {
 ",
             },
           ],
-          "nullable": false,
-          "type": null,
           "visibility": "",
         },
         Method {
@@ -1331,6 +1331,8 @@ Program {
                 "kind": "identifier",
                 "name": "FOO",
               },
+              "nullable": false,
+              "type": null,
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -1342,8 +1344,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": null,
           "visibility": "",
         },
         PropertyStatement {
@@ -1443,6 +1443,8 @@ Program {
                 "kind": "identifier",
                 "name": "list",
               },
+              "nullable": false,
+              "type": null,
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -1454,8 +1456,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": null,
           "visibility": "",
         },
         Method {

--- a/test/snapshot/__snapshots__/class.test.js.snap
+++ b/test/snapshot/__snapshots__/class.test.js.snap
@@ -148,7 +148,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
@@ -164,8 +164,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [],
-          "type": [
+          "leadingComments": [
             CommentLine {
               "kind": "commentline",
               "offset": 332,
@@ -173,6 +172,8 @@ Program {
 ",
             },
           ],
+          "nullable": false,
+          "type": null,
           "visibility": "",
         },
         Method {
@@ -217,7 +218,7 @@ Program {
     Trait {
       "body": [
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
@@ -233,8 +234,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [],
-          "type": [
+          "leadingComments": [
             CommentLine {
               "kind": "commentline",
               "offset": 455,
@@ -242,6 +242,8 @@ Program {
 ",
             },
           ],
+          "nullable": false,
+          "type": null,
           "visibility": "",
         },
         Method {
@@ -1321,7 +1323,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
@@ -1340,7 +1342,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [],
+          "nullable": false,
           "type": null,
           "visibility": "",
         },
@@ -1433,7 +1435,7 @@ Program {
           "visibility": "public",
         },
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
@@ -1452,7 +1454,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [],
+          "nullable": false,
           "type": null,
           "visibility": "",
         },

--- a/test/snapshot/__snapshots__/classconstant.test.js.snap
+++ b/test/snapshot/__snapshots__/classconstant.test.js.snap
@@ -7,7 +7,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": [],
+          "attrGroups": undefined,
           "constants": [
             Constant {
               "kind": "constant",
@@ -26,7 +26,7 @@ Program {
           ],
           "final": true,
           "kind": "classconstant",
-          "nullable": false,
+          "nullable": [],
           "type": null,
           "visibility": "public",
         },
@@ -56,7 +56,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": [],
+          "attrGroups": undefined,
           "constants": [
             Constant {
               "kind": "constant",
@@ -89,7 +89,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
+          "nullable": [],
           "type": null,
           "visibility": "",
         },
@@ -119,7 +119,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": [],
+          "attrGroups": undefined,
           "constants": [
             Constant {
               "kind": "constant",
@@ -138,7 +138,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
+          "nullable": [],
           "type": null,
           "visibility": "private",
         },
@@ -168,7 +168,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": [],
+          "attrGroups": undefined,
           "constants": [
             Constant {
               "kind": "constant",
@@ -187,7 +187,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
+          "nullable": [],
           "type": null,
           "visibility": "protected",
         },
@@ -217,7 +217,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": [],
+          "attrGroups": undefined,
           "constants": [
             Constant {
               "kind": "constant",
@@ -236,7 +236,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
+          "nullable": [],
           "type": null,
           "visibility": "public",
         },
@@ -266,7 +266,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": [],
+          "attrGroups": undefined,
           "constants": [
             Constant {
               "kind": "constant",
@@ -285,7 +285,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
+          "nullable": [],
           "type": null,
           "visibility": "",
         },
@@ -315,13 +315,13 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": [],
+          "attrGroups": undefined,
           "constants": [
             Constant {
               "kind": "constant",
               "name": Identifier {
                 "kind": "identifier",
-                "name": "CONSTANT",
+                "name": "PUBLIC_TEST_CLASS_CONSTANT",
               },
               "value": String {
                 "isDoubleQuote": true,
@@ -334,12 +334,8 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": TypeReference {
-            "kind": "typereference",
-            "name": "string",
-            "raw": "string",
-          },
+          "nullable": [],
+          "type": null,
           "visibility": "public",
         },
       ],
@@ -361,4 +357,102 @@ Program {
 }
 `;
 
-exports[`classconstant type hinted (unsupported) 1`] = `"Parse Error : syntax error, unexpected 'CONSTANT' (T_STRING), expecting '=' on line 1"`;
+exports[`classconstant type hinted (unsupported) 1`] = `"Parse Error : syntax error, unexpected 'CONSTANT' (T_STRING), expecting ';' on line 1"`;
+
+exports[`classconstant type hinted idx: 0 1`] = `
+Program {
+  "children": [
+    Class {
+      "attrGroups": [],
+      "body": [
+        ClassConstant {
+          "attrGroups": undefined,
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "CON_1",
+              },
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": ""Hello world!"",
+                "unicode": false,
+                "value": "Hello world!",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": [],
+          "type": null,
+          "visibility": "public",
+        },
+      ],
+      "extends": null,
+      "implements": null,
+      "isAbstract": false,
+      "isAnonymous": false,
+      "isFinal": false,
+      "isReadonly": false,
+      "kind": "class",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "Foo",
+      },
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+}
+`;
+
+exports[`classconstant type hinted idx: 1 1`] = `
+Program {
+  "children": [
+    Class {
+      "attrGroups": [],
+      "body": [
+        ClassConstant {
+          "attrGroups": undefined,
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "CON_2",
+              },
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": ""Hello world!"",
+                "unicode": false,
+                "value": "Hello world!",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": [],
+          "type": null,
+          "visibility": "",
+        },
+      ],
+      "extends": null,
+      "implements": null,
+      "isAbstract": false,
+      "isAnonymous": false,
+      "isFinal": false,
+      "isReadonly": false,
+      "kind": "class",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "Foo",
+      },
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+}
+`;

--- a/test/snapshot/__snapshots__/classconstant.test.js.snap
+++ b/test/snapshot/__snapshots__/classconstant.test.js.snap
@@ -1,5 +1,54 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`classconstant accept the constant name 'list' 1`] = `
+Program {
+  "children": [
+    Class {
+      "attrGroups": [],
+      "body": [
+        ClassConstant {
+          "attrGroups": undefined,
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "list",
+              },
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": ""Hello world!"",
+                "unicode": false,
+                "value": "Hello world!",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": [],
+          "type": null,
+          "visibility": "",
+        },
+      ],
+      "extends": null,
+      "implements": null,
+      "isAbstract": false,
+      "isAnonymous": false,
+      "isFinal": false,
+      "isReadonly": false,
+      "kind": "class",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "Foo",
+      },
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+}
+`;
+
 exports[`classconstant final 1`] = `
 Program {
   "children": [
@@ -519,236 +568,4 @@ Program {
 }
 `;
 
-exports[`classconstant type hinted (unsupported) 1`] = `"Parse Error : syntax error, unexpected 'CONSTANT' (T_STRING), expecting ';' on line 1"`;
-
-exports[`classconstant type hinted mixed position 1`] = `
-Program {
-  "children": [
-    Class {
-      "attrGroups": [],
-      "body": [
-        ClassConstant {
-          "attrGroups": undefined,
-          "constants": [
-            Constant {
-              "kind": "constant",
-              "name": Identifier {
-                "kind": "identifier",
-                "name": "CON_1",
-              },
-              "value": String {
-                "isDoubleQuote": true,
-                "kind": "string",
-                "raw": ""Hello world!"",
-                "unicode": false,
-                "value": "Hello world!",
-              },
-            },
-          ],
-          "final": false,
-          "kind": "classconstant",
-          "nullable": [],
-          "type": null,
-          "visibility": "public",
-        },
-        ClassConstant {
-          "attrGroups": undefined,
-          "constants": [
-            Constant {
-              "kind": "constant",
-              "name": Identifier {
-                "kind": "identifier",
-                "name": "CON_2",
-              },
-              "value": String {
-                "isDoubleQuote": true,
-                "kind": "string",
-                "raw": ""Hello world!"",
-                "unicode": false,
-                "value": "Hello world!",
-              },
-            },
-          ],
-          "final": false,
-          "kind": "classconstant",
-          "nullable": [],
-          "type": null,
-          "visibility": "",
-        },
-        ClassConstant {
-          "attrGroups": undefined,
-          "constants": [
-            Constant {
-              "kind": "constant",
-              "loc": TypeReference {
-                "kind": "typereference",
-                "name": "string",
-                "raw": "string",
-              },
-              "name": Identifier {
-                "kind": "identifier",
-                "name": "CON_3",
-              },
-              "value": String {
-                "isDoubleQuote": true,
-                "kind": "string",
-                "raw": ""Hello world!"",
-                "unicode": false,
-                "value": "Hello world!",
-              },
-            },
-          ],
-          "final": false,
-          "kind": "classconstant",
-          "nullable": [],
-          "type": null,
-          "visibility": "",
-        },
-        Method {
-          "arguments": [],
-          "attrGroups": [],
-          "body": Block {
-            "children": [],
-            "kind": "block",
-          },
-          "byref": false,
-          "isAbstract": false,
-          "isFinal": false,
-          "isReadonly": false,
-          "isStatic": false,
-          "kind": "method",
-          "name": Identifier {
-            "kind": "identifier",
-            "name": "donut",
-          },
-          "nullable": false,
-          "type": null,
-          "visibility": "",
-        },
-        ClassConstant {
-          "attrGroups": undefined,
-          "constants": [
-            Constant {
-              "kind": "constant",
-              "loc": TypeReference {
-                "kind": "typereference",
-                "name": "string",
-                "raw": "string",
-              },
-              "name": Identifier {
-                "kind": "identifier",
-                "name": "CON_4",
-              },
-              "value": String {
-                "isDoubleQuote": true,
-                "kind": "string",
-                "raw": ""Hello world!"",
-                "unicode": false,
-                "value": "Hello world!",
-              },
-            },
-          ],
-          "final": false,
-          "kind": "classconstant",
-          "nullable": [],
-          "type": null,
-          "visibility": "public",
-        },
-        ClassConstant {
-          "attrGroups": undefined,
-          "constants": [
-            Constant {
-              "kind": "constant",
-              "loc": UnionType {
-                "kind": "uniontype",
-                "name": null,
-                "types": [
-                  TypeReference {
-                    "kind": "typereference",
-                    "name": "string",
-                    "raw": "string",
-                  },
-                  TypeReference {
-                    "kind": "typereference",
-                    "name": "int",
-                    "raw": "int",
-                  },
-                ],
-              },
-              "name": Identifier {
-                "kind": "identifier",
-                "name": "CON_5",
-              },
-              "value": String {
-                "isDoubleQuote": true,
-                "kind": "string",
-                "raw": ""Hello world!"",
-                "unicode": false,
-                "value": "Hello world!",
-              },
-            },
-          ],
-          "final": false,
-          "kind": "classconstant",
-          "nullable": [],
-          "type": null,
-          "visibility": "public",
-        },
-        ClassConstant {
-          "attrGroups": undefined,
-          "constants": [
-            Constant {
-              "kind": "constant",
-              "loc": UnionType {
-                "kind": "uniontype",
-                "name": null,
-                "types": [
-                  TypeReference {
-                    "kind": "typereference",
-                    "name": "string",
-                    "raw": "string",
-                  },
-                  TypeReference {
-                    "kind": "typereference",
-                    "name": "int",
-                    "raw": "int",
-                  },
-                ],
-              },
-              "name": Identifier {
-                "kind": "identifier",
-                "name": "CON_6",
-              },
-              "value": String {
-                "isDoubleQuote": true,
-                "kind": "string",
-                "raw": ""Hello world!"",
-                "unicode": false,
-                "value": "Hello world!",
-              },
-            },
-          ],
-          "final": false,
-          "kind": "classconstant",
-          "nullable": [],
-          "type": null,
-          "visibility": "",
-        },
-      ],
-      "extends": null,
-      "implements": null,
-      "isAbstract": false,
-      "isAnonymous": false,
-      "isFinal": false,
-      "isReadonly": false,
-      "kind": "class",
-      "name": Identifier {
-        "kind": "identifier",
-        "name": "Foo",
-      },
-    },
-  ],
-  "errors": [],
-  "kind": "program",
-}
-`;
+exports[`classconstant type hinted (unsupported) 1`] = `"Parse Error: Typed Class Constants requires PHP 8.3+ on line 1"`;

--- a/test/snapshot/__snapshots__/classconstant.test.js.snap
+++ b/test/snapshot/__snapshots__/classconstant.test.js.snap
@@ -7,7 +7,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
@@ -26,7 +26,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [],
+          "nullable": false,
           "type": null,
           "visibility": "",
         },
@@ -56,7 +56,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
@@ -75,7 +75,7 @@ Program {
           ],
           "final": true,
           "kind": "classconstant",
-          "nullable": [],
+          "nullable": false,
           "type": null,
           "visibility": "public",
         },
@@ -105,7 +105,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
@@ -121,6 +121,16 @@ Program {
                 "value": "Hello world!",
               },
             },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": false,
+          "type": null,
+          "visibility": "",
+        },
+        ClassConstant {
+          "attrGroups": [],
+          "constants": [
             Constant {
               "kind": "constant",
               "name": Identifier {
@@ -138,7 +148,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [],
+          "nullable": false,
           "type": null,
           "visibility": "",
         },
@@ -168,7 +178,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
@@ -187,7 +197,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [],
+          "nullable": false,
           "type": null,
           "visibility": "private",
         },
@@ -217,7 +227,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
@@ -236,7 +246,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [],
+          "nullable": false,
           "type": null,
           "visibility": "protected",
         },
@@ -266,7 +276,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
@@ -285,7 +295,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [],
+          "nullable": false,
           "type": null,
           "visibility": "public",
         },
@@ -315,7 +325,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
@@ -334,7 +344,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [],
+          "nullable": false,
           "type": null,
           "visibility": "",
         },
@@ -364,7 +374,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
@@ -383,12 +393,12 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [],
+          "nullable": false,
           "type": null,
           "visibility": "public",
         },
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
@@ -407,20 +417,15 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [],
+          "nullable": false,
           "type": null,
           "visibility": "",
         },
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
-              "loc": TypeReference {
-                "kind": "typereference",
-                "name": "string",
-                "raw": "string",
-              },
               "name": Identifier {
                 "kind": "identifier",
                 "name": "CON_3",
@@ -436,20 +441,19 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [],
-          "type": null,
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "string",
+            "raw": "string",
+          },
           "visibility": "",
         },
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
-              "loc": TypeReference {
-                "kind": "typereference",
-                "name": "string",
-                "raw": "string",
-              },
               "name": Identifier {
                 "kind": "identifier",
                 "name": "CON_4",
@@ -465,31 +469,19 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [],
-          "type": null,
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "string",
+            "raw": "string",
+          },
           "visibility": "public",
         },
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
-              "loc": UnionType {
-                "kind": "uniontype",
-                "name": null,
-                "types": [
-                  TypeReference {
-                    "kind": "typereference",
-                    "name": "string",
-                    "raw": "string",
-                  },
-                  TypeReference {
-                    "kind": "typereference",
-                    "name": "int",
-                    "raw": "int",
-                  },
-                ],
-              },
               "name": Identifier {
                 "kind": "identifier",
                 "name": "CON_5",
@@ -505,31 +497,30 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [],
-          "type": null,
+          "nullable": false,
+          "type": UnionType {
+            "kind": "uniontype",
+            "name": null,
+            "types": [
+              TypeReference {
+                "kind": "typereference",
+                "name": "string",
+                "raw": "string",
+              },
+              TypeReference {
+                "kind": "typereference",
+                "name": "int",
+                "raw": "int",
+              },
+            ],
+          },
           "visibility": "public",
         },
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
-              "loc": UnionType {
-                "kind": "uniontype",
-                "name": null,
-                "types": [
-                  TypeReference {
-                    "kind": "typereference",
-                    "name": "string",
-                    "raw": "string",
-                  },
-                  TypeReference {
-                    "kind": "typereference",
-                    "name": "int",
-                    "raw": "int",
-                  },
-                ],
-              },
               "name": Identifier {
                 "kind": "identifier",
                 "name": "CON_6",
@@ -545,8 +536,23 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [],
-          "type": null,
+          "nullable": false,
+          "type": UnionType {
+            "kind": "uniontype",
+            "name": null,
+            "types": [
+              TypeReference {
+                "kind": "typereference",
+                "name": "string",
+                "raw": "string",
+              },
+              TypeReference {
+                "kind": "typereference",
+                "name": "int",
+                "raw": "int",
+              },
+            ],
+          },
           "visibility": "",
         },
       ],
@@ -569,3 +575,185 @@ Program {
 `;
 
 exports[`classconstant type hinted (unsupported) 1`] = `"Parse Error: Typed Class Constants requires PHP 8.3+ on line 1"`;
+
+exports[`classconstant type hinted list of constant with mixed type 1`] = `
+Program {
+  "children": [
+    Class {
+      "attrGroups": [],
+      "body": [
+        ClassConstant {
+          "attrGroups": [],
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "PUB1",
+              },
+              "value": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "'bar'",
+                "unicode": false,
+                "value": "bar",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "string",
+            "raw": "string",
+          },
+          "visibility": "public",
+        },
+        ClassConstant {
+          "attrGroups": [],
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "PUB2",
+              },
+              "value": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "'bar2'",
+                "unicode": false,
+                "value": "bar2",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": false,
+          "type": null,
+          "visibility": "public",
+        },
+        ClassConstant {
+          "attrGroups": [],
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "PUB3",
+              },
+              "value": Number {
+                "kind": "number",
+                "value": "1",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "int",
+            "raw": "int",
+          },
+          "visibility": "public",
+        },
+        ClassConstant {
+          "attrGroups": [],
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "PRI1",
+              },
+              "value": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "'baz'",
+                "unicode": false,
+                "value": "baz",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": false,
+          "type": null,
+          "visibility": "private",
+        },
+        ClassConstant {
+          "attrGroups": [],
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "PRI2",
+              },
+              "value": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "'baz2'",
+                "unicode": false,
+                "value": "baz2",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "string",
+            "raw": "string",
+          },
+          "visibility": "private",
+        },
+        ClassConstant {
+          "attrGroups": [],
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "BOB",
+              },
+              "value": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "'baz2'",
+                "unicode": false,
+                "value": "baz2",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "string",
+            "raw": "string",
+          },
+          "visibility": "private",
+        },
+      ],
+      "extends": null,
+      "implements": null,
+      "isAbstract": false,
+      "isAnonymous": false,
+      "isFinal": false,
+      "isReadonly": false,
+      "kind": "class",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "Foo",
+      },
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+}
+`;

--- a/test/snapshot/__snapshots__/classconstant.test.js.snap
+++ b/test/snapshot/__snapshots__/classconstant.test.js.snap
@@ -321,7 +321,7 @@ Program {
               "kind": "constant",
               "name": Identifier {
                 "kind": "identifier",
-                "name": "PUBLIC_TEST_CLASS_CONSTANT",
+                "name": "CON_1",
               },
               "value": String {
                 "isDoubleQuote": true,
@@ -337,6 +337,168 @@ Program {
           "nullable": [],
           "type": null,
           "visibility": "public",
+        },
+        ClassConstant {
+          "attrGroups": undefined,
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "CON_2",
+              },
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": ""Hello world!"",
+                "unicode": false,
+                "value": "Hello world!",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": [],
+          "type": null,
+          "visibility": "",
+        },
+        ClassConstant {
+          "attrGroups": undefined,
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "loc": TypeReference {
+                "kind": "typereference",
+                "name": "string",
+                "raw": "string",
+              },
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "CON_3",
+              },
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": ""Hello world!"",
+                "unicode": false,
+                "value": "Hello world!",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": [],
+          "type": null,
+          "visibility": "",
+        },
+        ClassConstant {
+          "attrGroups": undefined,
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "loc": TypeReference {
+                "kind": "typereference",
+                "name": "string",
+                "raw": "string",
+              },
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "CON_4",
+              },
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": ""Hello world!"",
+                "unicode": false,
+                "value": "Hello world!",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": [],
+          "type": null,
+          "visibility": "public",
+        },
+        ClassConstant {
+          "attrGroups": undefined,
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "loc": UnionType {
+                "kind": "uniontype",
+                "name": null,
+                "types": [
+                  TypeReference {
+                    "kind": "typereference",
+                    "name": "string",
+                    "raw": "string",
+                  },
+                  TypeReference {
+                    "kind": "typereference",
+                    "name": "int",
+                    "raw": "int",
+                  },
+                ],
+              },
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "CON_5",
+              },
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": ""Hello world!"",
+                "unicode": false,
+                "value": "Hello world!",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": [],
+          "type": null,
+          "visibility": "public",
+        },
+        ClassConstant {
+          "attrGroups": undefined,
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "loc": UnionType {
+                "kind": "uniontype",
+                "name": null,
+                "types": [
+                  TypeReference {
+                    "kind": "typereference",
+                    "name": "string",
+                    "raw": "string",
+                  },
+                  TypeReference {
+                    "kind": "typereference",
+                    "name": "int",
+                    "raw": "int",
+                  },
+                ],
+              },
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "CON_6",
+              },
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": ""Hello world!"",
+                "unicode": false,
+                "value": "Hello world!",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": [],
+          "type": null,
+          "visibility": "",
         },
       ],
       "extends": null,
@@ -359,7 +521,7 @@ Program {
 
 exports[`classconstant type hinted (unsupported) 1`] = `"Parse Error : syntax error, unexpected 'CONSTANT' (T_STRING), expecting ';' on line 1"`;
 
-exports[`classconstant type hinted idx: 0 1`] = `
+exports[`classconstant type hinted mixed position 1`] = `
 Program {
   "children": [
     Class {
@@ -389,31 +551,6 @@ Program {
           "type": null,
           "visibility": "public",
         },
-      ],
-      "extends": null,
-      "implements": null,
-      "isAbstract": false,
-      "isAnonymous": false,
-      "isFinal": false,
-      "isReadonly": false,
-      "kind": "class",
-      "name": Identifier {
-        "kind": "identifier",
-        "name": "Foo",
-      },
-    },
-  ],
-  "errors": [],
-  "kind": "program",
-}
-`;
-
-exports[`classconstant type hinted idx: 1 1`] = `
-Program {
-  "children": [
-    Class {
-      "attrGroups": [],
-      "body": [
         ClassConstant {
           "attrGroups": undefined,
           "constants": [
@@ -422,6 +559,165 @@ Program {
               "name": Identifier {
                 "kind": "identifier",
                 "name": "CON_2",
+              },
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": ""Hello world!"",
+                "unicode": false,
+                "value": "Hello world!",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": [],
+          "type": null,
+          "visibility": "",
+        },
+        ClassConstant {
+          "attrGroups": undefined,
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "loc": TypeReference {
+                "kind": "typereference",
+                "name": "string",
+                "raw": "string",
+              },
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "CON_3",
+              },
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": ""Hello world!"",
+                "unicode": false,
+                "value": "Hello world!",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": [],
+          "type": null,
+          "visibility": "",
+        },
+        Method {
+          "arguments": [],
+          "attrGroups": [],
+          "body": Block {
+            "children": [],
+            "kind": "block",
+          },
+          "byref": false,
+          "isAbstract": false,
+          "isFinal": false,
+          "isReadonly": false,
+          "isStatic": false,
+          "kind": "method",
+          "name": Identifier {
+            "kind": "identifier",
+            "name": "donut",
+          },
+          "nullable": false,
+          "type": null,
+          "visibility": "",
+        },
+        ClassConstant {
+          "attrGroups": undefined,
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "loc": TypeReference {
+                "kind": "typereference",
+                "name": "string",
+                "raw": "string",
+              },
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "CON_4",
+              },
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": ""Hello world!"",
+                "unicode": false,
+                "value": "Hello world!",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": [],
+          "type": null,
+          "visibility": "public",
+        },
+        ClassConstant {
+          "attrGroups": undefined,
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "loc": UnionType {
+                "kind": "uniontype",
+                "name": null,
+                "types": [
+                  TypeReference {
+                    "kind": "typereference",
+                    "name": "string",
+                    "raw": "string",
+                  },
+                  TypeReference {
+                    "kind": "typereference",
+                    "name": "int",
+                    "raw": "int",
+                  },
+                ],
+              },
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "CON_5",
+              },
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": ""Hello world!"",
+                "unicode": false,
+                "value": "Hello world!",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": [],
+          "type": null,
+          "visibility": "public",
+        },
+        ClassConstant {
+          "attrGroups": undefined,
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "loc": UnionType {
+                "kind": "uniontype",
+                "name": null,
+                "types": [
+                  TypeReference {
+                    "kind": "typereference",
+                    "name": "string",
+                    "raw": "string",
+                  },
+                  TypeReference {
+                    "kind": "typereference",
+                    "name": "int",
+                    "raw": "int",
+                  },
+                ],
+              },
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "CON_6",
               },
               "value": String {
                 "isDoubleQuote": true,

--- a/test/snapshot/__snapshots__/classconstant.test.js.snap
+++ b/test/snapshot/__snapshots__/classconstant.test.js.snap
@@ -15,6 +15,8 @@ Program {
                 "kind": "identifier",
                 "name": "list",
               },
+              "nullable": false,
+              "type": null,
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -26,8 +28,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": null,
           "visibility": "",
         },
       ],
@@ -64,6 +64,8 @@ Program {
                 "kind": "identifier",
                 "name": "CONSTANT",
               },
+              "nullable": false,
+              "type": null,
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -75,8 +77,6 @@ Program {
           ],
           "final": true,
           "kind": "classconstant",
-          "nullable": false,
-          "type": null,
           "visibility": "public",
         },
       ],
@@ -113,6 +113,8 @@ Program {
                 "kind": "identifier",
                 "name": "CONSTANT",
               },
+              "nullable": false,
+              "type": null,
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -121,22 +123,14 @@ Program {
                 "value": "Hello world!",
               },
             },
-          ],
-          "final": false,
-          "kind": "classconstant",
-          "nullable": false,
-          "type": null,
-          "visibility": "",
-        },
-        ClassConstant {
-          "attrGroups": [],
-          "constants": [
             Constant {
               "kind": "constant",
               "name": Identifier {
                 "kind": "identifier",
                 "name": "OTHER_CONSTANT",
               },
+              "nullable": false,
+              "type": null,
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -148,8 +142,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": null,
           "visibility": "",
         },
       ],
@@ -186,6 +178,8 @@ Program {
                 "kind": "identifier",
                 "name": "CONSTANT",
               },
+              "nullable": false,
+              "type": null,
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -197,8 +191,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": null,
           "visibility": "private",
         },
       ],
@@ -235,6 +227,8 @@ Program {
                 "kind": "identifier",
                 "name": "CONSTANT",
               },
+              "nullable": false,
+              "type": null,
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -246,8 +240,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": null,
           "visibility": "protected",
         },
       ],
@@ -284,6 +276,8 @@ Program {
                 "kind": "identifier",
                 "name": "CONSTANT",
               },
+              "nullable": false,
+              "type": null,
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -295,8 +289,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": null,
           "visibility": "public",
         },
       ],
@@ -333,6 +325,8 @@ Program {
                 "kind": "identifier",
                 "name": "CONSTANT",
               },
+              "nullable": false,
+              "type": null,
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -344,8 +338,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": null,
           "visibility": "",
         },
       ],
@@ -382,6 +374,8 @@ Program {
                 "kind": "identifier",
                 "name": "CON_1",
               },
+              "nullable": false,
+              "type": null,
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -393,8 +387,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": null,
           "visibility": "public",
         },
         ClassConstant {
@@ -406,6 +398,8 @@ Program {
                 "kind": "identifier",
                 "name": "CON_2",
               },
+              "nullable": false,
+              "type": null,
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -417,8 +411,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": null,
           "visibility": "",
         },
         ClassConstant {
@@ -430,6 +422,12 @@ Program {
                 "kind": "identifier",
                 "name": "CON_3",
               },
+              "nullable": false,
+              "type": TypeReference {
+                "kind": "typereference",
+                "name": "string",
+                "raw": "string",
+              },
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -441,12 +439,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": TypeReference {
-            "kind": "typereference",
-            "name": "string",
-            "raw": "string",
-          },
           "visibility": "",
         },
         ClassConstant {
@@ -458,6 +450,12 @@ Program {
                 "kind": "identifier",
                 "name": "CON_4",
               },
+              "nullable": false,
+              "type": TypeReference {
+                "kind": "typereference",
+                "name": "string",
+                "raw": "string",
+              },
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -469,12 +467,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": TypeReference {
-            "kind": "typereference",
-            "name": "string",
-            "raw": "string",
-          },
           "visibility": "public",
         },
         ClassConstant {
@@ -486,6 +478,23 @@ Program {
                 "kind": "identifier",
                 "name": "CON_5",
               },
+              "nullable": false,
+              "type": UnionType {
+                "kind": "uniontype",
+                "name": null,
+                "types": [
+                  TypeReference {
+                    "kind": "typereference",
+                    "name": "string",
+                    "raw": "string",
+                  },
+                  TypeReference {
+                    "kind": "typereference",
+                    "name": "int",
+                    "raw": "int",
+                  },
+                ],
+              },
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -497,23 +506,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": UnionType {
-            "kind": "uniontype",
-            "name": null,
-            "types": [
-              TypeReference {
-                "kind": "typereference",
-                "name": "string",
-                "raw": "string",
-              },
-              TypeReference {
-                "kind": "typereference",
-                "name": "int",
-                "raw": "int",
-              },
-            ],
-          },
           "visibility": "public",
         },
         ClassConstant {
@@ -525,6 +517,23 @@ Program {
                 "kind": "identifier",
                 "name": "CON_6",
               },
+              "nullable": false,
+              "type": UnionType {
+                "kind": "uniontype",
+                "name": null,
+                "types": [
+                  TypeReference {
+                    "kind": "typereference",
+                    "name": "string",
+                    "raw": "string",
+                  },
+                  TypeReference {
+                    "kind": "typereference",
+                    "name": "int",
+                    "raw": "int",
+                  },
+                ],
+              },
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
@@ -536,23 +545,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": UnionType {
-            "kind": "uniontype",
-            "name": null,
-            "types": [
-              TypeReference {
-                "kind": "typereference",
-                "name": "string",
-                "raw": "string",
-              },
-              TypeReference {
-                "kind": "typereference",
-                "name": "int",
-                "raw": "int",
-              },
-            ],
-          },
           "visibility": "",
         },
       ],
@@ -591,6 +583,12 @@ Program {
                 "kind": "identifier",
                 "name": "PUB1",
               },
+              "nullable": false,
+              "type": TypeReference {
+                "kind": "typereference",
+                "name": "string",
+                "raw": "string",
+              },
               "value": String {
                 "isDoubleQuote": false,
                 "kind": "string",
@@ -599,26 +597,14 @@ Program {
                 "value": "bar",
               },
             },
-          ],
-          "final": false,
-          "kind": "classconstant",
-          "nullable": false,
-          "type": TypeReference {
-            "kind": "typereference",
-            "name": "string",
-            "raw": "string",
-          },
-          "visibility": "public",
-        },
-        ClassConstant {
-          "attrGroups": [],
-          "constants": [
             Constant {
               "kind": "constant",
               "name": Identifier {
                 "kind": "identifier",
                 "name": "PUB2",
               },
+              "nullable": false,
+              "type": null,
               "value": String {
                 "isDoubleQuote": false,
                 "kind": "string",
@@ -627,21 +613,17 @@ Program {
                 "value": "bar2",
               },
             },
-          ],
-          "final": false,
-          "kind": "classconstant",
-          "nullable": false,
-          "type": null,
-          "visibility": "public",
-        },
-        ClassConstant {
-          "attrGroups": [],
-          "constants": [
             Constant {
               "kind": "constant",
               "name": Identifier {
                 "kind": "identifier",
                 "name": "PUB3",
+              },
+              "nullable": false,
+              "type": TypeReference {
+                "kind": "typereference",
+                "name": "int",
+                "raw": "int",
               },
               "value": Number {
                 "kind": "number",
@@ -651,12 +633,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": TypeReference {
-            "kind": "typereference",
-            "name": "int",
-            "raw": "int",
-          },
           "visibility": "public",
         },
         ClassConstant {
@@ -668,6 +644,8 @@ Program {
                 "kind": "identifier",
                 "name": "PRI1",
               },
+              "nullable": false,
+              "type": null,
               "value": String {
                 "isDoubleQuote": false,
                 "kind": "string",
@@ -676,21 +654,17 @@ Program {
                 "value": "baz",
               },
             },
-          ],
-          "final": false,
-          "kind": "classconstant",
-          "nullable": false,
-          "type": null,
-          "visibility": "private",
-        },
-        ClassConstant {
-          "attrGroups": [],
-          "constants": [
             Constant {
               "kind": "constant",
               "name": Identifier {
                 "kind": "identifier",
                 "name": "PRI2",
+              },
+              "nullable": false,
+              "type": TypeReference {
+                "kind": "typereference",
+                "name": "string",
+                "raw": "string",
               },
               "value": String {
                 "isDoubleQuote": false,
@@ -703,12 +677,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": TypeReference {
-            "kind": "typereference",
-            "name": "string",
-            "raw": "string",
-          },
           "visibility": "private",
         },
         ClassConstant {
@@ -720,6 +688,12 @@ Program {
                 "kind": "identifier",
                 "name": "BOB",
               },
+              "nullable": false,
+              "type": TypeReference {
+                "kind": "typereference",
+                "name": "string",
+                "raw": "string",
+              },
               "value": String {
                 "isDoubleQuote": false,
                 "kind": "string",
@@ -731,12 +705,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": TypeReference {
-            "kind": "typereference",
-            "name": "string",
-            "raw": "string",
-          },
           "visibility": "private",
         },
       ],

--- a/test/snapshot/__snapshots__/constantstatement.test.js.snap
+++ b/test/snapshot/__snapshots__/constantstatement.test.js.snap
@@ -11,6 +11,8 @@ Program {
             "kind": "identifier",
             "name": "CONSTANT",
           },
+          "nullable": null,
+          "type": undefined,
           "value": String {
             "isDoubleQuote": true,
             "kind": "string",
@@ -25,6 +27,8 @@ Program {
             "kind": "identifier",
             "name": "OTHER_CONSTANT",
           },
+          "nullable": null,
+          "type": undefined,
           "value": String {
             "isDoubleQuote": true,
             "kind": "string",
@@ -53,6 +57,8 @@ Program {
             "kind": "identifier",
             "name": "CONSTANT",
           },
+          "nullable": null,
+          "type": undefined,
           "value": String {
             "isDoubleQuote": true,
             "kind": "string",

--- a/test/snapshot/__snapshots__/enum.test.js.snap
+++ b/test/snapshot/__snapshots__/enum.test.js.snap
@@ -23,6 +23,8 @@ Program {
                 "kind": "identifier",
                 "name": "Baz",
               },
+              "nullable": false,
+              "type": null,
               "value": StaticLookup {
                 "kind": "staticlookup",
                 "offset": Identifier {
@@ -38,8 +40,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": null,
           "visibility": "public",
         },
       ],

--- a/test/snapshot/__snapshots__/enum.test.js.snap
+++ b/test/snapshot/__snapshots__/enum.test.js.snap
@@ -15,7 +15,7 @@ Program {
           "value": null,
         },
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
@@ -38,7 +38,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [],
+          "nullable": false,
           "type": null,
           "visibility": "public",
         },

--- a/test/snapshot/__snapshots__/enum.test.js.snap
+++ b/test/snapshot/__snapshots__/enum.test.js.snap
@@ -15,7 +15,7 @@ Program {
           "value": null,
         },
         ClassConstant {
-          "attrGroups": [],
+          "attrGroups": undefined,
           "constants": [
             Constant {
               "kind": "constant",
@@ -38,7 +38,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
+          "nullable": [],
           "type": null,
           "visibility": "public",
         },

--- a/test/snapshot/__snapshots__/heredoc.test.js.snap
+++ b/test/snapshot/__snapshots__/heredoc.test.js.snap
@@ -1676,7 +1676,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
@@ -1711,7 +1711,7 @@ FOOBAR",
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [],
+          "nullable": false,
           "type": null,
           "visibility": "",
         },

--- a/test/snapshot/__snapshots__/heredoc.test.js.snap
+++ b/test/snapshot/__snapshots__/heredoc.test.js.snap
@@ -1676,7 +1676,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": [],
+          "attrGroups": undefined,
           "constants": [
             Constant {
               "kind": "constant",
@@ -1711,7 +1711,7 @@ FOOBAR",
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
+          "nullable": [],
           "type": null,
           "visibility": "",
         },

--- a/test/snapshot/__snapshots__/heredoc.test.js.snap
+++ b/test/snapshot/__snapshots__/heredoc.test.js.snap
@@ -1684,6 +1684,8 @@ Program {
                 "kind": "identifier",
                 "name": "BAR",
               },
+              "nullable": false,
+              "type": null,
               "value": Encapsed {
                 "kind": "encapsed",
                 "label": "FOOBAR",
@@ -1711,8 +1713,6 @@ FOOBAR",
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": null,
           "visibility": "",
         },
         PropertyStatement {

--- a/test/snapshot/__snapshots__/interface.test.js.snap
+++ b/test/snapshot/__snapshots__/interface.test.js.snap
@@ -59,6 +59,8 @@ Program {
                 "kind": "identifier",
                 "name": "B",
               },
+              "nullable": false,
+              "type": null,
               "value": Number {
                 "kind": "number",
                 "value": "1",
@@ -67,8 +69,6 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": null,
           "visibility": "",
         },
       ],

--- a/test/snapshot/__snapshots__/interface.test.js.snap
+++ b/test/snapshot/__snapshots__/interface.test.js.snap
@@ -51,7 +51,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
@@ -67,7 +67,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [],
+          "nullable": false,
           "type": null,
           "visibility": "",
         },

--- a/test/snapshot/__snapshots__/interface.test.js.snap
+++ b/test/snapshot/__snapshots__/interface.test.js.snap
@@ -51,7 +51,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": [],
+          "attrGroups": undefined,
           "constants": [
             Constant {
               "kind": "constant",
@@ -67,7 +67,7 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
+          "nullable": [],
           "type": null,
           "visibility": "",
         },

--- a/test/snapshot/__snapshots__/location.test.js.snap
+++ b/test/snapshot/__snapshots__/location.test.js.snap
@@ -3363,19 +3363,6 @@ Program {
       "constants": [
         Constant {
           "kind": "constant",
-          "loc": Location {
-            "end": Position {
-              "column": 31,
-              "line": 1,
-              "offset": 31,
-            },
-            "source": "CONSTANT = "Hello world!"",
-            "start": Position {
-              "column": 6,
-              "line": 1,
-              "offset": 6,
-            },
-          },
           "name": Identifier {
             "kind": "identifier",
             "loc": Location {
@@ -3392,6 +3379,20 @@ Program {
               },
             },
             "name": "CONSTANT",
+          },
+          "nullable": null,
+          "type": Location {
+            "end": Position {
+              "column": 31,
+              "line": 1,
+              "offset": 31,
+            },
+            "source": "CONSTANT = "Hello world!"",
+            "start": Position {
+              "column": 6,
+              "line": 1,
+              "offset": 6,
+            },
           },
           "value": String {
             "isDoubleQuote": true,
@@ -3456,19 +3457,6 @@ Program {
       "constants": [
         Constant {
           "kind": "constant",
-          "loc": Location {
-            "end": Position {
-              "column": 31,
-              "line": 1,
-              "offset": 31,
-            },
-            "source": "CONSTANT = "Hello world!"",
-            "start": Position {
-              "column": 6,
-              "line": 1,
-              "offset": 6,
-            },
-          },
           "name": Identifier {
             "kind": "identifier",
             "loc": Location {
@@ -3485,6 +3473,20 @@ Program {
               },
             },
             "name": "CONSTANT",
+          },
+          "nullable": null,
+          "type": Location {
+            "end": Position {
+              "column": 31,
+              "line": 1,
+              "offset": 31,
+            },
+            "source": "CONSTANT = "Hello world!"",
+            "start": Position {
+              "column": 6,
+              "line": 1,
+              "offset": 6,
+            },
           },
           "value": String {
             "isDoubleQuote": true,
@@ -3509,19 +3511,6 @@ Program {
         },
         Constant {
           "kind": "constant",
-          "loc": Location {
-            "end": Position {
-              "column": 70,
-              "line": 1,
-              "offset": 70,
-            },
-            "source": "OTHER_CONSTANT = "Other hello world!"",
-            "start": Position {
-              "column": 33,
-              "line": 1,
-              "offset": 33,
-            },
-          },
           "name": Identifier {
             "kind": "identifier",
             "loc": Location {
@@ -3538,6 +3527,20 @@ Program {
               },
             },
             "name": "OTHER_CONSTANT",
+          },
+          "nullable": null,
+          "type": Location {
+            "end": Position {
+              "column": 70,
+              "line": 1,
+              "offset": 70,
+            },
+            "source": "OTHER_CONSTANT = "Other hello world!"",
+            "start": Position {
+              "column": 33,
+              "line": 1,
+              "offset": 33,
+            },
           },
           "value": String {
             "isDoubleQuote": true,

--- a/test/snapshot/__snapshots__/nowdoc.test.js.snap
+++ b/test/snapshot/__snapshots__/nowdoc.test.js.snap
@@ -206,6 +206,8 @@ Program {
                 "kind": "identifier",
                 "name": "BAR",
               },
+              "nullable": false,
+              "type": null,
               "value": Nowdoc {
                 "kind": "nowdoc",
                 "label": "FOOBAR",
@@ -218,8 +220,6 @@ FOOBAR",
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
-          "type": null,
           "visibility": "",
         },
         PropertyStatement {

--- a/test/snapshot/__snapshots__/nowdoc.test.js.snap
+++ b/test/snapshot/__snapshots__/nowdoc.test.js.snap
@@ -198,7 +198,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": undefined,
+          "attrGroups": [],
           "constants": [
             Constant {
               "kind": "constant",
@@ -218,7 +218,7 @@ FOOBAR",
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": [],
+          "nullable": false,
           "type": null,
           "visibility": "",
         },

--- a/test/snapshot/__snapshots__/nowdoc.test.js.snap
+++ b/test/snapshot/__snapshots__/nowdoc.test.js.snap
@@ -198,7 +198,7 @@ Program {
       "attrGroups": [],
       "body": [
         ClassConstant {
-          "attrGroups": [],
+          "attrGroups": undefined,
           "constants": [
             Constant {
               "kind": "constant",
@@ -218,7 +218,7 @@ FOOBAR",
           ],
           "final": false,
           "kind": "classconstant",
-          "nullable": false,
+          "nullable": [],
           "type": null,
           "visibility": "",
         },

--- a/test/snapshot/classconstant.test.js
+++ b/test/snapshot/classconstant.test.js
@@ -42,7 +42,14 @@ describe("classconstant", () => {
   it("type hinted (supported)", () => {
     expect(
       parser.parseEval(
-        'class Foo { public const string CONSTANT = "Hello world!"; }',
+        `class Foo {
+              public const CON_1 = "Hello world!";
+              const CON_2 = "Hello world!";
+              const string CON_3 = "Hello world!";
+              public const string CON_4 = "Hello world!";
+              public const string|int CON_5 = "Hello world!";
+              const string|int CON_6 = "Hello world!";
+              }`,
         { parser: { version: 803 } },
       ),
     ).toMatchSnapshot();

--- a/test/snapshot/classconstant.test.js
+++ b/test/snapshot/classconstant.test.js
@@ -43,15 +43,15 @@ describe("classconstant", () => {
     expect(
       parser.parseEval(
         'class Foo { public const string CONSTANT = "Hello world!"; }',
-        { parser: { version: 830 } },
+        { parser: { version: 803 } },
       ),
     ).toMatchSnapshot();
   });
   it("type hinted (unsupported)", () => {
     expect(() =>
       parser.parseEval(
-        'class Foo { public const string CONSTANT = "Hello world!"; }',
-        { parser: { version: 820 } },
+        'class Foo { public const  DDCONSTANT = "Hello world!"; public const string CONSTANT = "Hello world!"; }',
+        { parser: { version: 802 } },
       ),
     ).toThrowErrorMatchingSnapshot();
   });

--- a/test/snapshot/classconstant.test.js
+++ b/test/snapshot/classconstant.test.js
@@ -55,6 +55,19 @@ describe("classconstant", () => {
     ).toMatchSnapshot();
   });
 
+  it("type hinted list of constant with mixed type", () => {
+    expect(
+      parser.parseEval(
+        `class Foo {
+                  public const string PUB1 = 'bar', PUB2 = 'bar2', int PUB3 = 1;
+                  private const PRI1 = 'baz', string PRI2 = 'baz2';
+                  private const string BOB = 'baz2';
+                }`,
+        { parser: { version: 803 } },
+      ),
+    ).toMatchSnapshot();
+  });
+
   it("type hinted (unsupported)", () => {
     expect(() =>
       parser.parseEval(

--- a/test/snapshot/classconstant.test.js
+++ b/test/snapshot/classconstant.test.js
@@ -63,4 +63,15 @@ describe("classconstant", () => {
       ),
     ).toThrowErrorMatchingSnapshot();
   });
+
+  it("accept the constant name 'list'", () => {
+    expect(
+      parser.parseEval(
+        `class Foo {
+              const list = "Hello world!";
+              }`,
+        { parser: { version: 803 } },
+      ),
+    ).toMatchSnapshot();
+  });
 });

--- a/test/snapshot/classconstant.test.js
+++ b/test/snapshot/classconstant.test.js
@@ -54,6 +54,7 @@ describe("classconstant", () => {
       ),
     ).toMatchSnapshot();
   });
+
   it("type hinted (unsupported)", () => {
     expect(() =>
       parser.parseEval(

--- a/types.d.ts
+++ b/types.d.ts
@@ -161,8 +161,6 @@ declare module "php-parser" {
     parseFlags(flags: (number | null)[]): void;
     visibility: string;
     final: boolean;
-    nullable: boolean;
-    type: TypeReference | IntersectionType | UnionType | null;
     attrGroups: AttrGroup[];
   }
   /**
@@ -204,6 +202,8 @@ declare module "php-parser" {
   class Constant extends Node {
     name: string;
     value: Node | string | number | boolean | null;
+    nullable: boolean;
+    type: TypeReference | IntersectionType | UnionType | null;
   }
   /**
    * Declares a constants into the current scope


### PR DESCRIPTION
Fix https://github.com/glayzzle/php-parser/issues/1133

- make sure all variation of class constant are still being supported
- Throw a clear error when the parser detect typed class constants by the PHP version configured does not match
