### PR TITLE
fix: 🐛 syntax error on multiline class constant with comment

### DIFF
--- a/src/parser/class.js
+++ b/src/parser/class.js
@@ -358,7 +358,7 @@ module.exports = {
       this.next();
     }
 
-    if (this.peek() === "=") {
+    if (this.peekSkipComments() === "=") {
       return [false, null];
     }
 
@@ -384,6 +384,21 @@ module.exports = {
       } while (this.token === "|");
     }
     return [nullable, type];
+  },
+
+  peekSkipComments: function () {
+    const lexerState = this.lexer.getState();
+    let nextToken;
+
+    do {
+      nextToken = this.lexer.lex();
+    } while (
+      nextToken === this.tok.T_COMMENT ||
+      nextToken === this.tok.T_WHITESPACE
+    );
+
+    this.lexer.setState(lexerState);
+    return nextToken;
   },
 
   /*

--- a/test/snapshot/__snapshots__/classconstant.test.js.snap
+++ b/test/snapshot/__snapshots__/classconstant.test.js.snap
@@ -49,6 +49,59 @@ Program {
 }
 `;
 
+exports[`classconstant multiline declaration with comment 1`] = `
+Program {
+  "children": [
+    Class {
+      "attrGroups": [],
+      "body": [
+        ClassConstant {
+          "attrGroups": [],
+          "constants": [
+            Constant {
+              "kind": "constant",
+              "name": Identifier {
+                "kind": "identifier",
+                "name": "CONSTANT",
+              },
+              "value": String {
+                "isDoubleQuote": true,
+                "kind": "string",
+                "raw": ""Hello world!"",
+                "unicode": false,
+                "value": "Hello world!",
+              },
+            },
+          ],
+          "final": false,
+          "kind": "classconstant",
+          "nullable": false,
+          "type": TypeReference {
+            "kind": "typereference",
+            "name": "string",
+            "raw": "string",
+          },
+          "visibility": "public",
+        },
+      ],
+      "extends": null,
+      "implements": null,
+      "isAbstract": false,
+      "isAnonymous": false,
+      "isFinal": false,
+      "isReadonly": false,
+      "kind": "class",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "Foo",
+      },
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+}
+`;
+
 exports[`classconstant multiple 1`] = `
 Program {
   "children": [

--- a/test/snapshot/__snapshots__/classconstant.test.js.snap
+++ b/test/snapshot/__snapshots__/classconstant.test.js.snap
@@ -67,6 +67,20 @@ Program {
               "value": String {
                 "isDoubleQuote": true,
                 "kind": "string",
+                "leadingComments": [
+                  CommentLine {
+                    "kind": "commentline",
+                    "offset": 165,
+                    "value": "// comment 4
+",
+                  },
+                  CommentLine {
+                    "kind": "commentline",
+                    "offset": 200,
+                    "value": "// comment 5
+",
+                  },
+                ],
                 "raw": ""Hello world!"",
                 "unicode": false,
                 "value": "Hello world!",
@@ -75,9 +89,31 @@ Program {
           ],
           "final": false,
           "kind": "classconstant",
+          "leadingComments": [
+            CommentLine {
+              "kind": "commentline",
+              "offset": 122,
+              "value": "// comment 3
+",
+            },
+          ],
           "nullable": false,
           "type": TypeReference {
             "kind": "typereference",
+            "leadingComments": [
+              CommentLine {
+                "kind": "commentline",
+                "offset": 41,
+                "value": "// comment 1
+",
+              },
+              CommentLine {
+                "kind": "commentline",
+                "offset": 81,
+                "value": "// comment 2
+",
+              },
+            ],
             "name": "string",
             "raw": "string",
           },
@@ -95,6 +131,38 @@ Program {
         "kind": "identifier",
         "name": "Foo",
       },
+    },
+  ],
+  "comments": [
+    CommentLine {
+      "kind": "commentline",
+      "offset": 41,
+      "value": "// comment 1
+",
+    },
+    CommentLine {
+      "kind": "commentline",
+      "offset": 81,
+      "value": "// comment 2
+",
+    },
+    CommentLine {
+      "kind": "commentline",
+      "offset": 122,
+      "value": "// comment 3
+",
+    },
+    CommentLine {
+      "kind": "commentline",
+      "offset": 165,
+      "value": "// comment 4
+",
+    },
+    CommentLine {
+      "kind": "commentline",
+      "offset": 200,
+      "value": "// comment 5
+",
     },
   ],
   "errors": [],

--- a/test/snapshot/__snapshots__/classconstant.test.js.snap
+++ b/test/snapshot/__snapshots__/classconstant.test.js.snap
@@ -65,58 +65,26 @@ Program {
                 "name": "CONSTANT",
               },
               "value": String {
-                "isDoubleQuote": true,
+                "isDoubleQuote": false,
                 "kind": "string",
                 "leadingComments": [
                   CommentLine {
                     "kind": "commentline",
-                    "offset": 165,
-                    "value": "// comment 4
-",
-                  },
-                  CommentLine {
-                    "kind": "commentline",
-                    "offset": 200,
-                    "value": "// comment 5
+                    "offset": 75,
+                    "value": "// Comment
 ",
                   },
                 ],
-                "raw": ""Hello world!"",
+                "raw": "'string'",
                 "unicode": false,
-                "value": "Hello world!",
+                "value": "string",
               },
             },
           ],
           "final": false,
           "kind": "classconstant",
-          "leadingComments": [
-            CommentLine {
-              "kind": "commentline",
-              "offset": 122,
-              "value": "// comment 3
-",
-            },
-          ],
           "nullable": false,
-          "type": TypeReference {
-            "kind": "typereference",
-            "leadingComments": [
-              CommentLine {
-                "kind": "commentline",
-                "offset": 41,
-                "value": "// comment 1
-",
-              },
-              CommentLine {
-                "kind": "commentline",
-                "offset": 81,
-                "value": "// comment 2
-",
-              },
-            ],
-            "name": "string",
-            "raw": "string",
-          },
+          "type": null,
           "visibility": "public",
         },
       ],
@@ -136,32 +104,8 @@ Program {
   "comments": [
     CommentLine {
       "kind": "commentline",
-      "offset": 41,
-      "value": "// comment 1
-",
-    },
-    CommentLine {
-      "kind": "commentline",
-      "offset": 81,
-      "value": "// comment 2
-",
-    },
-    CommentLine {
-      "kind": "commentline",
-      "offset": 122,
-      "value": "// comment 3
-",
-    },
-    CommentLine {
-      "kind": "commentline",
-      "offset": 165,
-      "value": "// comment 4
-",
-    },
-    CommentLine {
-      "kind": "commentline",
-      "offset": 200,
-      "value": "// comment 5
+      "offset": 75,
+      "value": "// Comment
 ",
     },
   ],

--- a/test/snapshot/classconstant.test.js
+++ b/test/snapshot/classconstant.test.js
@@ -75,4 +75,24 @@ describe("classconstant", () => {
       ),
     ).toThrowErrorMatchingSnapshot();
   });
+  it("multiline declaration with comment", () => {
+    expect(
+      parser.parseEval(
+        `class Foo { 
+          public 
+          // comment 1
+          const 
+          // comment 2
+          string 
+          // comment 3
+          CONSTANT 
+          // comment 4
+          = 
+          // comment 5
+          "Hello world!"; 
+        }`,
+        { parser: { version: 803 } },
+      ),
+    ).toMatchSnapshot();
+  });
 });

--- a/test/snapshot/classconstant.test.js
+++ b/test/snapshot/classconstant.test.js
@@ -87,11 +87,11 @@ describe("classconstant", () => {
           // comment 3
           CONSTANT 
           // comment 4
-          = 
+          =
           // comment 5
           "Hello world!"; 
         }`,
-        { parser: { version: 803 } },
+        { parser: { version: 803, extractDoc: true } },
       ),
     ).toMatchSnapshot();
   });

--- a/test/snapshot/classconstant.test.js
+++ b/test/snapshot/classconstant.test.js
@@ -79,17 +79,12 @@ describe("classconstant", () => {
     expect(
       parser.parseEval(
         `class Foo { 
-          public 
-          // comment 1
-          const 
-          // comment 2
-          string 
-          // comment 3
-          CONSTANT 
-          // comment 4
+          public
+          const
+          CONSTANT
+          // Comment
           =
-          // comment 5
-          "Hello world!"; 
+          'string';
         }`,
         { parser: { version: 803, extractDoc: true } },
       ),


### PR DESCRIPTION
## Context
- fixes: #1151 

## Problem
- see: #1151 

## Solution
Skip comments and whitespace when peeking as peek() is just peeking next token without consider comment. I don't know this is proper solution but it works as expected in my environment. 