### PR TITLE
Add missing PHP 8.5 syntax support

### DIFF
--- a/src/ast/clone.js
+++ b/src/ast/clone.js
@@ -16,15 +16,13 @@ const KIND = "clone";
  * @property {Expression} what
  * @property {Expression|null} properties
  */
-module.exports = Expression.extends(KIND, function Clone(
-  what,
-  properties,
-  docs,
-  location,
-) {
-  Expression.apply(this, [KIND, docs, location]);
-  this.what = what;
-  if (properties) {
-    this.properties = properties;
-  }
-});
+module.exports = Expression.extends(
+  KIND,
+  function Clone(what, properties, docs, location) {
+    Expression.apply(this, [KIND, docs, location]);
+    this.what = what;
+    if (properties) {
+      this.properties = properties;
+    }
+  },
+);

--- a/src/ast/clone.js
+++ b/src/ast/clone.js
@@ -14,8 +14,17 @@ const KIND = "clone";
  * @memberOf module:php-parser
  * @extends {Expression}
  * @property {Expression} what
+ * @property {Expression|null} properties
  */
-module.exports = Expression.extends(KIND, function Clone(what, docs, location) {
+module.exports = Expression.extends(KIND, function Clone(
+  what,
+  properties,
+  docs,
+  location,
+) {
   Expression.apply(this, [KIND, docs, location]);
   this.what = what;
+  if (properties) {
+    this.properties = properties;
+  }
 });

--- a/src/lexer/attribute.js
+++ b/src/lexer/attribute.js
@@ -32,6 +32,7 @@ module.exports = {
       case ")":
       case ":":
       case "=":
+      case ";":
       case "|":
       case "&":
       case "^":
@@ -44,6 +45,9 @@ module.exports = {
       case ">":
       case "!":
       case ".":
+      case "{":
+      case "}":
+      case "$":
         return this.consume_TOKEN();
       case "[":
         this.attributeListDepth[this.attributeIndex]++;

--- a/src/parser/expr.js
+++ b/src/parser/expr.js
@@ -130,7 +130,13 @@ module.exports = {
       if (this.version < 805) {
         this.raiseError("PHP 8.5+ is required to use pipe operator");
       }
-      return result("bin", "|>", expr, this.next().read_expr());
+      const right = this.next().read_expr();
+      if (right.kind === "arrowfunc" && !right.parenthesizedExpression) {
+        this.raiseError(
+          "Arrow functions in a pipe chain must be wrapped in parentheses",
+        );
+      }
+      return result("bin", "|>", expr, right);
     }
 
     // extra operations :

--- a/src/parser/expr.js
+++ b/src/parser/expr.js
@@ -353,7 +353,19 @@ module.exports = {
     }
 
     if (this.token === this.tok.T_CLONE) {
-      return this.node("clone")(this.next().read_expr());
+      const node = this.node("clone");
+      this.next();
+      if (this.version >= 805 && this.token === "(") {
+        this.next();
+        const what = this.read_expr();
+        let properties = null;
+        if (this.token === ",") {
+          properties = this.next().read_expr();
+        }
+        this.expect(")") && this.next();
+        return node(what, properties);
+      }
+      return node(this.read_expr(), null);
     }
 
     switch (this.token) {

--- a/test/snapshot/__snapshots__/attributes.test.js.snap
+++ b/test/snapshot/__snapshots__/attributes.test.js.snap
@@ -490,6 +490,65 @@ Program {
 }
 `;
 
+exports[`Parse Attributes can parse closures in attribute constant expressions in PHP 8.5 1`] = `
+Program {
+  "children": [
+    _Function {
+      "arguments": [],
+      "attrGroups": [
+        AttrGroup {
+          "attrs": [
+            Attribute {
+              "args": [
+                Closure {
+                  "arguments": [],
+                  "attrGroups": [],
+                  "body": Block {
+                    "children": [
+                      Return {
+                        "expr": Number {
+                          "kind": "number",
+                          "value": "1",
+                        },
+                        "kind": "return",
+                      },
+                    ],
+                    "kind": "block",
+                  },
+                  "byref": false,
+                  "isStatic": true,
+                  "kind": "closure",
+                  "nullable": false,
+                  "type": null,
+                  "uses": [],
+                },
+              ],
+              "kind": "attribute",
+              "name": "A",
+            },
+          ],
+          "kind": "attrgroup",
+        },
+      ],
+      "body": Block {
+        "children": [],
+        "kind": "block",
+      },
+      "byref": false,
+      "kind": "function",
+      "name": Identifier {
+        "kind": "identifier",
+        "name": "a",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+}
+`;
+
 exports[`Parse Attributes can parse enum attributes 1`] = `
 Program {
   "children": [

--- a/test/snapshot/__snapshots__/clone.test.js.snap
+++ b/test/snapshot/__snapshots__/clone.test.js.snap
@@ -48,3 +48,80 @@ Program {
   "kind": "program",
 }
 `;
+
+exports[`clone with property overrides 1`] = `
+Program {
+  "children": [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "name": "var",
+        },
+        "operator": "=",
+        "right": Clone {
+          "kind": "clone",
+          "properties": Array {
+            "items": [
+              Entry {
+                "byRef": false,
+                "key": String {
+                  "isDoubleQuote": true,
+                  "kind": "string",
+                  "raw": ""name"",
+                  "unicode": false,
+                  "value": "name",
+                },
+                "kind": "entry",
+                "unpack": false,
+                "value": Variable {
+                  "curly": false,
+                  "kind": "variable",
+                  "name": "name",
+                },
+              },
+              Entry {
+                "byRef": false,
+                "key": String {
+                  "isDoubleQuote": true,
+                  "kind": "string",
+                  "raw": ""id"",
+                  "unicode": false,
+                  "value": "id",
+                },
+                "kind": "entry",
+                "unpack": false,
+                "value": Call {
+                  "arguments": [
+                    VariadicPlaceholder {
+                      "kind": "variadicplaceholder",
+                    },
+                  ],
+                  "kind": "call",
+                  "what": Name {
+                    "kind": "name",
+                    "name": "getId",
+                    "resolution": "uqn",
+                  },
+                },
+              },
+            ],
+            "kind": "array",
+            "shortForm": true,
+          },
+          "what": Variable {
+            "curly": false,
+            "kind": "variable",
+            "name": "obj",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+}
+`;

--- a/test/snapshot/__snapshots__/location.test.js.snap
+++ b/test/snapshot/__snapshots__/location.test.js.snap
@@ -4116,6 +4116,467 @@ Program {
 }
 `;
 
+exports[`Test locations test clone with in PHP 8.5 1`] = `
+Program {
+  "children": [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "loc": Location {
+            "end": Position {
+              "column": 4,
+              "line": 1,
+              "offset": 4,
+            },
+            "source": "$var",
+            "start": Position {
+              "column": 0,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "name": "var",
+        },
+        "loc": Location {
+          "end": Position {
+            "column": 58,
+            "line": 1,
+            "offset": 58,
+          },
+          "source": "$var = clone($obj, ["name" => $name, "id" => getId(...)]);",
+          "start": Position {
+            "column": 0,
+            "line": 1,
+            "offset": 0,
+          },
+        },
+        "operator": "=",
+        "right": Clone {
+          "kind": "clone",
+          "loc": Location {
+            "end": Position {
+              "column": 57,
+              "line": 1,
+              "offset": 57,
+            },
+            "source": "clone($obj, ["name" => $name, "id" => getId(...)])",
+            "start": Position {
+              "column": 7,
+              "line": 1,
+              "offset": 7,
+            },
+          },
+          "properties": Array {
+            "items": [
+              Entry {
+                "byRef": false,
+                "key": String {
+                  "isDoubleQuote": true,
+                  "kind": "string",
+                  "loc": Location {
+                    "end": Position {
+                      "column": 26,
+                      "line": 1,
+                      "offset": 26,
+                    },
+                    "source": ""name"",
+                    "start": Position {
+                      "column": 20,
+                      "line": 1,
+                      "offset": 20,
+                    },
+                  },
+                  "raw": ""name"",
+                  "unicode": false,
+                  "value": "name",
+                },
+                "kind": "entry",
+                "loc": Location {
+                  "end": Position {
+                    "column": 35,
+                    "line": 1,
+                    "offset": 35,
+                  },
+                  "source": ""name" => $name",
+                  "start": Position {
+                    "column": 20,
+                    "line": 1,
+                    "offset": 20,
+                  },
+                },
+                "unpack": false,
+                "value": Variable {
+                  "curly": false,
+                  "kind": "variable",
+                  "loc": Location {
+                    "end": Position {
+                      "column": 35,
+                      "line": 1,
+                      "offset": 35,
+                    },
+                    "source": "$name",
+                    "start": Position {
+                      "column": 30,
+                      "line": 1,
+                      "offset": 30,
+                    },
+                  },
+                  "name": "name",
+                },
+              },
+              Entry {
+                "byRef": false,
+                "key": String {
+                  "isDoubleQuote": true,
+                  "kind": "string",
+                  "loc": Location {
+                    "end": Position {
+                      "column": 41,
+                      "line": 1,
+                      "offset": 41,
+                    },
+                    "source": ""id"",
+                    "start": Position {
+                      "column": 37,
+                      "line": 1,
+                      "offset": 37,
+                    },
+                  },
+                  "raw": ""id"",
+                  "unicode": false,
+                  "value": "id",
+                },
+                "kind": "entry",
+                "loc": Location {
+                  "end": Position {
+                    "column": 55,
+                    "line": 1,
+                    "offset": 55,
+                  },
+                  "source": ""id" => getId(...)",
+                  "start": Position {
+                    "column": 37,
+                    "line": 1,
+                    "offset": 37,
+                  },
+                },
+                "unpack": false,
+                "value": Call {
+                  "arguments": [
+                    VariadicPlaceholder {
+                      "kind": "variadicplaceholder",
+                      "loc": Location {
+                        "end": Position {
+                          "column": 51,
+                          "line": 1,
+                          "offset": 51,
+                        },
+                        "source": "",
+                        "start": Position {
+                          "column": 51,
+                          "line": 1,
+                          "offset": 51,
+                        },
+                      },
+                    },
+                  ],
+                  "kind": "call",
+                  "loc": Location {
+                    "end": Position {
+                      "column": 55,
+                      "line": 1,
+                      "offset": 55,
+                    },
+                    "source": "getId(...)",
+                    "start": Position {
+                      "column": 45,
+                      "line": 1,
+                      "offset": 45,
+                    },
+                  },
+                  "what": Name {
+                    "kind": "name",
+                    "loc": Location {
+                      "end": Position {
+                        "column": 50,
+                        "line": 1,
+                        "offset": 50,
+                      },
+                      "source": "getId",
+                      "start": Position {
+                        "column": 45,
+                        "line": 1,
+                        "offset": 45,
+                      },
+                    },
+                    "name": "getId",
+                    "resolution": "uqn",
+                  },
+                },
+              },
+            ],
+            "kind": "array",
+            "loc": Location {
+              "end": Position {
+                "column": 56,
+                "line": 1,
+                "offset": 56,
+              },
+              "source": "["name" => $name, "id" => getId(...)]",
+              "start": Position {
+                "column": 19,
+                "line": 1,
+                "offset": 19,
+              },
+            },
+            "shortForm": true,
+          },
+          "what": Variable {
+            "curly": false,
+            "kind": "variable",
+            "loc": Location {
+              "end": Position {
+                "column": 17,
+                "line": 1,
+                "offset": 17,
+              },
+              "source": "$obj",
+              "start": Position {
+                "column": 13,
+                "line": 1,
+                "offset": 13,
+              },
+            },
+            "name": "obj",
+          },
+        },
+      },
+      "kind": "expressionstatement",
+      "loc": Location {
+        "end": Position {
+          "column": 58,
+          "line": 1,
+          "offset": 58,
+        },
+        "source": "$var = clone($obj, ["name" => $name, "id" => getId(...)]);",
+        "start": Position {
+          "column": 0,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+  "loc": Location {
+    "end": Position {
+      "column": 58,
+      "line": 1,
+      "offset": 58,
+    },
+    "source": "$var = clone($obj, ["name" => $name, "id" => getId(...)]);",
+    "start": Position {
+      "column": 0,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+}
+`;
+
+exports[`Test locations test closures in attribute constant expressions in PHP 8.5 1`] = `
+Program {
+  "children": [
+    _Function {
+      "arguments": [],
+      "attrGroups": [
+        AttrGroup {
+          "attrs": [
+            Attribute {
+              "args": [
+                Closure {
+                  "arguments": [],
+                  "attrGroups": [],
+                  "body": Block {
+                    "children": [
+                      Return {
+                        "expr": Number {
+                          "kind": "number",
+                          "loc": Location {
+                            "end": Position {
+                              "column": 33,
+                              "line": 1,
+                              "offset": 33,
+                            },
+                            "source": "1",
+                            "start": Position {
+                              "column": 32,
+                              "line": 1,
+                              "offset": 32,
+                            },
+                          },
+                          "value": "1",
+                        },
+                        "kind": "return",
+                        "loc": Location {
+                          "end": Position {
+                            "column": 34,
+                            "line": 1,
+                            "offset": 34,
+                          },
+                          "source": "return 1;",
+                          "start": Position {
+                            "column": 25,
+                            "line": 1,
+                            "offset": 25,
+                          },
+                        },
+                      },
+                    ],
+                    "kind": "block",
+                    "loc": Location {
+                      "end": Position {
+                        "column": 36,
+                        "line": 1,
+                        "offset": 36,
+                      },
+                      "source": "{ return 1; }",
+                      "start": Position {
+                        "column": 23,
+                        "line": 1,
+                        "offset": 23,
+                      },
+                    },
+                  },
+                  "byref": false,
+                  "isStatic": true,
+                  "kind": "closure",
+                  "loc": Location {
+                    "end": Position {
+                      "column": 36,
+                      "line": 1,
+                      "offset": 36,
+                    },
+                    "source": "function ()",
+                    "start": Position {
+                      "column": 11,
+                      "line": 1,
+                      "offset": 11,
+                    },
+                  },
+                  "nullable": false,
+                  "type": null,
+                  "uses": [],
+                },
+              ],
+              "kind": "attribute",
+              "loc": Location {
+                "end": Position {
+                  "column": 37,
+                  "line": 1,
+                  "offset": 37,
+                },
+                "source": "A(static function () { return 1; })",
+                "start": Position {
+                  "column": 2,
+                  "line": 1,
+                  "offset": 2,
+                },
+              },
+              "name": "A",
+            },
+          ],
+          "kind": "attrgroup",
+          "loc": Location {
+            "end": Position {
+              "column": 38,
+              "line": 1,
+              "offset": 38,
+            },
+            "source": "#[A(static function () { return 1; })]",
+            "start": Position {
+              "column": 0,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+        },
+      ],
+      "body": Block {
+        "children": [],
+        "kind": "block",
+        "loc": Location {
+          "end": Position {
+            "column": 54,
+            "line": 1,
+            "offset": 54,
+          },
+          "source": "{}",
+          "start": Position {
+            "column": 52,
+            "line": 1,
+            "offset": 52,
+          },
+        },
+      },
+      "byref": false,
+      "kind": "function",
+      "loc": Location {
+        "end": Position {
+          "column": 54,
+          "line": 1,
+          "offset": 54,
+        },
+        "source": "function a()",
+        "start": Position {
+          "column": 39,
+          "line": 1,
+          "offset": 39,
+        },
+      },
+      "name": Identifier {
+        "kind": "identifier",
+        "loc": Location {
+          "end": Position {
+            "column": 49,
+            "line": 1,
+            "offset": 49,
+          },
+          "source": "a",
+          "start": Position {
+            "column": 48,
+            "line": 1,
+            "offset": 48,
+          },
+        },
+        "name": "a",
+      },
+      "nullable": false,
+      "type": null,
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+  "loc": Location {
+    "end": Position {
+      "column": 54,
+      "line": 1,
+      "offset": 54,
+    },
+    "source": "#[A(static function () { return 1; })] function a() {}",
+    "start": Position {
+      "column": 0,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+}
+`;
+
 exports[`Test locations test conststatement 1`] = `
 Program {
   "children": [
@@ -11126,6 +11587,323 @@ Program {
       "offset": 33,
     },
     "source": "function foo(?int $foo = 2112) {}",
+    "start": Position {
+      "column": 0,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+}
+`;
+
+exports[`Test locations test pipe with parenthesized arrow function in PHP 8.5 1`] = `
+Program {
+  "children": [
+    ExpressionStatement {
+      "expression": Assign {
+        "kind": "assign",
+        "left": Variable {
+          "curly": false,
+          "kind": "variable",
+          "loc": Location {
+            "end": Position {
+              "column": 2,
+              "line": 1,
+              "offset": 2,
+            },
+            "source": "$c",
+            "start": Position {
+              "column": 0,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "name": "c",
+        },
+        "loc": Location {
+          "end": Position {
+            "column": 62,
+            "line": 1,
+            "offset": 62,
+          },
+          "source": "$c = $a |> (fn ($s) => explode(",", $s)) |> array_filter(...);",
+          "start": Position {
+            "column": 0,
+            "line": 1,
+            "offset": 0,
+          },
+        },
+        "operator": "=",
+        "right": Bin {
+          "kind": "bin",
+          "left": Variable {
+            "curly": false,
+            "kind": "variable",
+            "loc": Location {
+              "end": Position {
+                "column": 7,
+                "line": 1,
+                "offset": 7,
+              },
+              "source": "$a",
+              "start": Position {
+                "column": 5,
+                "line": 1,
+                "offset": 5,
+              },
+            },
+            "name": "a",
+          },
+          "loc": Location {
+            "end": Position {
+              "column": 61,
+              "line": 1,
+              "offset": 61,
+            },
+            "source": "$a |> (fn ($s) => explode(",", $s)) |> array_filter(...)",
+            "start": Position {
+              "column": 5,
+              "line": 1,
+              "offset": 5,
+            },
+          },
+          "right": Bin {
+            "kind": "bin",
+            "left": Closure {
+              "arguments": [
+                Parameter {
+                  "attrGroups": [],
+                  "byref": false,
+                  "flags": 0,
+                  "hooks": [],
+                  "kind": "parameter",
+                  "loc": Location {
+                    "end": Position {
+                      "column": 18,
+                      "line": 1,
+                      "offset": 18,
+                    },
+                    "source": "$s",
+                    "start": Position {
+                      "column": 16,
+                      "line": 1,
+                      "offset": 16,
+                    },
+                  },
+                  "name": Identifier {
+                    "kind": "identifier",
+                    "loc": Location {
+                      "end": Position {
+                        "column": 18,
+                        "line": 1,
+                        "offset": 18,
+                      },
+                      "source": "$s",
+                      "start": Position {
+                        "column": 16,
+                        "line": 1,
+                        "offset": 16,
+                      },
+                    },
+                    "name": "s",
+                  },
+                  "nullable": false,
+                  "readonly": false,
+                  "type": null,
+                  "value": null,
+                  "variadic": false,
+                },
+              ],
+              "attrGroups": [],
+              "body": Call {
+                "arguments": [
+                  String {
+                    "isDoubleQuote": true,
+                    "kind": "string",
+                    "loc": Location {
+                      "end": Position {
+                        "column": 34,
+                        "line": 1,
+                        "offset": 34,
+                      },
+                      "source": "","",
+                      "start": Position {
+                        "column": 31,
+                        "line": 1,
+                        "offset": 31,
+                      },
+                    },
+                    "raw": "","",
+                    "unicode": false,
+                    "value": ",",
+                  },
+                  Variable {
+                    "curly": false,
+                    "kind": "variable",
+                    "loc": Location {
+                      "end": Position {
+                        "column": 38,
+                        "line": 1,
+                        "offset": 38,
+                      },
+                      "source": "$s",
+                      "start": Position {
+                        "column": 36,
+                        "line": 1,
+                        "offset": 36,
+                      },
+                    },
+                    "name": "s",
+                  },
+                ],
+                "kind": "call",
+                "loc": Location {
+                  "end": Position {
+                    "column": 39,
+                    "line": 1,
+                    "offset": 39,
+                  },
+                  "source": "explode(",", $s)",
+                  "start": Position {
+                    "column": 23,
+                    "line": 1,
+                    "offset": 23,
+                  },
+                },
+                "what": Name {
+                  "kind": "name",
+                  "loc": Location {
+                    "end": Position {
+                      "column": 30,
+                      "line": 1,
+                      "offset": 30,
+                    },
+                    "source": "explode",
+                    "start": Position {
+                      "column": 23,
+                      "line": 1,
+                      "offset": 23,
+                    },
+                  },
+                  "name": "explode",
+                  "resolution": "uqn",
+                },
+              },
+              "byref": false,
+              "isStatic": false,
+              "kind": "arrowfunc",
+              "loc": Location {
+                "end": Position {
+                  "column": 39,
+                  "line": 1,
+                  "offset": 39,
+                },
+                "source": "fn ($s) => explode(",", $s)",
+                "start": Position {
+                  "column": 12,
+                  "line": 1,
+                  "offset": 12,
+                },
+              },
+              "nullable": false,
+              "parenthesizedExpression": true,
+              "type": null,
+            },
+            "loc": Location {
+              "end": Position {
+                "column": 61,
+                "line": 1,
+                "offset": 61,
+              },
+              "source": "(fn ($s) => explode(",", $s)) |> array_filter(...)",
+              "start": Position {
+                "column": 11,
+                "line": 1,
+                "offset": 11,
+              },
+            },
+            "right": Call {
+              "arguments": [
+                VariadicPlaceholder {
+                  "kind": "variadicplaceholder",
+                  "loc": Location {
+                    "end": Position {
+                      "column": 57,
+                      "line": 1,
+                      "offset": 57,
+                    },
+                    "source": "",
+                    "start": Position {
+                      "column": 57,
+                      "line": 1,
+                      "offset": 57,
+                    },
+                  },
+                },
+              ],
+              "kind": "call",
+              "loc": Location {
+                "end": Position {
+                  "column": 61,
+                  "line": 1,
+                  "offset": 61,
+                },
+                "source": "array_filter(...)",
+                "start": Position {
+                  "column": 44,
+                  "line": 1,
+                  "offset": 44,
+                },
+              },
+              "what": Name {
+                "kind": "name",
+                "loc": Location {
+                  "end": Position {
+                    "column": 56,
+                    "line": 1,
+                    "offset": 56,
+                  },
+                  "source": "array_filter",
+                  "start": Position {
+                    "column": 44,
+                    "line": 1,
+                    "offset": 44,
+                  },
+                },
+                "name": "array_filter",
+                "resolution": "uqn",
+              },
+            },
+            "type": "|>",
+          },
+          "type": "|>",
+        },
+      },
+      "kind": "expressionstatement",
+      "loc": Location {
+        "end": Position {
+          "column": 62,
+          "line": 1,
+          "offset": 62,
+        },
+        "source": "$c = $a |> (fn ($s) => explode(",", $s)) |> array_filter(...);",
+        "start": Position {
+          "column": 0,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+    },
+  ],
+  "errors": [],
+  "kind": "program",
+  "loc": Location {
+    "end": Position {
+      "column": 62,
+      "line": 1,
+      "offset": 62,
+    },
+    "source": "$c = $a |> (fn ($s) => explode(",", $s)) |> array_filter(...);",
     "start": Position {
       "column": 0,
       "line": 1,

--- a/test/snapshot/__snapshots__/pipe.test.js.snap
+++ b/test/snapshot/__snapshots__/pipe.test.js.snap
@@ -19,29 +19,29 @@ Program {
             "kind": "variable",
             "name": "a",
           },
-          "right": Closure {
-            "arguments": [
-              Parameter {
-                "attrGroups": [],
-                "byref": false,
-                "flags": 0,
-                "hooks": [],
-                "kind": "parameter",
-                "name": Identifier {
-                  "kind": "identifier",
-                  "name": "s",
+          "right": Bin {
+            "kind": "bin",
+            "left": Closure {
+              "arguments": [
+                Parameter {
+                  "attrGroups": [],
+                  "byref": false,
+                  "flags": 0,
+                  "hooks": [],
+                  "kind": "parameter",
+                  "name": Identifier {
+                    "kind": "identifier",
+                    "name": "s",
+                  },
+                  "nullable": false,
+                  "readonly": false,
+                  "type": null,
+                  "value": null,
+                  "variadic": false,
                 },
-                "nullable": false,
-                "readonly": false,
-                "type": null,
-                "value": null,
-                "variadic": false,
-              },
-            ],
-            "attrGroups": [],
-            "body": Bin {
-              "kind": "bin",
-              "left": Call {
+              ],
+              "attrGroups": [],
+              "body": Call {
                 "arguments": [
                   String {
                     "isDoubleQuote": true,
@@ -63,37 +63,38 @@ Program {
                   "resolution": "uqn",
                 },
               },
-              "right": Bin {
-                "kind": "bin",
-                "left": Call {
-                  "arguments": [
-                    VariadicPlaceholder {
-                      "kind": "variadicplaceholder",
-                    },
-                  ],
-                  "kind": "call",
-                  "what": Name {
-                    "kind": "name",
-                    "name": "array_filter",
-                    "resolution": "uqn",
+              "byref": false,
+              "isStatic": false,
+              "kind": "arrowfunc",
+              "nullable": false,
+              "parenthesizedExpression": true,
+              "type": null,
+            },
+            "right": Bin {
+              "kind": "bin",
+              "left": Call {
+                "arguments": [
+                  VariadicPlaceholder {
+                    "kind": "variadicplaceholder",
                   },
+                ],
+                "kind": "call",
+                "what": Name {
+                  "kind": "name",
+                  "name": "array_filter",
+                  "resolution": "uqn",
                 },
-                "right": String {
-                  "isDoubleQuote": false,
-                  "kind": "string",
-                  "raw": "'array_last'",
-                  "unicode": false,
-                  "value": "array_last",
-                },
-                "type": "|>",
+              },
+              "right": String {
+                "isDoubleQuote": false,
+                "kind": "string",
+                "raw": "'array_last'",
+                "unicode": false,
+                "value": "array_last",
               },
               "type": "|>",
             },
-            "byref": false,
-            "isStatic": false,
-            "kind": "arrowfunc",
-            "nullable": false,
-            "type": null,
+            "type": "|>",
           },
           "type": "|>",
         },
@@ -105,3 +106,5 @@ Program {
   "kind": "program",
 }
 `;
+
+exports[`Parse Pipeline Operator requires parentheses around arrow functions in a pipe chain 1`] = `"Arrow functions in a pipe chain must be wrapped in parentheses on line 4"`;

--- a/test/snapshot/attributes.test.js
+++ b/test/snapshot/attributes.test.js
@@ -339,4 +339,16 @@ describe("Parse Attributes", () => {
       ),
     ).toMatchSnapshot();
   });
+
+  it("can parse closures in attribute constant expressions in PHP 8.5", () => {
+    expect(
+      parser.parseEval(
+        `
+    #[A(static function () { return 1; })]
+    function a() {}
+    `,
+        { parser: { version: "8.5" } },
+      ),
+    ).toMatchSnapshot();
+  });
 });

--- a/test/snapshot/clone.test.js
+++ b/test/snapshot/clone.test.js
@@ -10,7 +10,7 @@ describe("clone", function () {
   it("with property overrides", function () {
     expect(
       parser.parseEval(
-        "$var = clone($obj, [\"name\" => $name, \"id\" => getId(...)]);",
+        '$var = clone($obj, ["name" => $name, "id" => getId(...)]);',
         {
           parser: {
             version: "8.5",

--- a/test/snapshot/clone.test.js
+++ b/test/snapshot/clone.test.js
@@ -7,4 +7,16 @@ describe("clone", function () {
   it("assign", function () {
     expect(parser.parseEval("$var = clone $obj;")).toMatchSnapshot();
   });
+  it("with property overrides", function () {
+    expect(
+      parser.parseEval(
+        "$var = clone($obj, [\"name\" => $name, \"id\" => getId(...)]);",
+        {
+          parser: {
+            version: "8.5",
+          },
+        },
+      ),
+    ).toMatchSnapshot();
+  });
 });

--- a/test/snapshot/location.test.js
+++ b/test/snapshot/location.test.js
@@ -267,4 +267,55 @@ string";`,
       }),
     ).toMatchSnapshot();
   });
+
+  it("test clone with in PHP 8.5", function () {
+    expect(
+      parser.parseEval(
+        `$var = clone($obj, ["name" => $name, "id" => getId(...)]);`,
+        {
+          parser: {
+            version: "8.5",
+          },
+          ast: {
+            withPositions: true,
+            withSource: true,
+          },
+        },
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("test pipe with parenthesized arrow function in PHP 8.5", function () {
+    expect(
+      parser.parseEval(
+        `$c = $a |> (fn ($s) => explode(",", $s)) |> array_filter(...);`,
+        {
+          parser: {
+            version: "8.5",
+          },
+          ast: {
+            withPositions: true,
+            withSource: true,
+          },
+        },
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("test closures in attribute constant expressions in PHP 8.5", function () {
+    expect(
+      parser.parseEval(
+        `#[A(static function () { return 1; })] function a() {}`,
+        {
+          parser: {
+            version: "8.5",
+          },
+          ast: {
+            withPositions: true,
+            withSource: true,
+          },
+        },
+      ),
+    ).toMatchSnapshot();
+  });
 });

--- a/test/snapshot/pipe.test.js
+++ b/test/snapshot/pipe.test.js
@@ -10,9 +10,25 @@ describe("Parse Pipeline Operator", () => {
     expect(
       parser8_5.parseEval(`
     $c = $a 
-      |> fn ($s) => explode(",", $s) 
+      |> (fn ($s) => explode(",", $s))
       |> array_filter(...) |> 'array_last' ;
     `),
     ).toMatchSnapshot();
+  });
+
+  it("requires parentheses around arrow functions in a pipe chain", () => {
+    const parser8_5 = parser.create({
+      parser: {
+        version: "8.5",
+      },
+    });
+
+    expect(() =>
+      parser8_5.parseEval(`
+    $c = $a
+      |> fn ($s) => explode(",", $s)
+      |> array_filter(...);
+    `),
+    ).toThrowErrorMatchingSnapshot();
   });
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,27 +1,27 @@
 declare module "php-parser" {
   /**
-   * Defines an array structure
-   * @example
-   * // PHP code :
-   * [1, 'foo' => 'bar', 3]
-   *
-   * // AST structure :
-   * {
-   *  "kind": "array",
-   *  "shortForm": true
-   *  "items": [
-   *    {"kind": "number", "value": "1"},
-   *    {
-   *      "kind": "entry",
-   *      "key": {"kind": "string", "value": "foo", "isDoubleQuote": false},
-   *      "value": {"kind": "string", "value": "bar", "isDoubleQuote": false}
-   *    },
-   *    {"kind": "number", "value": "3"}
-   *  ]
-   * }
-   * @property items - List of array items
-   * @property shortForm - Indicate if the short array syntax is used, ex `[]` instead `array()`
-   */
+     * Defines an array structure
+     * @example
+     * // PHP code :
+    [1, 'foo' => 'bar', 3]
+    
+    // AST structure :
+    {
+     "kind": "array",
+     "shortForm": true
+     "items": [
+       {"kind": "number", "value": "1"},
+       {
+         "kind": "entry",
+         "key": {"kind": "string", "value": "foo", "isDoubleQuote": false},
+         "value": {"kind": "string", "value": "bar", "isDoubleQuote": false}
+       },
+       {"kind": "number", "value": "3"}
+     ]
+    }
+     * @property items - List of array items
+     * @property shortForm - Indicate if the short array syntax is used, ex `[]` instead `array()`
+     */
   class Array extends Expression {
     /**
      * List of array items
@@ -169,7 +169,7 @@ declare module "php-parser" {
    */
   class Clone extends Expression {
     what: Expression;
-    properties?: Expression | null;
+    properties: Expression | null;
   }
   /**
    * Defines a closure
@@ -232,37 +232,37 @@ declare module "php-parser" {
    */
   class Declare extends Block {
     /**
-     * The node is declared as a short tag syntax :
-     * ```php
-     * <?php
-     * declare(ticks=1):
-     * // some statements
-     * enddeclare;
-     * ```
-     */
+         * The node is declared as a short tag syntax :
+        ```php
+        <?php
+        declare(ticks=1):
+        // some statements
+        enddeclare;
+        ```
+         */
     readonly MODE_SHORT: string;
     /**
-     * The node is declared bracket enclosed code :
-     * ```php
-     * <?php
-     * declare(ticks=1) {
-     * // some statements
-     * }
-     * ```
-     */
+         * The node is declared bracket enclosed code :
+        ```php
+        <?php
+        declare(ticks=1) {
+        // some statements
+        }
+        ```
+         */
     readonly MODE_BLOCK: string;
     /**
-     * The node is declared as a simple statement. In order to make things simpler
-     * children of the node are automatically collected until the next
-     * declare statement.
-     * ```php
-     * <?php
-     * declare(ticks=1);
-     * // some statements
-     * declare(ticks=2);
-     * // some statements
-     * ```
-     */
+         * The node is declared as a simple statement. In order to make things simpler
+        children of the node are automatically collected until the next
+        declare statement.
+        ```php
+        <?php
+        declare(ticks=1);
+        // some statements
+        declare(ticks=2);
+        // some statements
+        ```
+         */
     readonly MODE_NONE: string;
     directives: DeclareDirective[];
     mode: string;
@@ -301,39 +301,39 @@ declare module "php-parser" {
    */
   class Encapsed extends Literal {
     /**
-     * The node is a double quote string :
-     * ```php
-     * <?php
-     * echo "hello $world";
-     * ```
-     */
+         * The node is a double quote string :
+        ```php
+        <?php
+        echo "hello $world";
+        ```
+         */
     readonly TYPE_STRING: string;
     /**
-     * The node is a shell execute string :
-     * ```php
-     * <?php
-     * echo `ls -larth $path`;
-     * ```
-     */
+         * The node is a shell execute string :
+        ```php
+        <?php
+        echo `ls -larth $path`;
+        ```
+         */
     readonly TYPE_SHELL: string;
     /**
-     * The node is a shell execute string :
-     * ```php
-     * <?php
-     * echo <<<STR
-     *  Hello $world
-     * STR
-     * ;
-     * ```
-     */
+         * The node is a shell execute string :
+        ```php
+        <?php
+        echo <<<STR
+         Hello $world
+        STR
+        ;
+        ```
+         */
     readonly TYPE_HEREDOC: string;
     /**
-     * The node contains a list of constref / variables / expr :
-     * ```php
-     * <?php
-     * echo $foo->bar_$baz;
-     * ```
-     */
+         * The node contains a list of constref / variables / expr :
+        ```php
+        <?php
+        echo $foo->bar_$baz;
+        ```
+         */
     readonly TYPE_OFFSET: string;
     /**
      * Defines the type of encapsed string (shell, heredoc, string)
@@ -417,9 +417,9 @@ declare module "php-parser" {
     useDie: boolean;
   }
   /**
-   * Any expression node. Since the left-hand side of an assignment may
-   * be any expression in general, an expression can also be a pattern.
-   */
+     * Any expression node. Since the left-hand side of an assignment may
+    be any expression in general, an expression can also be a pattern.
+     */
   class Expression extends Node {}
   /**
    * Defines an expression based statement
@@ -620,10 +620,10 @@ declare module "php-parser" {
      */
     readonly QUALIFIED_NAME: string;
     /**
-     * This is an identifier with a namespace separator that begins with
-     * a namespace separator, such as \Foo\Bar. The namespace \Foo is also
-     * a fully qualified name.
-     */
+         * This is an identifier with a namespace separator that begins with
+        a namespace separator, such as \Foo\Bar. The namespace \Foo is also
+        a fully qualified name.
+         */
     readonly FULL_QUALIFIED_NAME: string;
     /**
      * This is an identifier starting with namespace, such as namespace\Foo\Bar.
@@ -682,9 +682,9 @@ declare module "php-parser" {
     kind: string;
   }
   /**
-   * Ignore this node, it implies a no operation block, for example :
-   * [$foo, $bar, /* here a noop node * /]
-   */
+     * Ignore this node, it implies a no operation block, for example :
+    [$foo, $bar, /* here a noop node * /]
+     */
   class Noop extends Node {}
   /**
    * Defines a nowdoc string
@@ -983,20 +983,20 @@ declare module "php-parser" {
     alias: Identifier | null;
   }
   /**
-   * Any expression node. Since the left-hand side of an assignment may
-   * be any expression in general, an expression can also be a pattern.
-   * @example
-   * // PHP code :
-   * $foo
-   * // AST output
-   * {
-   *  "kind": "variable",
-   *  "name": "foo",
-   *  "curly": false
-   * }
-   * @property name - The variable name (can be a complex expression when the name is resolved dynamically)
-   * @property curly - Indicate if the name is defined between curlies, ex `${foo}`
-   */
+     * Any expression node. Since the left-hand side of an assignment may
+    be any expression in general, an expression can also be a pattern.
+     * @example
+     * // PHP code :
+    $foo
+    // AST output
+    {
+     "kind": "variable",
+     "name": "foo",
+     "curly": false
+    }
+     * @property name - The variable name (can be a complex expression when the name is resolved dynamically)
+     * @property curly - Indicate if the name is defined between curlies, ex `${foo}`
+     */
   class Variable extends Expression {
     /**
      * The variable name (can be a complex expression when the name is resolved dynamically)
@@ -1054,29 +1054,29 @@ declare module "php-parser" {
     withSource: boolean;
   }
   /**
-   * Initialise a new parser instance with the specified options
-   * @example
-   * var parser = require('php-parser');
-   * var instance = new parser({
-   *   parser: {
-   *     extractDoc: true,
-   *     suppressErrors: true,
-   *     version: 704 // or '7.4'
-   *   },
-   *   ast: {
-   *     withPositions: true
-   *   },
-   *   lexer: {
-   *     short_tags: true,
-   *     asp_tags: true
-   *   }
-   * });
-   *
-   * var evalAST = instance.parseEval('some php code');
-   * var codeAST = instance.parseCode('<?php some php code', 'foo.php');
-   * var tokens = instance.tokenGetAll('<?php some php code');
-   * @param options - List of options
-   */
+     * Initialise a new parser instance with the specified options
+     * @example
+     * var parser = require('php-parser');
+    var instance = new parser({
+      parser: {
+        extractDoc: true,
+        suppressErrors: true,
+        version: 704 // or '7.4'
+      },
+      ast: {
+        withPositions: true
+      },
+      lexer: {
+        short_tags: true,
+        asp_tags: true
+      }
+    });
+    
+    var evalAST = instance.parseEval('some php code');
+    var codeAST = instance.parseCode('<?php some php code', 'foo.php');
+    var tokens = instance.tokenGetAll('<?php some php code');
+     * @param options - List of options
+     */
   class Engine {
     constructor(options: any);
     /**
@@ -1084,30 +1084,30 @@ declare module "php-parser" {
      */
     parseEval(buffer: string): Program;
     /**
-     * Function that parse a php code with open/close tags
-     *
-     * Sample code :
-     * ```php
-     * <?php $x = 1;
-     * ```
-     *
-     * Usage :
-     * ```js
-     * var parser = require('php-parser');
-     * var phpParser = new parser({
-     *   // some options
-     * });
-     * var ast = phpParser.parseCode('...php code...', 'foo.php');
-     * ```
-     * @param buffer - The code to be parsed
-     * @param filename - Filename
-     */
+         * Function that parse a php code with open/close tags
+        
+        Sample code :
+        ```php
+        <?php $x = 1;
+        ```
+        
+        Usage :
+        ```js
+        var parser = require('php-parser');
+        var phpParser = new parser({
+          // some options
+        });
+        var ast = phpParser.parseCode('...php code...', 'foo.php');
+        ```
+         * @param buffer - The code to be parsed
+         * @param filename - Filename
+         */
     parseCode(buffer: string, filename: string): Program;
     /**
-     * Extract tokens from the specified buffer.
-     * > Note that the output tokens are *STRICLY* similar to PHP function `token_get_all`
-     * @returns - Each item can be a string or an array with following informations [token_name, text, line_number]
-     */
+         * Extract tokens from the specified buffer.
+        > Note that the output tokens are *STRICLY* similar to PHP function `token_get_all`
+         * @returns - Each item can be a string or an array with following informations [token_name, text, line_number]
+         */
     tokenGetAll(buffer: string): (string | string[])[];
     lexer: Lexer;
     parser: Parser;
@@ -1115,16 +1115,16 @@ declare module "php-parser" {
     tokens: any;
   }
   /**
-   * This is the php lexer. It will tokenize the string for helping the
-   * parser to build the AST from its grammar.
-   * @property all_tokens - defines if all tokens must be retrieved (used by token_get_all only)
-   * @property comment_tokens - extracts comments tokens
-   * @property mode_eval - enables the evald mode (ignore opening tags)
-   * @property asp_tags - disables by default asp tags mode
-   * @property short_tags - enables by default short tags mode
-   * @property keywords - List of php keyword
-   * @property castKeywords - List of php keywords for type casting
-   */
+     * This is the php lexer. It will tokenize the string for helping the
+    parser to build the AST from its grammar.
+     * @property all_tokens - defines if all tokens must be retrieved (used by token_get_all only)
+     * @property comment_tokens - extracts comments tokens
+     * @property mode_eval - enables the evald mode (ignore opening tags)
+     * @property asp_tags - disables by default asp tags mode
+     * @property short_tags - enables by default short tags mode
+     * @property keywords - List of php keyword
+     * @property castKeywords - List of php keywords for type casting
+     */
   class Lexer {
     /**
      * Initialize the lexer with the specified input
@@ -1252,14 +1252,14 @@ declare module "php-parser" {
      */
     expectEndOfStatement(): boolean;
     /**
-     * Force the parser to check the current token.
-     *
-     * If the current token does not match to expected token,
-     * the an error will be raised.
-     *
-     * If the suppressError mode is activated, then the error will
-     * be added to the program error stack and this function will return `false`.
-     */
+         * Force the parser to check the current token.
+        
+        If the current token does not match to expected token,
+        the an error will be raised.
+        
+        If the suppressError mode is activated, then the error will
+        be added to the program error stack and this function will return `false`.
+         */
     expect(token: string | number): boolean;
     /**
      * Returns the current token contents

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,27 +1,27 @@
 declare module "php-parser" {
   /**
-     * Defines an array structure
-     * @example
-     * // PHP code :
-    [1, 'foo' => 'bar', 3]
-    
-    // AST structure :
-    {
-     "kind": "array",
-     "shortForm": true
-     "items": [
-       {"kind": "number", "value": "1"},
-       {
-         "kind": "entry",
-         "key": {"kind": "string", "value": "foo", "isDoubleQuote": false},
-         "value": {"kind": "string", "value": "bar", "isDoubleQuote": false}
-       },
-       {"kind": "number", "value": "3"}
-     ]
-    }
-     * @property items - List of array items
-     * @property shortForm - Indicate if the short array syntax is used, ex `[]` instead `array()`
-     */
+   * Defines an array structure
+   * @example
+   * // PHP code :
+   * [1, 'foo' => 'bar', 3]
+   *
+   * // AST structure :
+   * {
+   *  "kind": "array",
+   *  "shortForm": true
+   *  "items": [
+   *    {"kind": "number", "value": "1"},
+   *    {
+   *      "kind": "entry",
+   *      "key": {"kind": "string", "value": "foo", "isDoubleQuote": false},
+   *      "value": {"kind": "string", "value": "bar", "isDoubleQuote": false}
+   *    },
+   *    {"kind": "number", "value": "3"}
+   *  ]
+   * }
+   * @property items - List of array items
+   * @property shortForm - Indicate if the short array syntax is used, ex `[]` instead `array()`
+   */
   class Array extends Expression {
     /**
      * List of array items
@@ -232,37 +232,37 @@ declare module "php-parser" {
    */
   class Declare extends Block {
     /**
-         * The node is declared as a short tag syntax :
-        ```php
-        <?php
-        declare(ticks=1):
-        // some statements
-        enddeclare;
-        ```
-         */
+     * The node is declared as a short tag syntax :
+     * ```php
+     * <?php
+     * declare(ticks=1):
+     * // some statements
+     * enddeclare;
+     * ```
+     */
     readonly MODE_SHORT: string;
     /**
-         * The node is declared bracket enclosed code :
-        ```php
-        <?php
-        declare(ticks=1) {
-        // some statements
-        }
-        ```
-         */
+     * The node is declared bracket enclosed code :
+     * ```php
+     * <?php
+     * declare(ticks=1) {
+     * // some statements
+     * }
+     * ```
+     */
     readonly MODE_BLOCK: string;
     /**
-         * The node is declared as a simple statement. In order to make things simpler
-        children of the node are automatically collected until the next
-        declare statement.
-        ```php
-        <?php
-        declare(ticks=1);
-        // some statements
-        declare(ticks=2);
-        // some statements
-        ```
-         */
+     * The node is declared as a simple statement. In order to make things simpler
+     * children of the node are automatically collected until the next
+     * declare statement.
+     * ```php
+     * <?php
+     * declare(ticks=1);
+     * // some statements
+     * declare(ticks=2);
+     * // some statements
+     * ```
+     */
     readonly MODE_NONE: string;
     directives: DeclareDirective[];
     mode: string;
@@ -301,39 +301,39 @@ declare module "php-parser" {
    */
   class Encapsed extends Literal {
     /**
-         * The node is a double quote string :
-        ```php
-        <?php
-        echo "hello $world";
-        ```
-         */
+     * The node is a double quote string :
+     * ```php
+     * <?php
+     * echo "hello $world";
+     * ```
+     */
     readonly TYPE_STRING: string;
     /**
-         * The node is a shell execute string :
-        ```php
-        <?php
-        echo `ls -larth $path`;
-        ```
-         */
+     * The node is a shell execute string :
+     * ```php
+     * <?php
+     * echo `ls -larth $path`;
+     * ```
+     */
     readonly TYPE_SHELL: string;
     /**
-         * The node is a shell execute string :
-        ```php
-        <?php
-        echo <<<STR
-         Hello $world
-        STR
-        ;
-        ```
-         */
+     * The node is a shell execute string :
+     * ```php
+     * <?php
+     * echo <<<STR
+     *  Hello $world
+     * STR
+     * ;
+     * ```
+     */
     readonly TYPE_HEREDOC: string;
     /**
-         * The node contains a list of constref / variables / expr :
-        ```php
-        <?php
-        echo $foo->bar_$baz;
-        ```
-         */
+     * The node contains a list of constref / variables / expr :
+     * ```php
+     * <?php
+     * echo $foo->bar_$baz;
+     * ```
+     */
     readonly TYPE_OFFSET: string;
     /**
      * Defines the type of encapsed string (shell, heredoc, string)
@@ -417,9 +417,9 @@ declare module "php-parser" {
     useDie: boolean;
   }
   /**
-     * Any expression node. Since the left-hand side of an assignment may
-    be any expression in general, an expression can also be a pattern.
-     */
+   * Any expression node. Since the left-hand side of an assignment may
+   * be any expression in general, an expression can also be a pattern.
+   */
   class Expression extends Node {}
   /**
    * Defines an expression based statement
@@ -620,10 +620,10 @@ declare module "php-parser" {
      */
     readonly QUALIFIED_NAME: string;
     /**
-         * This is an identifier with a namespace separator that begins with
-        a namespace separator, such as \Foo\Bar. The namespace \Foo is also
-        a fully qualified name.
-         */
+     * This is an identifier with a namespace separator that begins with
+     * a namespace separator, such as \Foo\Bar. The namespace \Foo is also
+     * a fully qualified name.
+     */
     readonly FULL_QUALIFIED_NAME: string;
     /**
      * This is an identifier starting with namespace, such as namespace\Foo\Bar.
@@ -682,9 +682,9 @@ declare module "php-parser" {
     kind: string;
   }
   /**
-     * Ignore this node, it implies a no operation block, for example :
-    [$foo, $bar, /* here a noop node * /]
-     */
+   * Ignore this node, it implies a no operation block, for example :
+   * [$foo, $bar, /* here a noop node * /]
+   */
   class Noop extends Node {}
   /**
    * Defines a nowdoc string
@@ -983,20 +983,20 @@ declare module "php-parser" {
     alias: Identifier | null;
   }
   /**
-     * Any expression node. Since the left-hand side of an assignment may
-    be any expression in general, an expression can also be a pattern.
-     * @example
-     * // PHP code :
-    $foo
-    // AST output
-    {
-     "kind": "variable",
-     "name": "foo",
-     "curly": false
-    }
-     * @property name - The variable name (can be a complex expression when the name is resolved dynamically)
-     * @property curly - Indicate if the name is defined between curlies, ex `${foo}`
-     */
+   * Any expression node. Since the left-hand side of an assignment may
+   * be any expression in general, an expression can also be a pattern.
+   * @example
+   * // PHP code :
+   * $foo
+   * // AST output
+   * {
+   *  "kind": "variable",
+   *  "name": "foo",
+   *  "curly": false
+   * }
+   * @property name - The variable name (can be a complex expression when the name is resolved dynamically)
+   * @property curly - Indicate if the name is defined between curlies, ex `${foo}`
+   */
   class Variable extends Expression {
     /**
      * The variable name (can be a complex expression when the name is resolved dynamically)
@@ -1054,29 +1054,29 @@ declare module "php-parser" {
     withSource: boolean;
   }
   /**
-     * Initialise a new parser instance with the specified options
-     * @example
-     * var parser = require('php-parser');
-    var instance = new parser({
-      parser: {
-        extractDoc: true,
-        suppressErrors: true,
-        version: 704 // or '7.4'
-      },
-      ast: {
-        withPositions: true
-      },
-      lexer: {
-        short_tags: true,
-        asp_tags: true
-      }
-    });
-    
-    var evalAST = instance.parseEval('some php code');
-    var codeAST = instance.parseCode('<?php some php code', 'foo.php');
-    var tokens = instance.tokenGetAll('<?php some php code');
-     * @param options - List of options
-     */
+   * Initialise a new parser instance with the specified options
+   * @example
+   * var parser = require('php-parser');
+   * var instance = new parser({
+   *   parser: {
+   *     extractDoc: true,
+   *     suppressErrors: true,
+   *     version: 704 // or '7.4'
+   *   },
+   *   ast: {
+   *     withPositions: true
+   *   },
+   *   lexer: {
+   *     short_tags: true,
+   *     asp_tags: true
+   *   }
+   * });
+   *
+   * var evalAST = instance.parseEval('some php code');
+   * var codeAST = instance.parseCode('<?php some php code', 'foo.php');
+   * var tokens = instance.tokenGetAll('<?php some php code');
+   * @param options - List of options
+   */
   class Engine {
     constructor(options: any);
     /**
@@ -1084,30 +1084,30 @@ declare module "php-parser" {
      */
     parseEval(buffer: string): Program;
     /**
-         * Function that parse a php code with open/close tags
-        
-        Sample code :
-        ```php
-        <?php $x = 1;
-        ```
-        
-        Usage :
-        ```js
-        var parser = require('php-parser');
-        var phpParser = new parser({
-          // some options
-        });
-        var ast = phpParser.parseCode('...php code...', 'foo.php');
-        ```
-         * @param buffer - The code to be parsed
-         * @param filename - Filename
-         */
+     * Function that parse a php code with open/close tags
+     *
+     * Sample code :
+     * ```php
+     * <?php $x = 1;
+     * ```
+     *
+     * Usage :
+     * ```js
+     * var parser = require('php-parser');
+     * var phpParser = new parser({
+     *   // some options
+     * });
+     * var ast = phpParser.parseCode('...php code...', 'foo.php');
+     * ```
+     * @param buffer - The code to be parsed
+     * @param filename - Filename
+     */
     parseCode(buffer: string, filename: string): Program;
     /**
-         * Extract tokens from the specified buffer.
-        > Note that the output tokens are *STRICLY* similar to PHP function `token_get_all`
-         * @returns - Each item can be a string or an array with following informations [token_name, text, line_number]
-         */
+     * Extract tokens from the specified buffer.
+     * > Note that the output tokens are *STRICLY* similar to PHP function `token_get_all`
+     * @returns - Each item can be a string or an array with following informations [token_name, text, line_number]
+     */
     tokenGetAll(buffer: string): (string | string[])[];
     lexer: Lexer;
     parser: Parser;
@@ -1115,16 +1115,16 @@ declare module "php-parser" {
     tokens: any;
   }
   /**
-     * This is the php lexer. It will tokenize the string for helping the
-    parser to build the AST from its grammar.
-     * @property all_tokens - defines if all tokens must be retrieved (used by token_get_all only)
-     * @property comment_tokens - extracts comments tokens
-     * @property mode_eval - enables the evald mode (ignore opening tags)
-     * @property asp_tags - disables by default asp tags mode
-     * @property short_tags - enables by default short tags mode
-     * @property keywords - List of php keyword
-     * @property castKeywords - List of php keywords for type casting
-     */
+   * This is the php lexer. It will tokenize the string for helping the
+   * parser to build the AST from its grammar.
+   * @property all_tokens - defines if all tokens must be retrieved (used by token_get_all only)
+   * @property comment_tokens - extracts comments tokens
+   * @property mode_eval - enables the evald mode (ignore opening tags)
+   * @property asp_tags - disables by default asp tags mode
+   * @property short_tags - enables by default short tags mode
+   * @property keywords - List of php keyword
+   * @property castKeywords - List of php keywords for type casting
+   */
   class Lexer {
     /**
      * Initialize the lexer with the specified input
@@ -1252,14 +1252,14 @@ declare module "php-parser" {
      */
     expectEndOfStatement(): boolean;
     /**
-         * Force the parser to check the current token.
-        
-        If the current token does not match to expected token,
-        the an error will be raised.
-        
-        If the suppressError mode is activated, then the error will
-        be added to the program error stack and this function will return `false`.
-         */
+     * Force the parser to check the current token.
+     *
+     * If the current token does not match to expected token,
+     * the an error will be raised.
+     *
+     * If the suppressError mode is activated, then the error will
+     * be added to the program error stack and this function will return `false`.
+     */
     expect(token: string | number): boolean;
     /**
      * Returns the current token contents

--- a/types.d.ts
+++ b/types.d.ts
@@ -169,6 +169,7 @@ declare module "php-parser" {
    */
   class Clone extends Expression {
     what: Expression;
+    properties?: Expression | null;
   }
   /**
    * Defines a closure


### PR DESCRIPTION
Closes #1237 

This PR adds the remaining PHP 8.5 syntax support that was still missing or incomplete in the parser.

Included changes:
- Add support for PHP 8.5 `clone with` syntax such as `clone($obj, ["name" => $name])`
- Align pipe operator parsing with the final accepted PHP 8.5 syntax by requiring parentheses around arrow functions in pipe chains
- Support closures in PHP 8.5 attribute constant expressions such as `#[A(static function () { return 1; })]`

Tests:
- Add focused regression coverage for `clone with`
- Update pipe operator tests and snapshots to reflect the final syntax
- Add attribute test coverage for closures in constant expressions
- Verify the Jest test suite passes