### PR TITLE
fix: valid_after_heredoc_73 missing the concatenation operator

### DIFF
--- a/src/lexer/strings.js
+++ b/src/lexer/strings.js
@@ -16,6 +16,7 @@ const valid_after_heredoc_73 = valid_after_heredoc.concat([
   "/",
   "=",
   "!",
+  ".",
 ]);
 
 module.exports = {

--- a/test/snapshot/__snapshots__/nowdoc.test.js.snap
+++ b/test/snapshot/__snapshots__/nowdoc.test.js.snap
@@ -27,6 +27,104 @@ c",
 }
 `;
 
+exports[`nowdoc Flexible nowdoc syntax: concatenation right after nowdoc 1`] = `
+Program {
+  "children": [
+    Echo {
+      "expressions": [
+        Bin {
+          "kind": "bin",
+          "left": Encapsed {
+            "kind": "encapsed",
+            "label": "END",
+            "raw": "<<<END
+
+END",
+            "type": "heredoc",
+            "value": [
+              EncapsedPart {
+                "curly": false,
+                "expression": String {
+                  "isDoubleQuote": false,
+                  "kind": "string",
+                  "raw": "
+",
+                  "unicode": false,
+                  "value": "",
+                },
+                "kind": "encapsedpart",
+                "syntax": null,
+              },
+            ],
+          },
+          "right": String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "raw": """",
+            "unicode": false,
+            "value": "",
+          },
+          "type": ".",
+        },
+      ],
+      "kind": "echo",
+      "shortForm": false,
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+}
+`;
+
+exports[`nowdoc Flexible nowdoc syntax: equals right after nowdoc 1`] = `
+Program {
+  "children": [
+    Echo {
+      "expressions": [
+        Bin {
+          "kind": "bin",
+          "left": Encapsed {
+            "kind": "encapsed",
+            "label": "END",
+            "raw": "<<<END
+
+END",
+            "type": "heredoc",
+            "value": [
+              EncapsedPart {
+                "curly": false,
+                "expression": String {
+                  "isDoubleQuote": false,
+                  "kind": "string",
+                  "raw": "
+",
+                  "unicode": false,
+                  "value": "",
+                },
+                "kind": "encapsedpart",
+                "syntax": null,
+              },
+            ],
+          },
+          "right": String {
+            "isDoubleQuote": true,
+            "kind": "string",
+            "raw": """",
+            "unicode": false,
+            "value": "",
+          },
+          "type": "==",
+        },
+      ],
+      "kind": "echo",
+      "shortForm": false,
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+}
+`;
+
 exports[`nowdoc Flexible nowdoc syntax: with variables 1`] = `
 Program {
   "children": [

--- a/test/snapshot/nowdoc.test.js
+++ b/test/snapshot/nowdoc.test.js
@@ -120,6 +120,38 @@ TEST;
     ).toMatchSnapshot();
   });
 
+  it("Flexible nowdoc syntax: errors in PHP 7.2", function () {
+    expect(() =>
+      parser.parseEval(
+        `
+echo <<<END
+
+END."";`,
+        { parser: { version: "7.2" } },
+      ),
+    ).toThrow();
+  });
+
+  it("Flexible nowdoc syntax: concatenation right after nowdoc", function () {
+    expect(
+      parser.parseEval(`
+echo <<<END
+
+END."";
+`),
+    ).toMatchSnapshot();
+  });
+
+  it("Flexible nowdoc syntax: equals right after nowdoc", function () {
+    expect(
+      parser.parseEval(`
+echo <<<END
+
+END=="";
+`),
+    ).toMatchSnapshot();
+  });
+
   it("Flexible nowdoc syntax: 4 spaces of indentation", function () {
     expect(
       parser.parseEval(`


### PR DESCRIPTION
Fixes #1155, sprinkled in some tests too relating to flexible nowdocs as well. One line fix, 130 lines of tests/fixtures.