### PR TITLE
fix: enforce underscore separator restrictions in hex, binary, and octal literals

### DIFF
--- a/src/lexer/numbers.js
+++ b/src/lexer/numbers.js
@@ -23,7 +23,7 @@ module.exports = {
       if (ch === "x" || ch === "X") {
         ch = this.input();
         if (ch !== "_" && this.is_HEX()) {
-          return this.consume_HNUM();
+          return this.consume_hexadecimal();
         } else {
           this.unput(ch ? 2 : 1);
         }
@@ -31,14 +31,14 @@ module.exports = {
       } else if (ch === "b" || ch === "B") {
         ch = this.input();
         if ((ch !== "_" && ch === "0") || ch === "1") {
-          return this.consume_BNUM();
+          return this.consume_binary();
         } else {
           this.unput(ch ? 2 : 1);
         }
       } else if (ch === "o" || ch === "O") {
         ch = this.input();
         if (ch !== "_" && this.is_OCTAL()) {
-          return this.consume_ONUM();
+          return this.consume_octal();
         } else {
           this.unput(ch ? 2 : 1);
         }
@@ -94,7 +94,7 @@ module.exports = {
           ch = this.input();
         }
         if (this.is_NUM_START()) {
-          this.consume_LNUM();
+          this.consume_decimal_digits();
           return this.tok.T_DNUMBER;
         }
         this.unput(ch ? undo : undo - 1); // keep only 1
@@ -123,19 +123,28 @@ module.exports = {
       return this.tok.T_DNUMBER;
     }
   },
-  // read hexa
-  consume_HNUM() {
+  consume_prefixed_digits(isValid) {
+    let prev = this._input[this.offset - 1];
     while (this.offset < this.size) {
       const ch = this.input();
-      if (!this.is_HEX()) {
+      if (!isValid.call(this)) {
         if (ch) this.unput(1);
         break;
       }
+      if (ch === "_" && prev === "_") {
+        this.unput(2);
+        prev = null;
+        break;
+      }
+      prev = ch;
     }
+    if (prev === "_") this.unput(1);
     return this.tok.T_LNUMBER;
   },
-  // read a generic number
-  consume_LNUM() {
+  consume_hexadecimal() {
+    return this.consume_prefixed_digits(this.is_HEX);
+  },
+  consume_decimal_digits() {
     while (this.offset < this.size) {
       const ch = this.input();
       if (!this.is_NUM()) {
@@ -145,27 +154,13 @@ module.exports = {
     }
     return this.tok.T_LNUMBER;
   },
-  // read binary
-  consume_BNUM() {
-    let ch;
-    while (this.offset < this.size) {
-      ch = this.input();
-      if (ch !== "0" && ch !== "1" && ch !== "_") {
-        if (ch) this.unput(1);
-        break;
-      }
-    }
-    return this.tok.T_LNUMBER;
+  consume_binary() {
+    return this.consume_prefixed_digits(function () {
+      const ch = this._input[this.offset - 1];
+      return ch === "0" || ch === "1" || ch === "_";
+    });
   },
-  // read an octal number
-  consume_ONUM() {
-    while (this.offset < this.size) {
-      const ch = this.input();
-      if (!this.is_OCTAL()) {
-        if (ch) this.unput(1);
-        break;
-      }
-    }
-    return this.tok.T_LNUMBER;
+  consume_octal() {
+    return this.consume_prefixed_digits(this.is_OCTAL);
   },
 };

--- a/test/snapshot/__snapshots__/number.test.js.snap
+++ b/test/snapshot/__snapshots__/number.test.js.snap
@@ -1,5 +1,98 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`Test numbers binary consecutive underscores 1`] = `
+Program {
+  "children": [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "e",
+        },
+        "operator": "=",
+        "right": Number {
+          "kind": "number",
+          "value": "0b1",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": undefined,
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": [
+    Error {
+      "expected": ";",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '__0' (T_STRING), expecting ';' on line 1",
+      "token": "'__0' (T_STRING)",
+    },
+    Error {
+      "expected": "EXPR",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error on line 1",
+      "token": "the end of file (EOF)",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
+exports[`Test numbers binary trailing underscore 1`] = `
+Program {
+  "children": [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "e",
+        },
+        "operator": "=",
+        "right": Number {
+          "kind": "number",
+          "value": "0b1",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Bin {
+        "kind": "bin",
+        "left": Name {
+          "kind": "name",
+          "name": "_",
+          "resolution": "uqn",
+        },
+        "right": Number {
+          "kind": "number",
+          "value": "1",
+        },
+        "type": "+",
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": [
+    Error {
+      "expected": ";",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '_' (T_STRING), expecting ';' on line 1",
+      "token": "'_' (T_STRING)",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
 exports[`Test numbers binary with 2 1`] = `
 Program {
   "children": [
@@ -138,6 +231,99 @@ Program {
 }
 `;
 
+exports[`Test numbers hex consecutive underscores 1`] = `
+Program {
+  "children": [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "e",
+        },
+        "operator": "=",
+        "right": Number {
+          "kind": "number",
+          "value": "0x1",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": undefined,
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": [
+    Error {
+      "expected": ";",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '__2' (T_STRING), expecting ';' on line 1",
+      "token": "'__2' (T_STRING)",
+    },
+    Error {
+      "expected": "EXPR",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error on line 1",
+      "token": "the end of file (EOF)",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
+exports[`Test numbers hex trailing underscore 1`] = `
+Program {
+  "children": [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "e",
+        },
+        "operator": "=",
+        "right": Number {
+          "kind": "number",
+          "value": "0x1",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Bin {
+        "kind": "bin",
+        "left": Name {
+          "kind": "name",
+          "name": "_",
+          "resolution": "uqn",
+        },
+        "right": Number {
+          "kind": "number",
+          "value": "1",
+        },
+        "type": "+",
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": [
+    Error {
+      "expected": ";",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '_' (T_STRING), expecting ';' on line 1",
+      "token": "'_' (T_STRING)",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
 exports[`Test numbers hexa without hex 1`] = `
 Program {
   "children": [
@@ -216,6 +402,99 @@ Program {
       "line": 1,
       "message": "Parse Error : syntax error, unexpected '.5' (T_DNUMBER), expecting ';' on line 1",
       "token": "'.5' (T_DNUMBER)",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
+exports[`Test numbers octal consecutive underscores 1`] = `
+Program {
+  "children": [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "e",
+        },
+        "operator": "=",
+        "right": Number {
+          "kind": "number",
+          "value": "0o7",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": undefined,
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": [
+    Error {
+      "expected": ";",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '__1' (T_STRING), expecting ';' on line 1",
+      "token": "'__1' (T_STRING)",
+    },
+    Error {
+      "expected": "EXPR",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error on line 1",
+      "token": "the end of file (EOF)",
+    },
+  ],
+  "kind": "program",
+}
+`;
+
+exports[`Test numbers octal trailing underscore 1`] = `
+Program {
+  "children": [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "e",
+        },
+        "operator": "=",
+        "right": Number {
+          "kind": "number",
+          "value": "0o7",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Bin {
+        "kind": "bin",
+        "left": Name {
+          "kind": "name",
+          "name": "_",
+          "resolution": "uqn",
+        },
+        "right": Number {
+          "kind": "number",
+          "value": "1",
+        },
+        "type": "+",
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": [
+    Error {
+      "expected": ";",
+      "kind": "error",
+      "line": 1,
+      "message": "Parse Error : syntax error, unexpected '_' (T_STRING), expecting ';' on line 1",
+      "token": "'_' (T_STRING)",
     },
   ],
   "kind": "program",
@@ -392,6 +671,63 @@ Program {
         "right": Number {
           "kind": "number",
           "value": "7E-10",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+}
+`;
+
+exports[`Test numbers test underscore separators in hex/binary/octal 1`] = `
+Program {
+  "children": [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "a",
+        },
+        "operator": "=",
+        "right": Number {
+          "kind": "number",
+          "value": "0x1_A2_B3",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "b",
+        },
+        "operator": "=",
+        "right": Number {
+          "kind": "number",
+          "value": "0b1010_0101",
+        },
+      },
+      "kind": "expressionstatement",
+    },
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "c",
+        },
+        "operator": "=",
+        "right": Number {
+          "kind": "number",
+          "value": "0o7_6_5",
         },
       },
       "kind": "expressionstatement",

--- a/test/snapshot/number.test.js
+++ b/test/snapshot/number.test.js
@@ -19,6 +19,16 @@ describe("Test numbers", function () {
     ).toMatchSnapshot();
   });
 
+  it("test underscore separators in hex/binary/octal", function () {
+    expect(
+      parser.parseEval(`
+      $a = 0x1_A2_B3;
+      $b = 0b1010_0101;
+      $c = 0o7_6_5;
+    `),
+    ).toMatchSnapshot();
+  });
+
   it.each([
     ["hexa without hex", "$a = 0xx;"],
     ["binary with 2", "$b = 0b2;"],
@@ -33,6 +43,12 @@ describe("Test numbers", function () {
     ["underscore #3", "$e = 7_.0;"],
     ["underscore #4", "$e = 7e_0;"],
     ["underscore #5", "$e = 7_e0;"],
+    ["hex consecutive underscores", "$e = 0x1__2;"],
+    ["hex trailing underscore", "$e = 0x1_ + 1;"],
+    ["binary consecutive underscores", "$e = 0b1__0;"],
+    ["binary trailing underscore", "$e = 0b1_ + 1;"],
+    ["octal consecutive underscores", "$e = 0o7__1;"],
+    ["octal trailing underscore", "$e = 0o7_ + 1;"],
   ])("%s", function (_, code) {
     const ast = parser.parseEval(code, {
       parser: {


### PR DESCRIPTION
This PR fixes the lexer to reject invalid underscore separator usage in prefixed numeric literals (0x…, 0b…, 0o…), matching PHP's actual behavior. Previously, the lexer silently accepted things like 0x1__2 (consecutive underscores) or 0x1_ (trailing underscore) as valid tokens. The PR adds tests for 6 invalid patterns, all of which now correctly produce parse errors instead of being silently accepted.

The four separate consume methods (consume_HNUM, consume_BNUM, consume_ONUM, consume_LNUM) were consolidated:
  - consume_prefixed_digits(isValid) — new shared method that handles the underscore-tracking logic (rejects consecutive __ and trailing _) for all prefixed literals
  - consume_hexadecimal() — thin wrapper calling consume_prefixed_digits(this.is_HEX)
  - consume_binary() — thin wrapper calling consume_prefixed_digits with an inline 0/1/_ check
  - consume_octal() — thin wrapper calling consume_prefixed_digits(this.is_OCTAL)
  - consume_decimal_digits() — rename of consume_LNUM