### PR TITLE
fix: correct unary minus/plus/tilde precedence

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -149,7 +149,7 @@ AST.precedence = {};
   ["<<", ">>"],
   ["+", "-", "."],
   ["*", "/", "%"],
-  ["!"],
+  ["!", "u-", "u+", "u~"], // u- etc. are unary variants; higher than * so -20*5 parses as (-20)*5
   ["instanceof"],
   ["cast", "silent"],
   ["**"],
@@ -300,7 +300,9 @@ AST.prototype.resolvePrecedence = function (result, parser) {
     // https://github.com/glayzzle/php-parser/issues/75
     if (result.what && !result.what.parenthesizedExpression) {
       if (result.what.kind === "bin") {
-        lLevel = AST.precedence[result.type];
+        // use the unary-specific precedence (u-, u+, u~) which is higher than binary - and +
+        lLevel =
+          AST.precedence["u" + result.type] || AST.precedence[result.type];
         rLevel = AST.precedence[result.what.type];
         if (lLevel && rLevel && rLevel < lLevel) {
           buffer = result.what;

--- a/src/ast.js
+++ b/src/ast.js
@@ -147,10 +147,11 @@ AST.precedence = {};
   ["==", "!=", "===", "!==", /* '<>', */ "<=>"],
   ["<", "<=", ">", ">="],
   ["<<", ">>"],
-  ["instanceof"],
   ["+", "-", "."],
   ["*", "/", "%"],
-  ["!", "u-", "u+", "u~"], // u- etc. are unary variants; higher than * so -20*5 parses as (-20)*5
+  ["!"],
+  ["instanceof"],
+  ["u-", "u+", "u~"],
   ["cast", "silent"],
   ["**"],
   // TODO: [ (array)

--- a/src/ast.js
+++ b/src/ast.js
@@ -147,10 +147,10 @@ AST.precedence = {};
   ["==", "!=", "===", "!==", /* '<>', */ "<=>"],
   ["<", "<=", ">", ">="],
   ["<<", ">>"],
+  ["instanceof"],
   ["+", "-", "."],
   ["*", "/", "%"],
   ["!", "u-", "u+", "u~"], // u- etc. are unary variants; higher than * so -20*5 parses as (-20)*5
-  ["instanceof"],
   ["cast", "silent"],
   ["**"],
   // TODO: [ (array)

--- a/test/precedence.test.js
+++ b/test/precedence.test.js
@@ -119,8 +119,8 @@ describe("Test precedence", function () {
     shouldBeSame("5 AND 4 + 3", "5 AND (4 + 3)");
   });
   it("test unary : !", function () {
-    shouldBeSame("!$a instanceof $b", "!($a instanceof $b)");
-    shouldBeSame("!$a + $b instanceof $c", "(!$a) + ($b instanceof $c)");
+    shouldBeSame("!$a instanceof $b", "(!$a) instanceof $b");
+    shouldBeSame("!$a + $b instanceof $c", "((!$a) + $b) instanceof $c");
     shouldBeSame("6 + !4 + 5", "6 + (!4) + 5");
     shouldBeSame("if($a && !$b) {}", "if($a && (!$b)) {}");
   });

--- a/test/precedence.test.js
+++ b/test/precedence.test.js
@@ -61,6 +61,11 @@ describe("Test precedence", function () {
   });
   it("test instanceof", function () {
     shouldBeSame("$a instanceof $b && $c", "($a instanceof $b) && $c");
+    shouldBeSame("$a + $b instanceof $c", "$a + ($b instanceof $c)");
+    shouldBeSame("$a * $b instanceof $c", "$a * ($b instanceof $c)");
+    shouldBeSame("-$a instanceof $b", "(-$a) instanceof $b");
+    shouldBeSame("+$a instanceof $b", "(+$a) instanceof $b");
+    shouldBeSame("~$a instanceof $b", "(~$a) instanceof $b");
   });
   it("test <<", function () {
     shouldBeSame("1 + 3 << 5", "(1 + 3) << 5");
@@ -119,10 +124,14 @@ describe("Test precedence", function () {
     shouldBeSame("5 AND 4 + 3", "5 AND (4 + 3)");
   });
   it("test unary : !", function () {
-    shouldBeSame("!$a instanceof $b", "(!$a) instanceof $b");
-    shouldBeSame("!$a + $b instanceof $c", "((!$a) + $b) instanceof $c");
+    shouldBeSame("!$a instanceof $b", "!($a instanceof $b)");
+    shouldBeSame("!$a + $b instanceof $c", "(!$a) + ($b instanceof $c)");
     shouldBeSame("6 + !4 + 5", "6 + (!4) + 5");
     shouldBeSame("if($a && !$b) {}", "if($a && (!$b)) {}");
+  });
+  it("test unary : - (prettier/plugin-php#2501)", function () {
+    shouldBeSame("5 * -1 + 2", "(5 * (-1)) + 2");
+    shouldBeSame('5 * -1 . "foo"', '(5 * (-1)) . "foo"');
   });
   it("test concat", function () {
     shouldBeSame('"a"."b"."c"."d"', '((("a"."b")."c")."d")');

--- a/test/snapshot/__snapshots__/attributes.test.js.snap
+++ b/test/snapshot/__snapshots__/attributes.test.js.snap
@@ -1591,74 +1591,74 @@ Program {
           "attrs": [
             Attribute {
               "args": [
-                Unary {
-                  "kind": "unary",
-                  "type": "-",
-                  "what": Bin {
+                Bin {
+                  "kind": "bin",
+                  "left": Bin {
                     "kind": "bin",
                     "left": Bin {
                       "kind": "bin",
                       "left": Bin {
                         "kind": "bin",
-                        "left": Bin {
-                          "kind": "bin",
-                          "left": Number {
+                        "left": Unary {
+                          "kind": "unary",
+                          "type": "-",
+                          "what": Number {
                             "kind": "number",
                             "value": "20",
                           },
-                          "right": Unary {
+                        },
+                        "right": Bin {
+                          "kind": "bin",
+                          "left": Unary {
                             "kind": "unary",
-                            "parenthesizedExpression": true,
                             "type": "+",
-                            "what": Bin {
-                              "kind": "bin",
-                              "left": Number {
-                                "kind": "number",
-                                "value": "10",
-                              },
-                              "right": Number {
-                                "kind": "number",
-                                "value": "5",
-                              },
-                              "type": "/",
+                            "what": Number {
+                              "kind": "number",
+                              "value": "10",
                             },
                           },
-                          "type": "*",
+                          "parenthesizedExpression": true,
+                          "right": Number {
+                            "kind": "number",
+                            "value": "5",
+                          },
+                          "type": "/",
                         },
-                        "right": Number {
-                          "kind": "number",
-                          "value": "2",
-                        },
-                        "type": "%",
+                        "type": "*",
                       },
-                      "right": Bin {
-                        "kind": "bin",
-                        "left": Number {
-                          "kind": "number",
-                          "value": "8",
-                        },
-                        "right": Number {
-                          "kind": "number",
-                          "value": "2",
-                        },
-                        "type": "**",
+                      "right": Number {
+                        "kind": "number",
+                        "value": "2",
                       },
-                      "type": "+",
+                      "type": "%",
                     },
-                    "right": Unary {
-                      "kind": "unary",
-                      "type": "+",
-                      "what": Unary {
-                        "kind": "unary",
-                        "type": "-",
-                        "what": Number {
-                          "kind": "number",
-                          "value": "2",
-                        },
+                    "right": Bin {
+                      "kind": "bin",
+                      "left": Number {
+                        "kind": "number",
+                        "value": "8",
                       },
+                      "right": Number {
+                        "kind": "number",
+                        "value": "2",
+                      },
+                      "type": "**",
                     },
-                    "type": "-",
+                    "type": "+",
                   },
+                  "right": Unary {
+                    "kind": "unary",
+                    "type": "+",
+                    "what": Unary {
+                      "kind": "unary",
+                      "type": "-",
+                      "what": Number {
+                        "kind": "number",
+                        "value": "2",
+                      },
+                    },
+                  },
+                  "type": "-",
                 },
               ],
               "kind": "attribute",

--- a/test/snapshot/__snapshots__/unary.test.js.snap
+++ b/test/snapshot/__snapshots__/unary.test.js.snap
@@ -479,6 +479,154 @@ Program {
 }
 `;
 
+exports[`Test unary precedence over add 1`] = `
+Program {
+  "children": [
+    ExpressionStatement {
+      "expression": Bin {
+        "kind": "bin",
+        "left": Unary {
+          "kind": "unary",
+          "type": "-",
+          "what": Number {
+            "kind": "number",
+            "value": "20",
+          },
+        },
+        "right": Number {
+          "kind": "number",
+          "value": "5",
+        },
+        "type": "+",
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary precedence over mul 1`] = `
+Program {
+  "children": [
+    ExpressionStatement {
+      "expression": Bin {
+        "kind": "bin",
+        "left": Unary {
+          "kind": "unary",
+          "type": "-",
+          "what": Number {
+            "kind": "number",
+            "value": "20",
+          },
+        },
+        "right": Number {
+          "kind": "number",
+          "value": "5",
+        },
+        "type": "*",
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary precedence over mul and add 1`] = `
+Program {
+  "children": [
+    ExpressionStatement {
+      "expression": Bin {
+        "kind": "bin",
+        "left": Bin {
+          "kind": "bin",
+          "left": Unary {
+            "kind": "unary",
+            "type": "-",
+            "what": Number {
+              "kind": "number",
+              "value": "20",
+            },
+          },
+          "right": Number {
+            "kind": "number",
+            "value": "5",
+          },
+          "type": "*",
+        },
+        "right": Number {
+          "kind": "number",
+          "value": "10",
+        },
+        "type": "+",
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary precedence with plus 1`] = `
+Program {
+  "children": [
+    ExpressionStatement {
+      "expression": Bin {
+        "kind": "bin",
+        "left": Unary {
+          "kind": "unary",
+          "type": "+",
+          "what": Number {
+            "kind": "number",
+            "value": "20",
+          },
+        },
+        "right": Number {
+          "kind": "number",
+          "value": "5",
+        },
+        "type": "*",
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+}
+`;
+
+exports[`Test unary precedence with tilde 1`] = `
+Program {
+  "children": [
+    ExpressionStatement {
+      "expression": Bin {
+        "kind": "bin",
+        "left": Unary {
+          "kind": "unary",
+          "type": "~",
+          "what": Number {
+            "kind": "number",
+            "value": "20",
+          },
+        },
+        "right": Number {
+          "kind": "number",
+          "value": "5",
+        },
+        "type": "*",
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+}
+`;
+
 exports[`Test unary simple 1`] = `
 Program {
   "children": [

--- a/test/snapshot/unary.test.js
+++ b/test/snapshot/unary.test.js
@@ -28,6 +28,11 @@ describe("Test unary", function () {
     ["parens (8)", "(~$var);"],
     ["parens (9)", "(-100);"],
     ["parens (10)", "-(100);"],
+    ["precedence over mul", "-20 * 5;"],
+    ["precedence over add", "-20 + 5;"],
+    ["precedence over mul and add", "-20 * 5 + 10;"],
+    ["precedence with plus", "+20 * 5;"],
+    ["precedence with tilde", "~20 * 5;"],
   ])("%s", function (_, code) {
     expect(parser.parseEval(code)).toMatchSnapshot();
   });


### PR DESCRIPTION
Unary -, +, and ~ shared the same precedence key as binary - and + (level 15), placing them below * (level 16). This caused -20 * 5 + 10 to be parsed as -(20 * 5 + 10) instead of (-20) * 5 + 10.

Add u-, u+, u~ keys to the precedence table at the ! level (17) and look them up in resolvePrecedence so unary operators correctly bind tighter than multiplicative operators.