### PR TITLE
fix: parse new without parens as `call` instead of `bin`

### DIFF
--- a/src/parser/class.js
+++ b/src/parser/class.js
@@ -386,7 +386,7 @@ module.exports = {
     return [nullable, type];
   },
 
-  peekSkipComments: function () {
+  peekSkipComments() {
     const lexerState = this.lexer.getState();
     let nextToken;
 

--- a/src/parser/expr.js
+++ b/src/parser/expr.js
@@ -97,14 +97,6 @@ module.exports = {
     if (this.token === this.tok.T_SPACESHIP) {
       return result("bin", "<=>", expr, this.next().read_expr());
     }
-    if (this.token === this.tok.T_OBJECT_OPERATOR) {
-      if (this.version < 804) {
-        this.raiseError(
-          "New without parenthesis is not allowed before PHP 8.4",
-        );
-      }
-      return result("bin", "->", expr, this.next().read_expr());
-    }
 
     if (this.token === this.tok.T_INSTANCEOF) {
       expr = result(
@@ -359,7 +351,13 @@ module.exports = {
         return this.node("pre")("-", this.next().read_variable(false, false));
 
       case this.tok.T_NEW:
-        return this.read_new_expr();
+        expr = this.read_new_expr();
+        if (this.token === this.tok.T_OBJECT_OPERATOR && this.version < 804) {
+          this.raiseError(
+            "New without parenthesis is not allowed before PHP 8.4",
+          );
+        }
+        return this.handleDereferencable(expr);
 
       case this.tok.T_ISSET:
       case this.tok.T_EMPTY:

--- a/test/snapshot/__snapshots__/class.test.js.snap
+++ b/test/snapshot/__snapshots__/class.test.js.snap
@@ -1,12 +1,48 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Test classes 8.4 allow new without parenthesis 1`] = `
 Program {
   "children": [
     ExpressionStatement {
-      "expression": Bin {
-        "kind": "bin",
-        "left": New {
+      "expression": Call {
+        "arguments": [],
+        "kind": "call",
+        "what": PropertyLookup {
+          "kind": "propertylookup",
+          "offset": Identifier {
+            "kind": "identifier",
+            "name": "name",
+          },
+          "what": New {
+            "arguments": [],
+            "kind": "new",
+            "what": Name {
+              "kind": "name",
+              "name": "People",
+              "resolution": "uqn",
+            },
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+}
+`;
+
+exports[`Test classes 8.4 new without parenthesis with array lookup 1`] = `
+Program {
+  "children": [
+    ExpressionStatement {
+      "expression": OffsetLookup {
+        "kind": "offsetlookup",
+        "offset": Number {
+          "kind": "number",
+          "value": "0",
+        },
+        "what": New {
           "arguments": [],
           "kind": "new",
           "what": Name {
@@ -15,16 +51,6 @@ Program {
             "resolution": "uqn",
           },
         },
-        "right": Call {
-          "arguments": [],
-          "kind": "call",
-          "what": Name {
-            "kind": "name",
-            "name": "name",
-            "resolution": "uqn",
-          },
-        },
-        "type": "->",
       },
       "kind": "expressionstatement",
     },

--- a/test/snapshot/class.test.js
+++ b/test/snapshot/class.test.js
@@ -266,10 +266,25 @@ describe("Test classes", function () {
     expect(test_parser.parseEval(code)).toMatchSnapshot();
   });
 
+  it("8.4 new without parenthesis with array lookup", () => {
+    const code = `new People()[0];`;
+    const test_parser = parser.create({
+      parser: {
+        version: "8.4",
+      },
+    });
+    expect(test_parser.parseEval(code)).toMatchSnapshot();
+  });
+
   it("new without parenthesis throw errors in PHP < 8.4", () => {
     const code = `new People()->name();`;
+    const test_parser = parser.create({
+      parser: {
+        version: "8.3",
+      },
+    });
     expect(() => {
-      parser.parseEval(code);
+      test_parser.parseEval(code);
     }).toThrowErrorMatchingSnapshot();
   });
 


### PR DESCRIPTION
Fixes #1161 and #1160 

cc @claytonrcarter