### PR TITLE
Fix Typed Class Constants parsing 

### DIFF
--- a/src/parser/class.js
+++ b/src/parser/class.js
@@ -235,7 +235,7 @@ module.exports = {
     }
 
     const [nullable, type] =
-      this.version >= 830 ? this.read_optional_type() : [false, null];
+      this.version >= 803 ? this.read_optional_type() : [false, null];
 
     const result = this.node("classconstant");
     const items = this.read_list(
@@ -364,6 +364,11 @@ module.exports = {
     if (nullable) {
       this.next();
     }
+
+    if (this.peek() === "=") {
+      return [false, null];
+    }
+
     let type = this.read_types();
     if (nullable && !type) {
       this.raiseError(

--- a/test/snapshot/__snapshots__/classconstant.test.js.snap
+++ b/test/snapshot/__snapshots__/classconstant.test.js.snap
@@ -112,6 +112,69 @@ Program {
 }
 `;
 
+exports[`classconstant multiple 8.3 1`] = `
+Program {
+  "children": [
+    Class {
+      "attrGroups": [],
+      "body": [
+        ClassConstant {
+          "attrGroups": [],
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "NAME_1",
+              },
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": ""Hello world!"",
+                "unicode": false,
+                "value": "Hello world!",
+              },
+            },
+            Constant {
+              "kind": "constant",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "NAME_2",
+              },
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": ""Other hello world!"",
+                "unicode": false,
+                "value": "Other hello world!",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": false,
+          "type": null,
+          "visibility": "",
+        },
+      ],
+      "extends": null,
+      "implements": null,
+      "isAbstract": false,
+      "isAnonymous": false,
+      "isFinal": false,
+      "isReadonly": false,
+      "kind": "class",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "Foo",
+      },
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+}
+`;
+
 exports[`classconstant private 1`] = `
 Program {
   "children": [
@@ -260,6 +323,55 @@ Program {
 `;
 
 exports[`classconstant simple 1`] = `
+Program {
+  "children": [
+    Class {
+      "attrGroups": [],
+      "body": [
+        ClassConstant {
+          "attrGroups": [],
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "CONSTANT",
+              },
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": ""Hello world!"",
+                "unicode": false,
+                "value": "Hello world!",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": false,
+          "type": null,
+          "visibility": "",
+        },
+      ],
+      "extends": null,
+      "implements": null,
+      "isAbstract": false,
+      "isAnonymous": false,
+      "isFinal": false,
+      "isReadonly": false,
+      "kind": "class",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "Foo",
+      },
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+}
+`;
+
+exports[`classconstant simple using 8.3 1`] = `
 Program {
   "children": [
     Class {

--- a/test/snapshot/classconstant.test.js
+++ b/test/snapshot/classconstant.test.js
@@ -6,6 +6,14 @@ describe("classconstant", () => {
       parser.parseEval('class Foo { const CONSTANT = "Hello world!"; }'),
     ).toMatchSnapshot();
   });
+  it("simple using 8.3", () => {
+    expect(
+      parser.parseEval(`class Foo { const CONSTANT = "Hello world!"; }`, {
+        parser: { version: 803 },
+      }),
+    ).toMatchSnapshot();
+  });
+
   it("multiple", () => {
     expect(
       parser.parseEval(
@@ -13,6 +21,18 @@ describe("classconstant", () => {
       ),
     ).toMatchSnapshot();
   });
+
+  it("multiple 8.3", () => {
+    expect(
+      parser.parseEval(
+        'class Foo { const NAME_1 = "Hello world!", NAME_2 = "Other hello world!"; }',
+        {
+          parser: { version: 803 },
+        },
+      ),
+    ).toMatchSnapshot();
+  });
+
   it("public", () => {
     expect(
       parser.parseEval('class Foo { public const CONSTANT = "Hello world!"; }'),
@@ -43,7 +63,7 @@ describe("classconstant", () => {
     expect(
       parser.parseEval(
         'class Foo { public const string CONSTANT = "Hello world!"; }',
-        { parser: { version: 830 } },
+        { parser: { version: 803 } },
       ),
     ).toMatchSnapshot();
   });
@@ -51,7 +71,7 @@ describe("classconstant", () => {
     expect(() =>
       parser.parseEval(
         'class Foo { public const string CONSTANT = "Hello world!"; }',
-        { parser: { version: 820 } },
+        { parser: { version: 802 } },
       ),
     ).toThrowErrorMatchingSnapshot();
   });


### PR DESCRIPTION
Class using untyped constant are breaking the parser when using 8.3

```
class Foo { 
const CONSTANT = "Hello world!"; 
}
```

The problem came from `read_optional_type` which was returning a "type" even if the statement did not have a type.