### PR TITLE
Consistent returns for `read_variable_declaration`

### DIFF
--- a/src/parser/class.js
+++ b/src/parser/class.js
@@ -204,13 +204,10 @@ module.exports = {
 
         let value = null;
 
-        if (this.token === ";" || this.token === ",") {
-          // no-op
-        } else if (this.token === "=") {
+        this.expect([",", ";", "="]);
+        if (this.token === "=") {
           // https://github.com/php/php-src/blob/master/Zend/zend_language_parser.y#L815
           value = this.next().read_expr();
-        } else {
-          this.expect([",", ";"]);
         }
         return result(propName, value, readonly, nullable, type, attrs || []);
       },

--- a/src/parser/class.js
+++ b/src/parser/class.js
@@ -210,7 +210,7 @@ module.exports = {
           // https://github.com/php/php-src/blob/master/Zend/zend_language_parser.y#L815
           value = this.next().read_expr();
         } else {
-          this.expect([",", ";", "="]);
+          this.expect([",", ";"]);
         }
         return result(propName, value, readonly, nullable, type, attrs || []);
       },

--- a/src/parser/class.js
+++ b/src/parser/class.js
@@ -201,22 +201,18 @@ module.exports = {
         const name = this.text().substring(1); // ignore $
         this.next();
         propName = propName(name);
+
+        let value = null;
+
         if (this.token === ";" || this.token === ",") {
-          return result(propName, null, readonly, nullable, type, attrs || []);
+          // no-op
         } else if (this.token === "=") {
           // https://github.com/php/php-src/blob/master/Zend/zend_language_parser.y#L815
-          return result(
-            propName,
-            this.next().read_expr(),
-            readonly,
-            nullable,
-            type,
-            attrs || [],
-          );
+          value = this.next().read_expr();
         } else {
           this.expect([",", ";", "="]);
-          return result(propName, null, nullable, type, attrs || []);
         }
+        return result(propName, value, readonly, nullable, type, attrs || []);
       },
       ",",
     );

--- a/test/snapshot/__snapshots__/class.test.js.snap
+++ b/test/snapshot/__snapshots__/class.test.js.snap
@@ -1200,19 +1200,19 @@ Program {
           "kind": "propertystatement",
           "properties": [
             Property {
-              "attrGroups": null,
+              "attrGroups": [],
               "kind": "property",
               "name": Identifier {
                 "kind": "identifier",
                 "name": "id",
               },
-              "nullable": TypeReference {
+              "nullable": false,
+              "readonly": true,
+              "type": TypeReference {
                 "kind": "typereference",
                 "name": "int",
                 "raw": "int",
               },
-              "readonly": false,
-              "type": [],
               "value": null,
             },
           ],

--- a/test/snapshot/__snapshots__/graceful.test.js.snap
+++ b/test/snapshot/__snapshots__/graceful.test.js.snap
@@ -300,19 +300,19 @@ Program {
           "kind": "propertystatement",
           "properties": [
             Property {
-              "attrGroups": null,
+              "attrGroups": [],
               "kind": "property",
               "name": Identifier {
                 "kind": "identifier",
                 "name": "onst",
               },
-              "nullable": Name {
+              "nullable": false,
+              "readonly": false,
+              "type": Name {
                 "kind": "name",
                 "name": "foo",
                 "resolution": "uqn",
               },
-              "readonly": false,
-              "type": [],
               "value": null,
             },
           ],
@@ -843,19 +843,19 @@ Program {
           "kind": "propertystatement",
           "properties": [
             Property {
-              "attrGroups": null,
+              "attrGroups": [],
               "kind": "property",
               "name": Identifier {
                 "kind": "identifier",
                 "name": "mplement",
               },
-              "nullable": Name {
+              "nullable": false,
+              "readonly": false,
+              "type": Name {
                 "kind": "name",
                 "name": "bar",
                 "resolution": "uqn",
               },
-              "readonly": false,
-              "type": [],
               "value": null,
             },
           ],


### PR DESCRIPTION
While working on adding support for property hooks, I realized that the function parsing class property does not always call the "return" function with the same parameters: in some instance,  the parameter `readonly` is not being passed done. 

This PR fix that by having 1 call to return despite multiple branches in the logic.